### PR TITLE
Added return codes according to verification outcome

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,9 @@ void print_version(){
             << ", with LLVM-" << LLVM_VERSION << ":" << LLVM_BUILDMODE << ")\n";
 }
 
+#define VERIFICATION_SUCCESS 0
+#define VERIFICATION_FAILURE 42
+
 int main(int argc, char *argv[]){
   /* Command line options */
   llvm::cl::SetVersionPrinter(print_version);
@@ -79,6 +82,7 @@ int main(int argc, char *argv[]){
              llvm::cl::init("-"));
   llvm::cl::ParseCommandLineOptions(argc, argv);
 
+  bool errors_detected = false;
   try{
     Configuration conf;
     conf.assign_by_commandline();
@@ -96,6 +100,7 @@ int main(int argc, char *argv[]){
                 << " (also " << res.sleepset_blocked_trace_count
                 << " sleepset blocked)" << std::endl; 
       if(res.has_errors()){
+	errors_detected = true;
         std::cout << "\n Error detected:\n"
                   << res.error_trace->to_string(2);
       }else{
@@ -115,5 +120,5 @@ int main(int argc, char *argv[]){
     return 1;
   }
 
-  return 0;
+  return (errors_detected ? VERIFICATION_FAILURE : VERIFICATION_SUCCESS);
 }

--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -61,13 +61,15 @@ def destroy_tmpdir():
 atexit.register(destroy_tmpdir)
 
 def run(cmd,ignoreret=False):
+    return_codes = [0, 42]
     cmdstr=''
     for s in cmd:
         cmdstr = cmdstr+('' if cmdstr=='' else ' ')+s
     print("* Nidhuggc: $ "+cmdstr)
     retval = subprocess.call(cmd)
-    if not(ignoreret) and retval != 0:
-        raise Exception('Command ({1}) returned non-zero exit code ({0}).'.format(retval,cmd[0]))
+    if not(ignoreret) and retval not in return_codes:
+        raise Exception('Command ({1}) returned an error exit code ({0}).'.format(retval,cmd[0]))
+    return retval
 
 # Read arguments from sys.argv. Return a tuple (A,B,C) of disjunct
 # argument lists A, B, C, together containing precisely the arguments
@@ -204,7 +206,7 @@ def transform(nidhuggcargs,transformargs,irfname):
 
 def run_nidhugg(nidhuggcargs,nidhuggargs,irfname):
     cmd = [NIDHUGG]+nidhuggargs+[irfname]
-    run(cmd)
+    return run(cmd)
 
 def main():
     try:
@@ -242,8 +244,9 @@ def main():
         # Transform
         irfname = transform(nidhuggcargs,transformargs,irfname)
         # Run stateless model-checker
-        run_nidhugg(nidhuggcargs,nidhuggargs,irfname)
+        ret = run_nidhugg(nidhuggcargs,nidhuggargs,irfname)
         print('Total wall-clock time: {0:.2f} s'.format(time.time()-t0))
+        exit(ret)
     except Exception as e:
         print("\nNidhuggc Error: {0}".format(str(e)))
         exit(1)


### PR DESCRIPTION
Instead of always returning zero, Nidhugg can return a different number according to the outcome of the verification.

This makes it easier to check whether the result of the verification matches the expected one (e.g. when running many tests with a script).