### PR TITLE
Add support for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: C++
+sudo: false
+branches:
+  only:
+    - master
+env:
+  - LLVM_VERSION=3.5.0  # default on Debian jessie
+  - LLVM_VERSION=3.6.2
+  #- LLVM_VERSION=3.8.1  # default on Debian stretch - does NOT work yet
+addons:
+  apt:
+    sources:
+      - boost-latest
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.9         # need at least this version of libstdc++6
+      - libc6
+      - libc6-dev
+      - libstdc++-4.9-dev
+      - autoconf
+      - automake
+      - python3
+      - libffi-dev
+      - libboost-test1.55-dev
+      - valgrind
+      - libedit-dev     # required by LLVM 3.5.0
+before_script:
+  - ./travis/install_deps.sh
+  - export LLVM_DIR=$PWD/cache/clang+llvm-$LLVM_VERSION
+  - export PATH=$LLVM_DIR/bin:$PATH
+  - export LD_LIBRARY_PATH=$LLVM_DIR/lib
+  - export CPATH=/usr/lib/gcc/x86_64-linux-gnu/4.9/include
+  - export CC=gcc-4.9
+  - export CXX=g++-4.9
+  - autoreconf --install
+  - ./configure         # || cat config.log    # left for debugging
+  - make -j6
+script: "make test && make valtest"
+cache:
+  directories:
+    - cache

--- a/travis/install_deps.sh
+++ b/travis/install_deps.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+mkdir -p cache
+
+# LLVM
+case $LLVM_VERSION in
+    "3.9.1")
+	LLVM_URL="http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-16.04.tar.xz"
+	;;
+    ?*)
+	LLVM_URL="http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz"
+	;;
+esac
+LLVM_DEP="cache/$LLVM_VERSION.tar.xz"
+LLVM_DIR="cache/clang+llvm-$LLVM_VERSION"
+
+echo $LLVM_URL
+echo $LLVM_DEP
+echo $LLVM_DIR
+
+# download and install
+if [ ! -f $LLVM_DEP ] ; then
+    echo "Downloading LLVM"
+    wget $LLVM_URL -O $LLVM_DEP
+    if [ ! $? -eq 0 ]; then
+	echo "Error: Download failed"
+	rm $LLVM_DEP || true
+	exit 1
+    fi
+else
+    echo "Found Cached Archive"
+fi
+
+if [ ! -d $LLVM_DIR ] ; then
+    echo "Extracting LLVM"
+    tar -xf $LLVM_DEP -C cache/
+    if [ ! $? -eq 0 ]; then
+	echo "Error: Extraction Failed"
+	rm $LLVM_DEP || true
+	exit 1
+    fi
+    case $LLVM_VERSION in
+	"3.5.0")
+	    mv cache/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu cache/clang+llvm-$LLVM_VERSION
+	    ;;
+	"3.9.1")
+	    mv cache/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-16.04 cache/clang+llvm-$LLVM_VERSION
+	    ;;
+	?*)
+	    mv cache/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04 cache/clang+llvm-$LLVM_VERSION
+	    ;;
+    esac
+else
+    echo "Found Cached Installation"
+fi


### PR DESCRIPTION
This pull request adds support for automatically building nidhugg and
running the test on travis-ci.org for pull requests and for commits to
the master branch of the repository.

As a first step, it adds support for testing under two relatively old
LLVM versions (3.5.0 and 3.6.2).  Newer ones (e.g., 3.8.1) can currently
not be run on Travis because of llvm-config returning some unknown flags
which g++ cannot handle.