### PR TITLE
Add LLVM 4.0 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -244,8 +244,26 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
            [AC_DEFINE([LLVM_MODULE_MATERIALIZE_ALL_PERMANENTLY_BOOL_STRPTR],[1],
             [Define if Module::MaterializeAllPermanenty has signature std::string* -> bool])
             AC_MSG_RESULT([string* -> bool])],
-           [AC_MSG_RESULT([use materializeAll instead])])
-])
+           [
+   AC_MSG_RESULT([use materializeAll instead])
+   ## Check the signature of llvm::Module::materializeAll
+   AC_MSG_CHECKING([the signature of llvm::Module::materializeAll])
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <llvm/Support/Error.h>
+#if defined(HAVE_LLVM_MODULE_H)
+#include <llvm/Module.h>
+#elif defined(HAVE_LLVM_IR_MODULE_H)
+#include <llvm/IR/Module.h>
+#endif
+]],[[
+  llvm::Module *M = 0;
+  llvm::Error Err = M->materializeAll();
+]])],
+           [AC_DEFINE([LLVM_MODULE_MATERIALIZE_LLVM_ALL_ERROR],[1],
+            [Define if Module::materializeAll has signature () -> llvm::Error])
+            AC_MSG_RESULT([() -> llvm::Error])],
+           [AC_MSG_RESULT([() -> llvm::error_code])])
+])])
 
 ## Check if AtomicOrdering is an enum class
 AC_MSG_CHECKING([whether AtomicOrdering is an enum class])
@@ -886,6 +904,54 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
    AC_DEFINE([HAVE_LLVM_INITIALIZE_IPA],[1],
    [Define if llvm::initializeIPA exists])],
   [AC_MSG_RESULT([no])])
