### PR TITLE
Ignore generated .dwo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 *.o
+*.dwo
 *.log
 *.trs
 *.aux


### PR DESCRIPTION
Newer versions of GCC seem to be leaving around `.dwo` files, at least on a recent Debian.
Add a line to `.gitignore` that ignores them so that `git status` shows clean information.