### PR TITLE
Add LLVM 5.0 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,6 @@ AC_CHECK_HEADERS([ \
   llvm/Support/CommandLine.h \
   llvm/Support/DataTypes.h \
   llvm/Support/Debug.h \
-  llvm/Support/Dwarf.h \
   llvm/Support/DynamicLibrary.h \
   llvm/Support/ErrorHandling.h \
   llvm/Support/FileSystem.h \
@@ -171,6 +170,7 @@ AC_CHECK_HEADERS_ALT([llvm/PassManager.h llvm/IR/PassManager.h],[],[AC_MSG_FAILU
 AC_CHECK_HEADERS_ALT([llvm/Type.h llvm/IR/Type.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])
 AC_CHECK_HEADERS_ALT([llvm/Assembly/PrintModulePass.h llvm/IR/IRPrintingPasses.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])
 AC_CHECK_HEADERS_ALT([llvm/Analysis/Verifier.h llvm/IR/Verifier.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],AC_INCLUDES_DEFAULT[])
+AC_CHECK_HEADERS_ALT([llvm/Support/Dwarf.h llvm/BinaryFormat/Dwarf.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],AC_INCLUDES_DEFAULT[])
 AC_CHECK_HEADERS_ALT([llvm/Support/ErrorOr.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])
 AC_CHECK_HEADERS([llvm/Support/system_error.h],[],[],[AC_INCLUDES_DEFAULT])
 
@@ -293,11 +293,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <llvm/IR/Instructions.h>
 #endif
 ]],[[
-  llvm::AtomicCmpXchgInst I((llvm::Value*)0,(llvm::Value*)0,(llvm::Value*)0,
-                            (llvm::AtomicOrdering)0,
-                            (llvm::AtomicOrdering)0,
-                            llvm::SynchronizationScope(llvm::CrossThread),
-                            (llvm::Instruction*)0);
+  llvm::AtomicCmpXchgInst *I = nullptr;
+  I->getSuccessOrdering();
 ]])],
            [AC_DEFINE([LLVM_CMPXCHG_SEPARATE_SUCCESS_FAILURE_ORDERING],[1],
             [Define if llvm::AtomicCmpXchgInst has separate orderings for success and failure.])
@@ -501,7 +498,11 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 ## Check if llvm::LLVMDebugVersion is defined
 AC_MSG_CHECKING([for LLVMDebugVersion])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_SUPPORT_DWARF_H)
 #include <llvm/Support/Dwarf.h>
+#elif defined(HAVE_LLVM_BINARYFORMAT_DWARF_H)
+#include <llvm/BinaryFormat/Dwarf.h>
+#endif
 ]],[[
   unsigned dbg = llvm::LLVMDebugVersion;
 ]])],
@@ -949,6 +950,42 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 ]])],
         [AC_DEFINE([LLVM_NEW_GEP_TYPE_ITERATOR_API],[1],
          [Define if llvm:gep_type_iterator uses the new API.])
+         AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+
+## Check whether functions use llvm::AttributeList
+AC_MSG_CHECKING([whether functions use llvm::AttributeList])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_IR_MODULE_H)
+#include <llvm/IR/Module.h>
+#elif defined(HAVE_LLVM_MODULE_H)
+#include <llvm/Module.h>
+#endif
+]],[[
+  llvm::Module *M = nullptr;
+  llvm::AttributeList assumeAttrs =
+    llvm::AttributeList::get(M->getContext(),llvm::AttributeList::FunctionIndex,
+                             std::vector<llvm::Attribute::AttrKind>({llvm::Attribute::NoUnwind}));
+]])],
+        [AC_DEFINE([LLVM_HAS_ATTRIBUTELIST],[1],
+         [Define if llvm::AttributeList exists.])
+         AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+
+## Check whether llvm::SwitchInst::CaseIt needs dereference
+AC_MSG_CHECKING([whether llvm::SwitchInst::CaseIt needs dereference])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_IR_INSTRUCTIONS_H)
+#include <llvm/IR/Instructions.h>
+#elif defined(HAVE_LLVM_INSTRUCTIONS_H)
+#include <llvm/Instructions.h>
+#endif
+]],[[
+  llvm::SwitchInst::CaseIt *i = nullptr;
+  (*i)->getCaseValue();
+]])],
+        [AC_DEFINE([LLVM_SWITCHINST_CASEIT_NEEDS_DEREFERENCE],[1],
+         [Define if llvm::SwitchInst::CaseIt should be dereferenced.])
          AC_MSG_RESULT([yes])],
         [AC_MSG_RESULT([no])])
 

