### PR TITLE
Improve the printouts of traces explored

### DIFF
--- a/src/DPORDriver.cpp
+++ b/src/DPORDriver.cpp
@@ -229,11 +229,11 @@ DPORDriver::Result DPORDriver::run(){
       llvm::dbgs() << esc << "[u" // Restore cursor position
                    << esc << "[s" // Save cursor position
                    << esc << "[K" // Erase the line
-                   << "Computation #" << computation_count+1;
+                   << "Trace #" << computation_count+1;
       if(conf.print_progress_estimate){
         llvm::dbgs() << " ("
                      << int(100.0*float(computation_count+1)/float(estimate))
-                     << "% of total estimate: "
+                     << "% of current estimate: "
                      << estimate << ")";
       }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,9 +98,11 @@ int main(int argc, char *argv[]){
         DPORDriver::parseIRFile(input_file,conf);
 
       DPORDriver::Result res = driver->run();
-      std::cout << "Trace count: " << res.trace_count
-                << " (also " << res.sleepset_blocked_trace_count
-                << " sleepset blocked)" << std::endl; 
+      int traces = res.trace_count + res.sleepset_blocked_trace_count;
+      std::cout << "Trace count: " << traces
+                << " (" << res.trace_count << " fully explored"
+		<< " and " << res.sleepset_blocked_trace_count
+                << " sleep-set blocked)" << std::endl;
       if(res.has_errors()){
 	errors_detected = true;
         std::cout << "\n Error detected:\n"


### PR DESCRIPTION
Report the *total* number of traces explored, rather than the number of
Mazurkiewicz traces with only just a mention that some sleep-set blocked
traces were also encountered.  Sleep-set blocked traces are explored
alright, even though they are explored only up to a point.

Also, there is no reason for the progress printout to refer to traces as
"Computations".