### PR TITLE
Make nidhugg support LLVM 3.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,8 +196,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <llvm/IR/LLVMContext.h>
 #endif
 ]],[[
-          llvm::Module M("",llvm::getGlobalContext());
-          std::string s = M.getDataLayoutStr();
+          llvm::Module *M = 0;
+          std::string s = M->getDataLayoutStr();
         ]])],
         [AC_DEFINE([LLVM_MODULE_GET_DATA_LAYOUT_STRING],[getDataLayoutStr],
             [The name of the method in llvm::Module which returns the data layout string.])
@@ -222,8 +222,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <llvm/IR/LLVMContext.h>
 #endif
 ]],[[
-  llvm::Module M("",llvm::getGlobalContext());
-  std::error_code ec = M.materializeAllPermanently();
+  llvm::Module *M = 0;
+  std::error_code ec = M->materializeAllPermanently();
 ]])],
            [AC_DEFINE([LLVM_MODULE_MATERIALIZE_ALL_PERMANENTLY_ERRORCODE_BOOL],[1],
             [Define if Module::materializeAllPermanently accepts zero arguments and returns an error_code.])

--- a/configure.ac
+++ b/configure.ac
@@ -247,6 +247,25 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
            [AC_MSG_RESULT([use materializeAll instead])])
 ])
 
+## Check if AtomicOrdering is a enum class
+AC_MSG_CHECKING([whether AtomicOrdering is a enum class])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_INSTRUCTIONS_H)
+#include <llvm/Instructions.h>
+#elif defined(HAVE_LLVM_INSTRUCTIONS_H)
+#include <llvm/IR/Instructions.h>
+#endif
+]],[[
+  llvm::AtomicOrdering o = llvm::SequentiallyConsistent;
+]])],
+           [AC_DEFINE([LLVM_ATOMIC_ORDERING_SCOPE],[llvm],
+            [The scope name for AtomicOrdering enum iterms])
+            AC_MSG_RESULT([no])
+           ],
+           [AC_DEFINE([LLVM_ATOMIC_ORDERING_SCOPE],[llvm::AtomicOrdering],
+            [The scope name for AtomicOrdering enum iterms])
+            AC_MSG_RESULT([yes])])
+
 ## Check if AtomicCmpXchg has separate success and failure orderings
 AC_MSG_CHECKING([for success/failure orderings of llvm::AtomicCmpXchgInst])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
@@ -257,8 +276,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #endif
 ]],[[
   llvm::AtomicCmpXchgInst I((llvm::Value*)0,(llvm::Value*)0,(llvm::Value*)0,
-                            llvm::AtomicOrdering(llvm::SequentiallyConsistent),
-                            llvm::AtomicOrdering(llvm::SequentiallyConsistent),
+                            (llvm::AtomicOrdering)0,
+                            (llvm::AtomicOrdering)0,
                             llvm::SynchronizationScope(llvm::CrossThread),
                             (llvm::Instruction*)0);
 ]])],

--- a/configure.ac
+++ b/configure.ac
@@ -770,6 +770,11 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 ## Check the signature of Linker::linkInModule
 AC_MSG_CHECKING([the signature of Linker::linkInModule])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_MODULE_H)
+#include <llvm/Module.h>
+#elif defined(HAVE_LLVM_IR_MODULE_H)
+#include <llvm/IR/Module.h>
+#endif
 #if defined(HAVE_LLVM_LINKER_H)
 #include <llvm/Linker.h>
 #elif defined(HAVE_LLVM_LINKER_LINKER_H)
@@ -788,6 +793,11 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 
 if test "x$LLVM_LINKER_LINKINMODULE_PTR_BOOL" != 'xyes'; then
    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_MODULE_H)
+#include <llvm/Module.h>
+#elif defined(HAVE_LLVM_IR_MODULE_H)
+#include <llvm/IR/Module.h>
+#endif
 #if defined(HAVE_LLVM_LINKER_H)
 #include <llvm/Linker.h>
 #elif defined(HAVE_LLVM_LINKER_LINKER_H)

--- a/src/CheckModule.cpp
+++ b/src/CheckModule.cpp
@@ -98,7 +98,7 @@ void CheckModule::check_pthread_create(const llvm::Module *M){
           << *ty0e;
       throw CheckModuleError(err.str());
     }