--- a/src/AddLibPass.cpp
+++ b/src/AddLibPass.cpp
@@ -153,7 +153,7 @@ bool AddLibPass::runOnModule(llvm::Module &M){
       /* Figure out types for arguments of calloc (declaration) and
        * malloc.
        */
-      if(F->getArgumentList().size() != 2){
+      if(F->arg_size() != 2){
         throw std::logic_error("Unable to add definition of calloc. Wrong signature.");
       }
       std::string arg0ty, arg1ty, malloc_argty, malloc_declaration;
@@ -167,7 +167,7 @@ bool AddLibPass::runOnModule(llvm::Module &M){
       arg1tys.flush();
       llvm::Function *F_malloc = M.getFunction("malloc");
       if(F_malloc){
-        if(F_malloc->getArgumentList().size() != 1){
+        if(F_malloc->arg_size() != 1){
           throw std::logic_error("Unable to add definition of calloc. malloc has the wrong signature.");
         }
         malloc_argtys << *F_malloc->arg_begin()->getType();

--- a/src/CheckModule.cpp
+++ b/src/CheckModule.cpp
@@ -82,9 +82,9 @@ void CheckModule::check_pthread_create(const llvm::Module *M){
           << *pthread_create->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(pthread_create->getArgumentList().size() != 4){
+    if(pthread_create->arg_size() != 4){
       err << "pthread_create takes wrong number of arguments ("
-          << pthread_create->getArgumentList().size() << ")";
+          << pthread_create->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     if(!pthread_create->arg_begin()->getType()->isPointerTy()){
@@ -129,9 +129,9 @@ void CheckModule::check_pthread_join(const llvm::Module *M){
           << *pthread_join->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(pthread_join->getArgumentList().size() != 2){
+    if(pthread_join->arg_size() != 2){
       err << "pthread_join takes wrong number of arguments ("
-          << pthread_join->getArgumentList().size() << ")";
+          << pthread_join->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0_ty, *arg1_ty;
@@ -164,7 +164,7 @@ void CheckModule::check_pthread_self(const llvm::Module *M){
           << *pthread_self->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(pthread_self->getArgumentList().size()){
+    if(pthread_self->arg_size()){
       err << "pthread_self takes arguments. Should not take any.";
       throw CheckModuleError(err.str());
     }
@@ -182,9 +182,9 @@ void CheckModule::check_pthread_exit(const llvm::Module *M){
           << *pthread_exit->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(pthread_exit->getArgumentList().size() != 1){
+    if(pthread_exit->arg_size() != 1){
       err << "pthread_exit takes wrong number of arguments ("
-          << pthread_exit->getArgumentList().size() << ")";
+          << pthread_exit->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *ty = pthread_exit->arg_begin()->getType(),
@@ -207,9 +207,9 @@ void CheckModule::check_pthread_mutex_init(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 2){
+    if(F->arg_size() != 2){
       err << "pthread_mutex_init takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty, *arg1ty;
@@ -241,9 +241,9 @@ void CheckModule::check_pthread_mutex_lock(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 1){
+    if(F->arg_size() != 1){
       err << "pthread_mutex_lock takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty = F->arg_begin()->getType();
@@ -265,9 +265,9 @@ void CheckModule::check_pthread_mutex_trylock(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 1){
+    if(F->arg_size() != 1){
       err << "pthread_mutex_trylock takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty = F->arg_begin()->getType();
@@ -289,9 +289,9 @@ void CheckModule::check_pthread_mutex_unlock(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 1){
+    if(F->arg_size() != 1){
       err << "pthread_mutex_unlock takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty = F->arg_begin()->getType();
@@ -313,9 +313,9 @@ void CheckModule::check_pthread_mutex_destroy(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 1){
+    if(F->arg_size() != 1){
       err << "pthread_mutex_destroy takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty = F->arg_begin()->getType();
@@ -365,9 +365,9 @@ namespace CheckModule {
             << *F->getReturnType();
         throw CheckModuleError(err.str());
       }
-      if(F->getArgumentList().size() != 1){
+      if(F->arg_size() != 1){
         err << name << " takes wrong number of arguments ("
-            << F->getArgumentList().size() << ")";
+            << F->arg_size() << ")";
         throw CheckModuleError(err.str());
       }
       if(!F->arg_begin()->getType()->isIntegerTy()){
@@ -399,9 +399,9 @@ void CheckModule::check_pthread_cond_init(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 2){
+    if(F->arg_size() != 2){
       err << "pthread_cond_init takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty, *arg1ty;
@@ -433,9 +433,9 @@ void CheckModule::check_pthread_cond_signal(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 1){
+    if(F->arg_size() != 1){
       err << "pthread_cond_signal takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty = F->arg_begin()->getType();
@@ -457,9 +457,9 @@ void CheckModule::check_pthread_cond_broadcast(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 1){
+    if(F->arg_size() != 1){
       err << "pthread_cond_broadcast takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty = F->arg_begin()->getType();
@@ -481,9 +481,9 @@ void CheckModule::check_pthread_cond_wait(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 2){
+    if(F->arg_size() != 2){
       err << "pthread_cond_wait takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty, *arg1ty;
@@ -515,9 +515,9 @@ void CheckModule::check_pthread_cond_destroy(const llvm::Module *M){
           << *F->getReturnType();
       throw CheckModuleError(err.str());
     }
-    if(F->getArgumentList().size() != 1){
+    if(F->arg_size() != 1){
       err << "pthread_cond_destroy takes wrong number of arguments ("
-          << F->getArgumentList().size() << ")";
+          << F->arg_size() << ")";
       throw CheckModuleError(err.str());
     }
     llvm::Type *arg0ty = F->arg_begin()->getType();

--- a/src/POWERInterpreter.h
+++ b/src/POWERInterpreter.h
@@ -240,9 +240,9 @@ private:
   std::vector<llvm::Function*> AtExitHandlers;
 
   /* A dummy store of the value 0 (int32) to null. */
-  llvm::Instruction *dummy_store;
+  llvm::StoreInst *dummy_store;
   /* A dummy load from null (int8*). */
-  llvm::Instruction *dummy_load8;
+  llvm::LoadInst *dummy_load8;
 
 public:
   explicit POWERInterpreter(llvm::Module *M, POWERARMTraceBuilder &TB,

--- a/src/SpinAssumePass.cpp
+++ b/src/SpinAssumePass.cpp
@@ -57,6 +57,12 @@
 #include "SpinAssumePass.h"
 #include "vecset.h"
 
+#ifdef LLVM_HAS_ATTRIBUTELIST
+typedef llvm::AttributeList AttributeList;
+#else
+typedef llvm::AttributeSet AttributeList;
+#endif
+
 void SpinAssumePass::getAnalysisUsage(llvm::AnalysisUsage &AU) const{
   AU.addRequired<llvm::LLVM_DOMINATOR_TREE_PASS>();
   AU.addRequired<DeclareAssumePass>();
@@ -74,8 +80,8 @@ bool DeclareAssumePass::runOnModule(llvm::Module &M){
       llvm::Type *i1Ty = llvm::Type::getInt1Ty(M.getContext());
       assumeTy = llvm::FunctionType::get(voidTy,{i1Ty},false);
     }
-    llvm::AttributeSet assumeAttrs =
-      llvm::AttributeSet::get(M.getContext(),llvm::AttributeSet::FunctionIndex,
+    AttributeList assumeAttrs =
+      AttributeList::get(M.getContext(),AttributeList::FunctionIndex,
                               std::vector<llvm::Attribute::AttrKind>({llvm::Attribute::NoUnwind}));
     F_assume = llvm::dyn_cast<llvm::Function>(M.getOrInsertFunction("__VERIFIER_assume",assumeTy,assumeAttrs));
     assert(F_assume);

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -41,7 +41,11 @@
 #elif defined(HAVE_LLVM_CONSTANTS_H)
 #include <llvm/Constants.h>
 #endif
+#if defined(HAVE_LLVM_SUPPORT_DWARF_H)
 #include <llvm/Support/Dwarf.h>
+#elif defined(HAVE_LLVM_BINARYFORMAT_DWARF_H)
+#include <llvm/BinaryFormat/Dwarf.h>
+#endif
 
 Trace::Trace(const std::vector<Error*> &errors, bool blk)
   : errors(errors), blocked(blk) {


### PR DESCRIPTION
This PR adds support for LLVM 5.0 by
 * Switching all users of `llvm::Function::getArgumentList().size()` to `llvm::Function::arg_size()`, as the former was dropped from LLVM 5.0 and the latter has been available since LLVM 3.3.
 * Adding `configure.ac` checks for API changes in LLVM 5.0.
 * Simplifying a `configure.ac` check that was failing under LLVM 5.0 from API changes that it was not intended to check for.