### PR TITLE
Add support for passing arguments to the test program

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -22,6 +22,8 @@
 #include <llvm/Support/CommandLine.h>
 #include "Debug.h"
 
+extern llvm::cl::list<std::string> cl_program_arguments;
+
 extern llvm::cl::opt<std::string> cl_transform;
 
 static llvm::cl::opt<bool> cl_explore_all("explore-all",llvm::cl::NotHidden,
@@ -112,6 +114,9 @@ void Configuration::assign_by_commandline(){
   transform_loop_unroll = cl_transform_loop_unroll;
   print_progress = cl_print_progress || cl_print_progress_estimate;
   print_progress_estimate = cl_print_progress_estimate;
+  for(std::string a : cl_program_arguments){
+    argv.push_back(a);
+  }
 }
 
 void Configuration::check_commandline(){

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -84,6 +84,8 @@ public:
     transform_loop_unroll = -1;
     print_progress = false;
     print_progress_estimate = false;
+    argv = std::vector<std::string>();
+    argv.push_back("a.out");
   };
   /* Read the switches given to the program by the user. Assign
    * configuration options accordingly.
@@ -173,7 +175,8 @@ public:
    * traces.
    */
   bool print_progress_estimate;
-
+  /* The arguments that will be passed to the program under test */
+  std::vector<std::string> argv;
   /* The set of all commandline switches that are associated with
    * setting configuration options. This set has nothing to do with
    * which switches were actually given by the user.

--- a/src/DPORDriver.cpp
+++ b/src/DPORDriver.cpp
@@ -152,7 +152,7 @@ Trace *DPORDriver::run_once(TraceBuilder &TB) const{
   std::shared_ptr<llvm::ExecutionEngine> EE(create_execution_engine(TB,conf));
 
   // Run main.
-  EE->runFunctionAsMain(mod->getFunction("main"), {"prog"}, 0);
+  EE->runFunctionAsMain(mod->getFunction("main"), conf.argv, 0);
 
   // Run static destructors.
   EE->runStaticConstructorsDestructors(true);
@@ -172,7 +172,7 @@ Trace *DPORDriver::run_once(TraceBuilder &TB) const{
       Configuration conf2(conf);
       conf2.ee_store_trace = true;
       llvm::ExecutionEngine *E = create_execution_engine(TB,conf2);
-      E->runFunctionAsMain(mod->getFunction("main"), {"prog"}, 0);
+      E->runFunctionAsMain(mod->getFunction("main"), conf.argv, 0);
       E->runStaticConstructorsDestructors(true);
       if(conf.check_robustness){
         static_cast<llvm::Interpreter*>(E)->checkForCycles();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,16 @@ cl_transform("transform",llvm::cl::init(""),
              llvm::cl::desc("Transform the input module and store it (as LLVM assembly) to OUTFILE."),
              llvm::cl::NotHidden,llvm::cl::value_desc("OUTFILE"));
 
+llvm::cl::opt<std::string>
+cl_input_file(llvm::cl::desc("<input bitcode or assembly>"),
+              llvm::cl::Positional,
+              llvm::cl::init("-"));
+
+llvm::cl::list<std::string>
+cl_program_arguments(llvm::cl::desc("[-- <program arguments>...]"),
+                     llvm::cl::Positional,
+                     llvm::cl::ZeroOrMore);
+
 void print_version(){
   std::cout << PACKAGE_STRING
             << " ("
@@ -79,10 +89,6 @@ int main(int argc, char *argv[]){
       }
     }
   }
-  llvm::cl::opt<std::string>
-    input_file(llvm::cl::desc("<input bitcode or assembly>"),
-               llvm::cl::Positional,
-               llvm::cl::init("-"));
   llvm::cl::ParseCommandLineOptions(argc, argv);
 
   bool errors_detected = false;
@@ -92,11 +98,11 @@ int main(int argc, char *argv[]){
     conf.check_commandline();
 
     if(cl_transform != ""){
-      Transform::transform(input_file,cl_transform,conf);
+      Transform::transform(cl_input_file,cl_transform,conf);
     }else{
       /* Use DPORDriver to explore the given module */
       DPORDriver *driver =
-        DPORDriver::parseIRFile(input_file,conf);
+        DPORDriver::parseIRFile(cl_input_file,conf);
 
       DPORDriver::Result res = driver->run();
       std::cout << "Trace count: " << res.trace_count

--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -93,14 +93,11 @@ def get_args():
             return nidhuggcparamaliases[arg[:i]]+arg[i:]
         return arg
     shouldhaveinput=(0 == len([a for a in sys.argv[1:] if canonize(a) in disablesinput]))
+    hasinput=False
     fornidhuggcsingle=[p['name'] for p in nidhuggcparams if p['param'] == False]
     hascompilerargs=False
     i = 1
     argc = len(sys.argv)
-    if shouldhaveinput:
-        if argc<2: print_help(); raise Exception('No input file specified.')
-        A['--input'] = sys.argv[argc-1]
-        argc = argc-1
     while i < argc:
         arg = canonize(sys.argv[i])
         i = i+1
@@ -121,12 +118,18 @@ def get_args():
                     foundparam=True
                     break
             if foundparam: pass
-            elif arg == '--' and not(hascompilerargs):
+            elif len(arg) > 0 and arg[0] != '-' and not(hasinput):
+                A['--input'] = arg
+                hasinput = True
+            elif arg == '--' and not(hascompilerargs) and not(hasinput):
                 B = C
                 C = []
                 hascompilerargs=True
             else:
                 C.append(arg)
+    if shouldhaveinput and not(hasinput):
+        print_help()
+        raise Exception('No input file specified.')
     return (A,B,C)
 
 def help_indent(s,n):
@@ -134,7 +137,8 @@ def help_indent(s,n):
     return ind+(s.replace('\n','\n'+ind))
 
 def print_help():
-    print('Usage: {0} [[COMPILER/NIDHUGGC OPTIONS --] NIDHUGG/NIDHUGGC OPTIONS] FILE'.format(sys.argv[0]))
+    print('Usage: {0} [[COMPILER/NIDHUGGC OPTIONS --] NIDHUGG/NIDHUGGC OPTIONS]'
+          ' FILE [-- [PROGRAM ARGUMENTS]]'.format(sys.argv[0]))
     print('')
     print(' - FILE should be a source code file in C or C++.')
     print(' - COMPILER OPTIONS are options that will be sent to the compiler')
@@ -205,7 +209,7 @@ def transform(nidhuggcargs,transformargs,irfname):
     return outputfname
 
 def run_nidhugg(nidhuggcargs,nidhuggargs,irfname):
-    cmd = [NIDHUGG]+nidhuggargs+[irfname]
+    cmd = [NIDHUGG,irfname]+nidhuggargs
     return run(cmd)
 
 def main():


### PR DESCRIPTION
This commit makes it possible to pass arguments to the test
program. The following example illustrate how this can be done:

$ nidhugg --sc test_program.ll argument1 argument2