-    llvm::Type *vpty = llvm::Type::getInt8PtrTy(llvm::getGlobalContext());
+    llvm::Type *vpty = llvm::Type::getInt8PtrTy(M->getContext());
     llvm::Type *fty = llvm::FunctionType::get(vpty,{vpty},false)->getPointerTo();
     llvm::Type *arg2_ty, *arg3_ty;
     {
@@ -145,7 +145,7 @@ void CheckModule::check_pthread_join(const llvm::Module *M){
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg1_ty_expected =
-      llvm::Type::getInt8PtrTy(llvm::getGlobalContext())->getPointerTo();
+      llvm::Type::getInt8PtrTy(M->getContext())->getPointerTo();
     if(arg1_ty != arg1_ty_expected){
       err << "Second argument of pthread_join has wrong type: "
           << *arg1_ty << ", should be " << *arg1_ty_expected;
@@ -188,7 +188,7 @@ void CheckModule::check_pthread_exit(const llvm::Module *M){
       throw CheckModuleError(err.str());
     }
     llvm::Type *ty = pthread_exit->arg_begin()->getType(),
-      *ty_expected = llvm::Type::getInt8PtrTy(llvm::getGlobalContext());
+      *ty_expected = llvm::Type::getInt8PtrTy(M->getContext());
     if(ty != ty_expected){
       err << "Argument of pthread_exit has wrong type: "
           << *ty << ", should be " << *ty_expected;

--- a/src/Execution.cpp
+++ b/src/Execution.cpp
@@ -2605,7 +2605,7 @@ void Interpreter::callPthreadCreate(Function *F,
   Function *F_inner = (Function*)GVTOP(ArgVals[2]);
   std::vector<GenericValue> ArgVals_inner;
   if(F_inner->getArgumentList().size() == 1 &&
-     F_inner->arg_begin()->getType() == Type::getInt8PtrTy(getGlobalContext())){
+     F_inner->arg_begin()->getType() == Type::getInt8PtrTy(F->getContext())){
     ArgVals_inner.push_back(ArgVals[3]);
   }else if(F_inner->getArgumentList().size()){
     std::string _err;
@@ -2641,7 +2641,7 @@ void Interpreter::callPthreadJoin(Function *F,
   // Forward return value
   GenericValue *rvPtr = (GenericValue*)GVTOP(ArgVals[1]);
   if(rvPtr){
-    Type *ty = Type::getInt8PtrTy(getGlobalContext())->getPointerTo();
+    Type *ty = Type::getInt8PtrTy(F->getContext())->getPointerTo();
     if(!CheckedStoreValueToMemory(Threads[tid].RetVal,rvPtr,ty)) return;
   }
 
@@ -2662,7 +2662,7 @@ void Interpreter::callPthreadExit(Function *F,
                                   const std::vector<GenericValue> &ArgVals){
   TB.fence();
   while(ECStack()->size() > 1) ECStack()->pop_back();
-  popStackAndReturnValueToCaller(Type::getInt8PtrTy(getGlobalContext()),ArgVals[0]);
+  popStackAndReturnValueToCaller(Type::getInt8PtrTy(F->getContext()),ArgVals[0]);
 }
 
 void Interpreter::callPthreadMutexInit(Function *F,
@@ -2996,7 +2996,7 @@ void Interpreter::callAssume(Function *F, const std::vector<GenericValue> &ArgVa
         /* We are inside an atomic function call. Remove the top part
          * of the stack corresponding to that call.
          */
-        popStackAndReturnValueToCaller(Type::getVoidTy(getGlobalContext()), GenericValue());
+        popStackAndReturnValueToCaller(Type::getVoidTy(F->getContext()), GenericValue());
       }
       return;
     }
@@ -3301,7 +3301,7 @@ bool Interpreter::checkRefuse(Instruction &I){
 
 void Interpreter::terminate(Type *RetTy, GenericValue Result){
   if(CurrentThread != 0){
-    assert(RetTy == Type::getInt8PtrTy(getGlobalContext()));
+    assert(RetTy == Type::getInt8PtrTy(F->getContext()));
     Threads[CurrentThread].RetVal = Result;
   }
   for(int p : Threads[CurrentThread].AwaitingJoin){

--- a/src/POWERExecution.cpp
+++ b/src/POWERExecution.cpp
@@ -2322,11 +2322,11 @@ void POWERInterpreter::callPthreadCreate(llvm::Function *F){
   // Build stack frame for the call
   llvm::Function *F_inner = (llvm::Function*)GVTOP(getOperandValue(2));
   std::vector<llvm::Value*> ArgVals_inner;
-  llvm::Type *i8ptr = llvm::Type::getInt8PtrTy(llvm::getGlobalContext());
+  llvm::Type *i8ptr = llvm::Type::getInt8PtrTy(F->getContext());
   if(F_inner->getArgumentList().size() == 1 &&
      F_inner->arg_begin()->getType() == i8ptr){
     void *opval = llvm::GVTOP(getOperandValue(3));
-    llvm::Type *i64 = llvm::Type::getInt64Ty(llvm::getGlobalContext());
+    llvm::Type *i64 = llvm::Type::getInt64Ty(F->getContext());
     llvm::Constant *opval_int = llvm::ConstantInt::get(i64,uint64_t(opval));
     llvm::Value *opval_ptr = llvm::ConstantExpr::getIntToPtr(opval_int,i8ptr);
     ArgVals_inner.push_back(opval_ptr);

--- a/src/POWERInterpreter.cpp
+++ b/src/POWERInterpreter.cpp
@@ -97,10 +97,10 @@ POWERInterpreter::POWERInterpreter(llvm::Module *M, POWERARMTraceBuilder &TB, co
 
   IL = new llvm::IntrinsicLowering(TD);
 
-  static llvm::Value *V0 = llvm::ConstantInt::get(llvm::Type::getInt32Ty(llvm::getGlobalContext()),0);
-  static llvm::Value *P0_32 = llvm::ConstantPointerNull::get(llvm::Type::getInt32PtrTy(llvm::getGlobalContext()));
+  static llvm::Value *V0 = llvm::ConstantInt::get(llvm::Type::getInt32Ty(M->getContext()),0);
+  static llvm::Value *P0_32 = llvm::ConstantPointerNull::get(llvm::Type::getInt32PtrTy(M->getContext()));
   dummy_store = new llvm::StoreInst(V0,P0_32);
-  static llvm::Value *P0_8 = llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(llvm::getGlobalContext()));
+  static llvm::Value *P0_8 = llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(M->getContext()));
   dummy_load8 = new llvm::LoadInst(P0_8);
 }
 

--- a/src/PSOInterpreter.cpp
+++ b/src/PSOInterpreter.cpp
@@ -166,22 +166,22 @@ bool PSOInterpreter::isFence(llvm::Instruction &I){
       if(isInlineAsm(CS,&asmstr) && asmstr == "mfence") return true;
     }
   }else if(llvm::isa<llvm::StoreInst>(I)){
-    return static_cast<llvm::StoreInst&>(I).getOrdering() == llvm::SequentiallyConsistent;
+    return static_cast<llvm::StoreInst&>(I).getOrdering() == LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent;
   }else if(llvm::isa<llvm::FenceInst>(I)){
-    return static_cast<llvm::FenceInst&>(I).getOrdering() == llvm::SequentiallyConsistent;
+    return static_cast<llvm::FenceInst&>(I).getOrdering() == LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent;
   }else if(llvm::isa<llvm::AtomicCmpXchgInst>(I)){
 #ifdef LLVM_CMPXCHG_SEPARATE_SUCCESS_FAILURE_ORDERING
     llvm::AtomicOrdering succ = static_cast<llvm::AtomicCmpXchgInst&>(I).getSuccessOrdering();
     llvm::AtomicOrdering fail = static_cast<llvm::AtomicCmpXchgInst&>(I).getFailureOrdering();
-    if(succ != llvm::SequentiallyConsistent || fail != llvm::SequentiallyConsistent){
+    if(succ != LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent || fail != LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent){
 #else
-    if(static_cast<llvm::AtomicCmpXchgInst&>(I).getOrdering() != llvm::SequentiallyConsistent){
+    if(static_cast<llvm::AtomicCmpXchgInst&>(I).getOrdering() != LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent){
 #endif
       Debug::warn("PSOInterpreter::isFence::cmpxchg") << "WARNING: Non-sequentially consistent CMPXCHG instruction interpreted as sequentially consistent.\n";
     }
     return true;
   }else if(llvm::isa<llvm::AtomicRMWInst>(I)){
-    if(static_cast<llvm::AtomicRMWInst&>(I).getOrdering() != llvm::SequentiallyConsistent){
+    if(static_cast<llvm::AtomicRMWInst&>(I).getOrdering() != LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent){
       Debug::warn("PSOInterpreter::isFence::rmw") << "WARNING: Non-sequentially consistent RMW instruction interpreted as sequentially consistent.\n";
     }
     return true;
@@ -288,7 +288,7 @@ void PSOInterpreter::visitStoreInst(llvm::StoreInst &I){
 
   PSOThread &thr = pso_threads[CurrentThread];
 
-  if(I.getOrdering() == llvm::SequentiallyConsistent ||
+  if(I.getOrdering() == LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent ||
      0 <= AtomicFunctionCall){
     /* Atomic store */
     assert(thr.all_buffers_empty());
@@ -319,7 +319,7 @@ void PSOInterpreter::visitStoreInst(llvm::StoreInst &I){
 }
 
 void PSOInterpreter::visitFenceInst(llvm::FenceInst &I){
-  if(I.getOrdering() == llvm::SequentiallyConsistent){
+  if(I.getOrdering() == LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent){
     TB.fence();
   }
 }

--- a/src/SpinAssumePass.cpp
+++ b/src/SpinAssumePass.cpp
@@ -70,12 +70,12 @@ bool DeclareAssumePass::runOnModule(llvm::Module &M){
   if(!F_assume){
     llvm::FunctionType *assumeTy;
     {
-      llvm::Type *voidTy = llvm::Type::getVoidTy(llvm::getGlobalContext());
-      llvm::Type *i1Ty = llvm::Type::getInt1Ty(llvm::getGlobalContext());
+      llvm::Type *voidTy = llvm::Type::getVoidTy(M.getContext());
+      llvm::Type *i1Ty = llvm::Type::getInt1Ty(M.getContext());
       assumeTy = llvm::FunctionType::get(voidTy,{i1Ty},false);
     }
     llvm::AttributeSet assumeAttrs =
-      llvm::AttributeSet::get(llvm::getGlobalContext(),llvm::AttributeSet::FunctionIndex,
+      llvm::AttributeSet::get(M.getContext(),llvm::AttributeSet::FunctionIndex,
                               std::vector<llvm::Attribute::AttrKind>({llvm::Attribute::NoUnwind}));
     F_assume = llvm::dyn_cast<llvm::Function>(M.getOrInsertFunction("__VERIFIER_assume",assumeTy,assumeAttrs));
     assert(F_assume);

--- a/src/StrModule.cpp
+++ b/src/StrModule.cpp
@@ -54,6 +54,8 @@
 
 namespace StrModule {
 
+  static llvm::LLVMContext TheContext;
+
   llvm::Module *read_module(std::string infile){
     llvm::Module *mod;
     llvm::SMDiagnostic err;
@@ -72,9 +74,9 @@ namespace StrModule {
     llvm::MemoryBuffer *mbp = buf.get().release();
 #endif
 #ifdef LLVM_PARSE_IR_MEMBUF_PTR
-    mod = llvm::ParseIR(mbp,err,llvm::getGlobalContext());
+    mod = llvm::ParseIR(mbp,err,TheContext);
 #else
-    mod = llvm::parseIR(mbp->getMemBufferRef(),err,llvm::getGlobalContext()).release();
+    mod = llvm::parseIR(mbp->getMemBufferRef(),err,TheContext).release();
 #endif
 #ifndef LLVM_PARSE_IR_TAKES_OWNERSHIP
     delete mbp;
@@ -96,9 +98,9 @@ namespace StrModule {
       llvm::MemoryBuffer::getMemBuffer(src,"",false).release();
 #endif
 #ifdef LLVM_PARSE_IR_MEMBUF_PTR
-    mod = llvm::ParseIR(buf,err,llvm::getGlobalContext());
+    mod = llvm::ParseIR(buf,err,TheContext);
 #else
-    mod = llvm::parseIR(buf->getMemBufferRef(),err,llvm::getGlobalContext()).release();
+    mod = llvm::parseIR(buf->getMemBufferRef(),err,TheContext).release();
 #endif
 #ifndef LLVM_PARSE_IR_TAKES_OWNERSHIP
     delete buf;

--- a/src/TSOInterpreter.cpp
+++ b/src/TSOInterpreter.cpp
@@ -126,22 +126,22 @@ bool TSOInterpreter::isFence(llvm::Instruction &I){
       if(isInlineAsm(CS,&asmstr) && asmstr == "mfence") return true;
     }
   }else if(llvm::isa<llvm::StoreInst>(I)){
-    return static_cast<llvm::StoreInst&>(I).getOrdering() == llvm::SequentiallyConsistent;
+    return static_cast<llvm::StoreInst&>(I).getOrdering() == LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent;
   }else if(llvm::isa<llvm::FenceInst>(I)){
-    return static_cast<llvm::FenceInst&>(I).getOrdering() == llvm::SequentiallyConsistent;
+    return static_cast<llvm::FenceInst&>(I).getOrdering() == LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent;
   }else if(llvm::isa<llvm::AtomicCmpXchgInst>(I)){
 #ifdef LLVM_CMPXCHG_SEPARATE_SUCCESS_FAILURE_ORDERING
     llvm::AtomicOrdering succ = static_cast<llvm::AtomicCmpXchgInst&>(I).getSuccessOrdering();
     llvm::AtomicOrdering fail = static_cast<llvm::AtomicCmpXchgInst&>(I).getFailureOrdering();
-    if(succ != llvm::SequentiallyConsistent || fail != llvm::SequentiallyConsistent){
+    if(succ != LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent || fail != LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent){
 #else
-    if(static_cast<llvm::AtomicCmpXchgInst&>(I).getOrdering() != llvm::SequentiallyConsistent){
+    if(static_cast<llvm::AtomicCmpXchgInst&>(I).getOrdering() != LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent){
 #endif
       Debug::warn("TSOInterpreter::isFence::cmpxchg") << "WARNING: Non-sequentially consistent CMPXCHG instruction interpreted as sequentially consistent.\n";
     }
     return true;
   }else if(llvm::isa<llvm::AtomicRMWInst>(I)){
-    if(static_cast<llvm::AtomicRMWInst&>(I).getOrdering() != llvm::SequentiallyConsistent){
+    if(static_cast<llvm::AtomicRMWInst&>(I).getOrdering() != LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent){
       Debug::warn("TSOInterpreter::isFence::rmw") << "WARNING: Non-sequentially consistent RMW instruction interpreted as sequentially consistent.\n";
     }
     return true;
@@ -248,7 +248,7 @@ void TSOInterpreter::visitStoreInst(llvm::StoreInst &I){
   llvm::GenericValue Val = getOperandValue(I.getOperand(0), SF);
   llvm::GenericValue *Ptr = (llvm::GenericValue *)GVTOP(getOperandValue(I.getPointerOperand(), SF));
 
-  if(I.getOrdering() == llvm::SequentiallyConsistent ||
+  if(I.getOrdering() == LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent ||
      0 <= AtomicFunctionCall){
     /* Atomic store */
     assert(tso_threads[CurrentThread].store_buffer.empty());
@@ -270,7 +270,7 @@ void TSOInterpreter::visitStoreInst(llvm::StoreInst &I){
 }
 
 void TSOInterpreter::visitFenceInst(llvm::FenceInst &I){
-  if(I.getOrdering() == llvm::SequentiallyConsistent){
+  if(I.getOrdering() == LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent){
     TB.fence();
   }
 }


### PR DESCRIPTION
Hi,

I did some modification to make nidhugg able to compile on my machine with LLVM 3.9.
It works right now. But I haven't done any compile test with early versions of LLVM.

Regards,
Boqun