### PR TITLE
Small Makefile fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ dist_doc_DATA = README
 
 .PHONY: test valtest
 test:
-	cd $(top_builddir)/src &&	make test
+	cd $(top_builddir)/src && $(MAKE) $(AM_MAKEFLAGS) test
 
 valtest:
-	cd $(top_builddir)/src &&	make valtest
+	cd $(top_builddir)/src && $(MAKE) $(AM_MAKEFLAGS) valtest

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -10,14 +10,14 @@ EXTRA_DIST = manual.tex
 ## --enable-build-documentation switch.
 if BUILDPDFDOCUMENTATION
 
-manual.pdf: manual.tex
-	cat manual.tex | \
+manual.pdf: $(srcdir)/manual.tex
+	cat $(srcdir)/manual.tex | \
 	sed 's/%%NIDHUGGVERSION%%/@VERSION@/g' | \
 	pdflatex -jobname manual || :
-	cat manual.tex | \
+	cat $(srcdir)/manual.tex | \
 	sed 's/%%NIDHUGGVERSION%%/@VERSION@/g' | \
 	pdflatex -jobname manual || :
-	cat manual.tex | \
+	cat $(srcdir)/manual.tex | \
 	sed 's/%%NIDHUGGVERSION%%/@VERSION@/g' | \
 	pdflatex -jobname manual || \
 	echo -e '\n\n * Failed to build documentation.\n'

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -84,7 +84,7 @@ valtest: unittest
 	valgrind --leak-check=full ./unittest $(BOOSTTESTFLAGS) --show_progress --run_test='$(UTEST)'
 
 nidhuggc$(EXEEXT): $(srcdir)/nidhuggc.py
-	cat nidhuggc.py \
+	cat $(srcdir)/nidhuggc.py \
 	| sed 's|%%PYTHON%%|@PYTHON@|g' \
 	| sed 's|%%CLANG%%|@CLANG@|g' \
 	| sed 's|%%CLANGXX%%|@CLANGXX@|g' \


### PR DESCRIPTION
 * The first fix is for building in a different directory than the source code root.
 * The second fix is to get rid of some make warnings when recursing with the `-j` flag.