+
+## Check whether Pass::getPassName() returns a StringRef
+AC_MSG_CHECKING([whether Pass::getPassName() returns a StringRef])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <llvm/Pass.h>
+]],[[
+  class MyPass : public llvm::Pass {
+  public:
+    virtual llvm::StringRef getPassName() const { return "MyPass"; };
+  };
+]])],
+        [AC_DEFINE([LLVM_PASS_GETPASSNAME_IS_STRINGREF],[1],
+         [Define if Pass::getPassName() returns a StringRef.])
+         AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+
+## Check whether llvm::cl::values needs a sentinel
+AC_MSG_CHECKING([whether whether llvm::cl::values needs a sentinel])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <llvm/Support/CommandLine.h>
+]],[[
+  enum Unit{
+    UNIT
+  };
+  auto v = llvm::cl::values(clEnumVal(UNIT,"The only option"),clEnumValEnd);
+]])],
+        [AC_DEFINE([LLVM_CL_VALUES_USES_SENTINEL],[1],
+         [Define if llvm::cl::values needs a sentinel.])
+         AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+
+## Check whether llvm:gep_type_iterator uses the new API
+AC_MSG_CHECKING([whether llvm:gep_type_iterator uses the new API])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_SUPPORT_GETELEMENTPTRTYPEITERATOR_H)
+#include <llvm/Support/GetElementPtrTypeIterator.h>
+#elif defined(HAVE_LLVM_IR_GETELEMENTPTRTYPEITERATOR_H)
+#include <llvm/IR/GetElementPtrTypeIterator.h>
+#endif
+]],[[
+  llvm::gep_type_iterator *I = 0;
+  llvm::StructType *STy = I->getStructTypeOrNull();
+]])],
+        [AC_DEFINE([LLVM_NEW_GEP_TYPE_ITERATOR_API],[1],
+         [Define if llvm:gep_type_iterator uses the new API.])
+         AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/src/AddLibPass.h
+++ b/src/AddLibPass.h
@@ -17,6 +17,8 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+
 #ifndef __ADD_LIB_PASS_H__
 #define __ADD_LIB_PASS_H__
 
@@ -37,7 +39,11 @@ public:
   AddLibPass() : llvm::ModulePass(ID) {};
   virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
   virtual bool runOnModule(llvm::Module &M);
+#ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF
+  virtual llvm::StringRef getPassName() const { return "AddLibPass"; };
+#else
   virtual const char *getPassName() const { return "AddLibPass"; };
+#endif
 protected:
   /* If a function named name is already defined in M, then return
    * false. Otherwise search for a definition in the LLVM assembly

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -46,8 +46,11 @@ cl_memory_model(llvm::cl::NotHidden, llvm::cl::init(Configuration::MM_UNDEF),
                                  clEnumValN(Configuration::ARM,"arm","The ARM model"),
                                  clEnumValN(Configuration::POWER,"power","The POWER model"),
                                  clEnumValN(Configuration::PSO,"pso","Partial Store Order"),
-                                 clEnumValN(Configuration::TSO,"tso","Total Store Order"),
-                                 clEnumValEnd));
+                                 clEnumValN(Configuration::TSO,"tso","Total Store Order")
+#ifdef LLVM_CL_VALUES_USES_SENTINEL
+                                ,clEnumValEnd
+#endif
+                                 ));
 
 static llvm::cl::opt<bool> cl_check_robustness("robustness",llvm::cl::NotHidden,
                                                llvm::cl::desc("Check for robustness as a correctness criterion."));

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -74,6 +74,17 @@ ExecutionEngine *Interpreter::create(Module *M, TSOPSOTraceBuilder &TB,
     // We got an error, just return 0
     return 0;
   }
+#elif defined LLVM_MODULE_MATERIALIZE_LLVM_ALL_ERROR
+  if (Error Err = M->materializeAll()) {
+    std::string Msg;
+    handleAllErrors(std::move(Err), [&](ErrorInfoBase &EIB) {
+      Msg = EIB.message();
+    });
+    if (ErrStr)
+      *ErrStr = Msg;
+    // We got an error, just return 0
+    return nullptr;
+  }
 #else
   if(std::error_code EC = M->materializeAll()){
     // We got an error, just return 0

--- a/src/LoopUnrollPass.h
+++ b/src/LoopUnrollPass.h
@@ -17,6 +17,8 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+
 #ifndef __LOOP_UNROLL_PASS_H__
 #define __LOOP_UNROLL_PASS_H__
 
@@ -37,7 +39,11 @@ public:
   };
   virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
   virtual bool runOnLoop(llvm::Loop *L, llvm::LPPassManager &LPM);
+#ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF
+  virtual llvm::StringRef getPassName() const { return "LoopUnrollPass"; };
+#else
   virtual const char *getPassName() const { return "LoopUnrollPass"; };
+#endif
 protected:
   llvm::BasicBlock *make_diverge_block(llvm::Loop *L);
   int unroll_depth;

--- a/src/POWERInterpreter.cpp
+++ b/src/POWERInterpreter.cpp
@@ -63,6 +63,17 @@ llvm::ExecutionEngine *POWERInterpreter::create(llvm::Module *M, POWERARMTraceBu
     // We got an error, just return 0
     return 0;
   }
+#elif defined LLVM_MODULE_MATERIALIZE_LLVM_ALL_ERROR
+  if (llvm::Error Err = M->materializeAll()) {
+    std::string Msg;
+    handleAllErrors(std::move(Err), [&](llvm::ErrorInfoBase &EIB) {
+      Msg = EIB.message();
+    });
+    if (ErrStr)
+      *ErrStr = Msg;
+    // We got an error, just return 0
+    return nullptr;
+  }
 #else
   if(std::error_code EC = M->materializeAll()){
     // We got an error, just return 0

--- a/src/PSOInterpreter.cpp
+++ b/src/PSOInterpreter.cpp
@@ -64,6 +64,17 @@ llvm::ExecutionEngine *PSOInterpreter::create(llvm::Module *M, PSOTraceBuilder &
     // We got an error, just return 0
     return 0;
   }
+#elif defined LLVM_MODULE_MATERIALIZE_LLVM_ALL_ERROR
+  if (llvm::Error Err = M->materializeAll()) {
+    std::string Msg;
+    handleAllErrors(std::move(Err), [&](llvm::ErrorInfoBase &EIB) {
+      Msg = EIB.message();
+    });
+    if (ErrorStr)
+      *ErrorStr = Msg;
+    // We got an error, just return 0
+    return nullptr;
+  }
 #else
   if(std::error_code EC = M->materializeAll()){
     // We got an error, just return 0

--- a/src/SpinAssumePass.h
+++ b/src/SpinAssumePass.h
@@ -17,6 +17,8 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+
 #ifndef __SPIN_ASSUME_PASS_H__
 #define __SPIN_ASSUME_PASS_H__
 
@@ -62,7 +64,11 @@ public:
   SpinAssumePass() : llvm::LoopPass(ID) {};
   virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
   virtual bool runOnLoop(llvm::Loop *L, llvm::LPPassManager &LPM);
+#ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF
+  virtual llvm::StringRef getPassName() const { return "SpinAssumePass"; };
+#else
   virtual const char *getPassName() const { return "SpinAssumePass"; };
+#endif
 protected:
   bool is_spin(const llvm::Loop *l) const;
   bool is_assume(llvm::Instruction &I) const;

--- a/src/TSOInterpreter.cpp
+++ b/src/TSOInterpreter.cpp
@@ -53,6 +53,17 @@ llvm::ExecutionEngine *TSOInterpreter::create(llvm::Module *M, TSOTraceBuilder &
     // We got an error, just return 0
     return 0;
   }
+#elif defined LLVM_MODULE_MATERIALIZE_LLVM_ALL_ERROR
+  if (llvm::Error Err = M->materializeAll()) {
+    std::string Msg;
+    handleAllErrors(std::move(Err), [&](llvm::ErrorInfoBase &EIB) {
+      Msg = EIB.message();
+    });
+    if (ErrorStr)
+      *ErrorStr = Msg;
+    // We got an error, just return 0
+    return nullptr;
+  }
 #else
   if(std::error_code EC = M->materializeAll()){
     // We got an error, just return 0


### PR DESCRIPTION
This PR adds `configure.ac` checks for the API changes in LLVM 4.0 that prevents Nidhugg from compiling.