### PR TITLE
Add flags for graphical output of exploration

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -2,6 +2,7 @@
 
 \usepackage[utf8]{inputenc}
 \usepackage{amssymb}
+\usepackage[colorlinks,linkcolor=black]{hyperref}
 
 \title{Nidhugg -- Manual\\\large{Version %%NIDHUGGVERSION%%}}
 \author{}
@@ -363,6 +364,38 @@ int main(int argc, char *argv[]){
   representation after compilation and possibly optimization. These
   loops do not necessarily correspond one-to-one with the loops in the
   high-level language.
+\end{description}
+
+\subsubsection{Tracing Switches}
+
+Nidhugg has some switches that can show how it is exploring a program
+and what operations it considers racing. There operations output graphs
+in Graphviz\footnote{\url{https://graphviz.org}} DOT format.
+
+\begin{description}
+\item{\texttt{--dump-tree=$OUTFILE$}}
+%
+  After analysis, write a graph that visualises the exploration tree to
+  $OUTFILE$.
+
+\item{\texttt{--dump-traces=$OUTFILE$}}
+%
+  After analysis, write a graph of the happens-before orders of all explored
+  traces to $OUTFILE$.
+%
+  \limitsupport{SC, TSO, PSO}
+
+\item{\texttt{--dump-spec=$OUTFILE$}}
+%
+  This option is primarily useful to developers of Nidhugg. After analysis,
+  write a minimised \texttt{DPORDriver\_test::trace\_set\_\hspace{0pt}spec}
+  characterising the explored set of traces, excluding sleepset-blocked ones, to
+  $OUTFILE$. Useful for creating regression tests after an issue has been fixed,
+  and the test program is not small enough to make writing a
+  \texttt{DPORDriver\_test::trace\_set\_spec} by hand feasible.
+%
+  \limitsupport{SC, TSO, PSO}
+
 \end{description}
 
 \subsubsection{Exit Status}

--- a/src/CPid.cpp
+++ b/src/CPid.cpp
@@ -121,6 +121,10 @@ int CPid::get_aux_index() const{
   return aux_idx;
 }
 
+int CPid::get_child_index() const{
+  return proc_seq.back();
+}
+
 CPidSystem::CPidSystem(){
   real_children.push_back({});
   aux_children.push_back({});

--- a/src/CPid.h
+++ b/src/CPid.h
@@ -71,6 +71,9 @@ public:
    */
   int get_aux_index() const;
 
+  /* Returns pn where this CPid is <p0.....pn/i>. */
+  int get_child_index() const;
+
   std::string to_string() const;
 
   /* Comparison implements a total order over CPids. */

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -99,6 +99,14 @@ static llvm::cl::opt<bool> cl_debug_print_on_reset
 ("debug-print-on-reset",llvm::cl::Hidden,
  llvm::cl::desc("Print debug info after exploring each trace."));
 
+static llvm::cl::OptionCategory cl_dump_cat
+("Trace Dumping");
+
+static llvm::cl::opt<std::string> cl_dump_traces
+("dump-traces",llvm::cl::NotHidden,llvm::cl::cat(cl_dump_cat),
+ llvm::cl::value_desc("FILE"),
+ llvm::cl::desc("Write graph of explored equivalence classes to FILE."));
+
 const std::set<std::string> &Configuration::commandline_opts(){
   static std::set<std::string> opts = {
     "dpor-explore-all",
@@ -113,7 +121,8 @@ const std::set<std::string> &Configuration::commandline_opts(){
     "no-spin-assume",
     "unroll",
     "print-progress",
-    "print-progress-estimate"
+    "print-progress-estimate",
+    "dump-traces",
   };
   return opts;
 }
@@ -137,6 +146,8 @@ void Configuration::assign_by_commandline(){
   print_progress = cl_print_progress || cl_print_progress_estimate;
   print_progress_estimate = cl_print_progress_estimate;
   debug_print_on_reset = cl_debug_print_on_reset;
+  trace_dump_file = cl_dump_traces;
+  debug_collect_all_traces |= !cl_dump_traces.empty();
   argv.resize(1);
   argv[0] = get_default_program_name();
   for(std::string a : cl_program_arguments){
@@ -225,6 +236,10 @@ void Configuration::check_commandline(){
       if(cl_check_robustness.getNumOccurrences()){
         Debug::warn("Configuration::check_commandline:mm:robustness")
           << "WARNING: --robustness ignored under memory model " << mm << ".\n";
+      }
+      if (cl_dump_traces != ""){
+        Debug::warn("Configuration::check_commandline:mm:dump-traces")
+          << "WARNING: --dump-traces not implemented for memory model " << mm << ".\n";
       }
     }
     if (cl_dpor_algorithm == Configuration::OPTIMAL

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -112,6 +112,11 @@ static llvm::cl::opt<std::string> cl_dump_tree
  llvm::cl::value_desc("FILE"),
  llvm::cl::desc("Write graph of exploration tree to FILE."));
 
+static llvm::cl::opt<std::string> cl_dump_spec
+("dump-spec",llvm::cl::NotHidden,llvm::cl::cat(cl_dump_cat),
+ llvm::cl::value_desc("FILE"),
+ llvm::cl::desc("Write minimal trace_set_spec to FILE."));
+
 const std::set<std::string> &Configuration::commandline_opts(){
   static std::set<std::string> opts = {
     "dpor-explore-all",
@@ -129,6 +134,7 @@ const std::set<std::string> &Configuration::commandline_opts(){
     "print-progress-estimate",
     "dump-traces",
     "dump-tree",
+    "dump-spec",
   };
   return opts;
 }
@@ -157,6 +163,8 @@ void Configuration::assign_by_commandline(){
   tree_dump_file = cl_dump_tree;
   debug_collect_all_traces |= !cl_dump_tree.empty();
   ee_store_trace           |= !cl_dump_tree.empty();
+  spec_dump_file = cl_dump_spec;
+  debug_collect_all_traces |= !cl_dump_spec.empty();
   argv.resize(1);
   argv[0] = get_default_program_name();
   for(std::string a : cl_program_arguments){
@@ -249,6 +257,10 @@ void Configuration::check_commandline(){
       if (cl_dump_traces != ""){
         Debug::warn("Configuration::check_commandline:mm:dump-traces")
           << "WARNING: --dump-traces not implemented for memory model " << mm << ".\n";
+      }
+      if (cl_dump_spec != ""){
+        Debug::warn("Configuration::check_commandline:mm:dump-spec")
+          << "WARNING: --dump-spec ignored under memory model " << mm << ".\n";
       }
     }
     if (cl_dpor_algorithm == Configuration::OPTIMAL

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -107,6 +107,11 @@ static llvm::cl::opt<std::string> cl_dump_traces
  llvm::cl::value_desc("FILE"),
  llvm::cl::desc("Write graph of explored equivalence classes to FILE."));
 
+static llvm::cl::opt<std::string> cl_dump_tree
+("dump-tree",llvm::cl::NotHidden,llvm::cl::cat(cl_dump_cat),
+ llvm::cl::value_desc("FILE"),
+ llvm::cl::desc("Write graph of exploration tree to FILE."));
+
 const std::set<std::string> &Configuration::commandline_opts(){
   static std::set<std::string> opts = {
     "dpor-explore-all",
@@ -123,6 +128,7 @@ const std::set<std::string> &Configuration::commandline_opts(){
     "print-progress",
     "print-progress-estimate",
     "dump-traces",
+    "dump-tree",
   };
   return opts;
 }
@@ -148,6 +154,8 @@ void Configuration::assign_by_commandline(){
   debug_print_on_reset = cl_debug_print_on_reset;
   trace_dump_file = cl_dump_traces;
   debug_collect_all_traces |= !cl_dump_traces.empty();
+  tree_dump_file = cl_dump_tree;
+  debug_collect_all_traces |= !cl_dump_tree.empty();
   argv.resize(1);
   argv[0] = get_default_program_name();
   for(std::string a : cl_program_arguments){

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -156,6 +156,7 @@ void Configuration::assign_by_commandline(){
   debug_collect_all_traces |= !cl_dump_traces.empty();
   tree_dump_file = cl_dump_tree;
   debug_collect_all_traces |= !cl_dump_tree.empty();
+  ee_store_trace           |= !cl_dump_tree.empty();
   argv.resize(1);
   argv[0] = get_default_program_name();
   for(std::string a : cl_program_arguments){

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -184,6 +184,8 @@ public:
    * traces.
    */
   bool print_progress_estimate;
+  /* File to dump graph of equivalence classes to. */
+  std::string trace_dump_file;
   /* The arguments that will be passed to the program under test */
   std::vector<std::string> argv;
   /* The default program name to send to the program under test as

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -188,6 +188,8 @@ public:
   std::string trace_dump_file;
   /* File to dump graph of exploration tree to. */
   std::string tree_dump_file;
+  /* File to dump minimal trace set specification to. */
+  std::string spec_dump_file;
   /* The arguments that will be passed to the program under test */
   std::vector<std::string> argv;
   /* The default program name to send to the program under test as

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -186,6 +186,8 @@ public:
   bool print_progress_estimate;
   /* File to dump graph of equivalence classes to. */
   std::string trace_dump_file;
+  /* File to dump graph of exploration tree to. */
+  std::string tree_dump_file;
   /* The arguments that will be passed to the program under test */
   std::vector<std::string> argv;
   /* The default program name to send to the program under test as

--- a/src/DPORDriver_test.cpp
+++ b/src/DPORDriver_test.cpp
@@ -99,7 +99,7 @@ namespace DPORDriver_test {
     return res;
   }
 
-  int find(const IIDSeqTrace *_t, const IID<CPid> &iid){
+  int find(const IIDVCSeqTrace *_t, const IID<CPid> &iid){
     const std::vector<IID<CPid> > &t = _t->get_computation();
     for(int i = 0; i < int(t.size()); ++i){
       if(t[i] == iid){
@@ -109,7 +109,7 @@ namespace DPORDriver_test {
     return -1;
   }
 
-  bool check_trace(const IIDSeqTrace *t, const trace_spec &spec){
+  bool check_trace(const IIDVCSeqTrace *t, const trace_spec &spec){
     for(unsigned i = 0; i < spec.size(); ++i){
       int a_i = find(t,spec[i].a);
       int b_i = find(t,spec[i].b);
@@ -122,7 +122,7 @@ namespace DPORDriver_test {
 
   /* Returns true iff the indices of the IIDs of each process is
    * strictly increasing along the computation of t. */
-  bool all_clocks_increasing(const IIDSeqTrace *t){
+  bool all_clocks_increasing(const IIDVCSeqTrace *t){
     VClock<CPid> pcs;
     for(auto it = t->get_computation().begin(); it != t->get_computation().end(); ++it){
       if(it->get_index() <= pcs[it->get_pid()]) return false;
@@ -141,7 +141,7 @@ namespace DPORDriver_test {
     }
     bool retval = true;
     for(unsigned i = 0; i < res.all_traces.size(); ++i){
-      if(!all_clocks_increasing(static_cast<const IIDSeqTrace*>(res.all_traces[i]))){
+      if(!all_clocks_increasing(static_cast<const IIDVCSeqTrace*>(res.all_traces[i]))){
         llvm::dbgs() << "DPORDriver_test::check_all_traces: "
                      << "Non increasing instruction index in trace.\n";
         retval = false;
@@ -160,7 +160,7 @@ namespace DPORDriver_test {
       int prev_match = -1;
       for(unsigned j = 0; j < res.all_traces.size(); ++j){
         if(res.all_traces[j]->is_blocked()) continue;
-        if(check_trace(static_cast<const IIDSeqTrace*>(res.all_traces[j]),spec[i])){
+        if(check_trace(static_cast<const IIDVCSeqTrace*>(res.all_traces[j]),spec[i])){
           if(found){
             // Multiple traces match the same specification
             llvm::dbgs() << "DPORDriver_test::check_all_traces: Multiple traces (#"

--- a/src/DPORDriver_test.cpp
+++ b/src/DPORDriver_test.cpp
@@ -99,10 +99,9 @@ namespace DPORDriver_test {
     return res;
   }
 
-  int find(const IIDVCSeqTrace *_t, const IID<CPid> &iid){
-    const std::vector<IID<CPid> > &t = _t->get_computation();
-    for(int i = 0; i < int(t.size()); ++i){
-      if(t[i] == iid){
+  int find(const IIDVCSeqTrace *t, const IID<CPid> &iid){
+    for(int i = 0; i < int(t->size()); ++i){
+      if(t->get_iid(i) == iid){
         return i;
       }
     }
@@ -124,9 +123,10 @@ namespace DPORDriver_test {
    * strictly increasing along the computation of t. */
   bool all_clocks_increasing(const IIDVCSeqTrace *t){
     VClock<CPid> pcs;
-    for(auto it = t->get_computation().begin(); it != t->get_computation().end(); ++it){
-      if(it->get_index() <= pcs[it->get_pid()]) return false;
-      pcs[it->get_pid()] = it->get_index();
+    for(unsigned i = 0; i < t->size(); ++i){
+      const IID<CPid> &iid = t->get_iid(i);
+      if(iid.get_index() <= pcs[iid.get_pid()]) return false;
+      pcs[iid.get_pid()] = iid.get_index();
     }
     return true;
   }

--- a/src/DPORDriver_test.cpp
+++ b/src/DPORDriver_test.cpp
@@ -215,12 +215,12 @@ namespace DPORDriver_test {
   static bool trace_equiv(const Trace *a, const Trace *b){
     if (a->get_errors().size() != b->get_errors().size()) return false;
     std::list<Error*> bes;
-    for (Error *be : b->get_errors()) {
-      bes.push_back(be);
+    for (const std::unique_ptr<Error> &be : b->get_errors()) {
+      bes.push_back(be.get());
     }
-    for (Error *ae : a->get_errors()) {
-      auto bei = std::find_if(bes.begin(), bes.end(), [ae](const Error *be){
-          return error_equiv(ae, be);
+    for (const std::unique_ptr<Error> &ae : a->get_errors()) {
+      auto bei = std::find_if(bes.begin(), bes.end(), [&ae](const Error *be){
+          return error_equiv(ae.get(), be);
         });
       if (bei == bes.end()) return false;
       bei = bes.erase(bei);

--- a/src/DPORDriver_test.h
+++ b/src/DPORDriver_test.h
@@ -18,7 +18,6 @@
  */
 
 #include <config.h>
-#ifdef HAVE_BOOST_UNIT_TEST_FRAMEWORK
 
 #ifndef __DPOR_DRIVER_TEST_H__
 #define __DPOR_DRIVER_TEST_H__
@@ -33,15 +32,6 @@
  * check the set of traces produced by DPORDriver.
  */
 namespace DPORDriver_test {
-
-  /* A configuration with memory_model == TSO (resp. SC, PSO), and
-   * debug_collect_all_traces == true.
-   */
-  const Configuration &get_tso_conf();
-  const Configuration &get_sc_conf();
-  const Configuration &get_pso_conf();
-  const Configuration &get_power_conf();
-  const Configuration &get_arm_conf();
 
   /* An IIDOrder object {a,b} should be interpreted as a predicate
    * over traces, with the meaning "a precedes b in time".
@@ -63,6 +53,17 @@ namespace DPORDriver_test {
    * between traces in S and trace_specs in the trace_set_spec.
    */
   typedef std::vector<trace_spec> trace_set_spec;
+
+#ifdef HAVE_BOOST_UNIT_TEST_FRAMEWORK
+
+  /* A configuration with memory_model == TSO (resp. SC, PSO), and
+   * debug_collect_all_traces == true.
+   */
+  const Configuration &get_tso_conf();
+  const Configuration &get_sc_conf();
+  const Configuration &get_pso_conf();
+  const Configuration &get_power_conf();
+  const Configuration &get_arm_conf();
 
   /* Returns the cross product of specs. */
   trace_set_spec spec_xprod(const std::vector<trace_set_spec> &specs);
@@ -103,7 +104,7 @@ namespace DPORDriver_test {
                            const DPORDriver::Result &optimal_res,
                            const Configuration &conf);
 
+#endif /* defined(HAVE_BOOST_UNIT_TEST_FRAMEWORK) */
 }
 
-#endif
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,6 +32,7 @@ libnidhugg_a_SOURCES = \
   SymAddr.cpp SymAddr.h \
   Trace.cpp Trace.h \
   TraceBuilder.cpp TraceBuilder.h \
+  TraceDumper.cpp TraceDumper.h \
   Transform.cpp Transform.h \
   TSOInterpreter.cpp TSOInterpreter.h \
   TSOPSOTraceBuilder.h \

--- a/src/POWERARMTraceBuilder.cpp
+++ b/src/POWERARMTraceBuilder.cpp
@@ -94,11 +94,11 @@ bool PATB_impl::TraceRecorder::source_line(int proc, const llvm::MDNode *md, std
   if(md){
     int lineno;
     std::string fname, dname;
-    if(get_location(md,&lineno,&fname,&dname)){
+    if(Trace::get_location(md,&lineno,&fname,&dname)){
       success = true;
       std::stringstream ss;
-      ss << basename(fname) << ":" << lineno
-         << " " << get_src_line_verbatim(md);
+      ss << Trace::basename(fname) << ":" << lineno
+         << " " << Trace::get_src_line_verbatim(md);
       ln += ss.str();
     }
   }

--- a/src/POWERARMTraceBuilder.cpp
+++ b/src/POWERARMTraceBuilder.cpp
@@ -51,6 +51,11 @@ std::string PATB_impl::PATrace::to_string(int _ind) const{
   return ss.str();
 }
 
+IID<CPid> PATB_impl::PATrace::get_iid(int index) const{
+  IID<int> iiid = events[index].iid;
+  return {cpids[iiid.get_pid()], iiid.get_index()};
+}
+
 std::string PATB_impl::TraceRecorder::to_string(int ind) const{
   std::stringstream ss;
   for(const Line &L : lines){

--- a/src/POWERARMTraceBuilder.cpp
+++ b/src/POWERARMTraceBuilder.cpp
@@ -117,13 +117,15 @@ void PATB_impl::TraceRecorder::trace_register_metadata(int proc, const llvm::MDN
   std::string ln;
   int cpid_indent;
   source_line(proc,md,&ln,&cpid_indent);
+  std::string indent = "";
+  for(int i = 0; i < cpid_indent; ++i) indent += " ";
   lines.push_back({proc,ln});
   if(!last_committed.consumed){
     last_committed.consumed = true;
     int load_count = 0;
+    event_descs[last_committed.iid] += ln;
     for(const Access &A : last_committed.accesses){ // One line per access
       ln = "";
-      for(int i = 0; i < cpid_indent; ++i) ln += " "; // Indentation
       if(A.type == Access::LOAD){
         ln += "load 0x";
         std::stringstream ss;
@@ -169,7 +171,8 @@ void PATB_impl::TraceRecorder::trace_register_metadata(int proc, const llvm::MDN
            << "]";
         ln += ss.str();
       }
-      lines.push_back({proc,ln});
+      event_descs[last_committed.iid] += "\n" + ln;
+      lines.push_back({proc,indent+ln});
     }
   }
 }

--- a/src/POWERARMTraceBuilder.h
+++ b/src/POWERARMTraceBuilder.h
@@ -95,6 +95,8 @@ public:
   /********************************
    * Methods for Recording Traces *
    ********************************/
+  /* Enables trace recording until the next reset. */
+  virtual void enable_tracing() = 0;
   /* When recording a trace, trace_register_metadata(proc,md) should
    * be called by the ExecutionEngine when an instruction has been
    * committed. proc should be the committing thread and md should be

--- a/src/POWERARMTraceBuilder.tcc
+++ b/src/POWERARMTraceBuilder.tcc
@@ -57,7 +57,8 @@ namespace PATB_impl{
       // Ignore the rest of the parameter (relations etc.)
     }
     return new PATrace(evts, cpids, conf, std::move(errs), replay_point,
-                       TRec.to_string(2), !sleepset_is_empty());
+                       TRec.to_string(2), TRec.get_event_descs(),
+                       !sleepset_is_empty());
   }
 
   template<MemoryModel MemMod,CB_T CB,class Event>
@@ -2132,6 +2133,11 @@ namespace PATB_impl{
       ++b;
     }
     tgt = VecSet<Branch>(std::move(AB));
+  }
+
+  template<MemoryModel MemMod,CB_T CB,class Event>
+  void TB<MemMod,CB,Event>::enable_tracing(){
+    TRec.activate();
   }
 
   template<MemoryModel MemMod,CB_T CB,class Event>

--- a/src/POWERARMTraceBuilder.tcc
+++ b/src/POWERARMTraceBuilder.tcc
@@ -2200,7 +2200,6 @@ namespace PATB_impl{
     cpids.clear();
     cpids.emplace_back();
     CPS = CPidSystem();
-    for(Error *e : errors) delete e;
     errors.clear();
     TRec.clear();
     TRec.activate();
@@ -2330,7 +2329,6 @@ namespace PATB_impl{
     cpids.clear();
     cpids.emplace_back();
     CPS = CPidSystem();
-    for(Error *e : errors) delete e;
     errors.clear();
     TRec.clear();
     TRec.deactivate();

--- a/src/POWERARMTraceBuilder.tcc
+++ b/src/POWERARMTraceBuilder.tcc
@@ -56,8 +56,8 @@ namespace PATB_impl{
       evts[i].param.choices = get_evt(prefix[i]).cur_param.choices;
       // Ignore the rest of the parameter (relations etc.)
     }
-    return new PATrace(evts, cpids, conf, std::move(errs), TRec.to_string(2),
-                       !sleepset_is_empty());
+    return new PATrace(evts, cpids, conf, std::move(errs), replay_point,
+                       TRec.to_string(2), !sleepset_is_empty());
   }
 
   template<MemoryModel MemMod,CB_T CB,class Event>
@@ -2222,6 +2222,7 @@ namespace PATB_impl{
       }
     }
     if(i < 0) return false; // Nothing more to explore.
+    replay_point = i;
 
     int new_pfx_len;
     Event &evt = get_evt(prefix[i]);

--- a/src/POWERARMTraceBuilder.tcc
+++ b/src/POWERARMTraceBuilder.tcc
@@ -44,10 +44,10 @@ namespace PATB_impl{
 
   template<MemoryModel MemMod,CB_T CB,class Event>
   Trace *TB<MemMod,CB,Event>::get_trace() const{
-    std::vector<Error*> errs;
+    std::vector<std::unique_ptr<Error>> errs;
     for(unsigned i = 0; i < errors.size(); ++i){
       if(error_is_real(*errors[i])){
-        errs.push_back(errors[i]->clone());
+        errs.emplace_back(errors[i]->clone());
       }
     }
     std::vector<PATrace::Evt> evts(prefix.size());
@@ -56,7 +56,7 @@ namespace PATB_impl{
       evts[i].param.choices = get_evt(prefix[i]).cur_param.choices;
       // Ignore the rest of the parameter (relations etc.)
     }
-    return new PATrace(evts, cpids, conf, errs, TRec.to_string(2),
+    return new PATrace(evts, cpids, conf, std::move(errs), TRec.to_string(2),
                        !sleepset_is_empty());
   }
 

--- a/src/POWERARMTraceBuilder_decl.h
+++ b/src/POWERARMTraceBuilder_decl.h
@@ -1051,11 +1051,14 @@ namespace PATB_impl{
             const std::vector<CPid> &cpids,
             const Configuration &conf,
             std::vector<std::unique_ptr<Error>> errors,
+            int replay_point,
             const std::string &str_rep = "",
             bool blocked = false)
-      : Trace(std::move(errors),blocked), events(events), cpids(cpids), string_rep(str_rep), conf(conf) {};
+      : Trace(std::move(errors),replay_point,blocked), events(events),
+        cpids(cpids), string_rep(str_rep), conf(conf) {};
     virtual ~PATrace(){};
     virtual std::string to_string(int ind = 0) const;
+    virtual std::string event_desc(int event_index) const { return ""; }
     virtual IID<CPid> get_iid(int index) const override;
     virtual std::size_t size() const override { return events.size(); }
   protected:

--- a/src/POWERARMTraceBuilder_decl.h
+++ b/src/POWERARMTraceBuilder_decl.h
@@ -1056,6 +1056,8 @@ namespace PATB_impl{
       : Trace(std::move(errors),blocked), events(events), cpids(cpids), string_rep(str_rep), conf(conf) {};
     virtual ~PATrace(){};
     virtual std::string to_string(int ind = 0) const;
+    virtual IID<CPid> get_iid(int index) const override;
+    virtual std::size_t size() const override { return events.size(); }
   protected:
     std::vector<Evt> events;
     std::vector<CPid> cpids;

--- a/src/POWERARMTraceBuilder_decl.h
+++ b/src/POWERARMTraceBuilder_decl.h
@@ -567,9 +567,9 @@ namespace PATB_impl{
   /* A TraceRecorder helps the TraceBuilder to record a human-readable
    * string representation of a trace.
    */
-  class TraceRecorder : public Trace{
+  class TraceRecorder{
   public:
-    TraceRecorder(const std::vector<CPid> *cpids) : Trace({}), cpids(cpids), active(false) {};
+    TraceRecorder(const std::vector<CPid> *cpids) : cpids(cpids), active(false) {};
     /* Get the recorded trace representation. */
     std::string to_string(int ind = 0) const;
     /* Called when an event is committed by the TraceBuilder. */

--- a/src/POWERARMTraceBuilder_decl.h
+++ b/src/POWERARMTraceBuilder_decl.h
@@ -1050,10 +1050,10 @@ namespace PATB_impl{
     PATrace(const std::vector<Evt> &events,
             const std::vector<CPid> &cpids,
             const Configuration &conf,
-            const std::vector<Error*> &errors,
+            std::vector<std::unique_ptr<Error>> errors,
             const std::string &str_rep = "",
             bool blocked = false)
-      : Trace(errors,blocked), events(events), cpids(cpids), string_rep(str_rep), conf(conf) {};
+      : Trace(std::move(errors),blocked), events(events), cpids(cpids), string_rep(str_rep), conf(conf) {};
     virtual ~PATrace(){};
     virtual std::string to_string(int ind = 0) const;
   protected:

--- a/src/POWERInterpreter.cpp
+++ b/src/POWERInterpreter.cpp
@@ -169,6 +169,10 @@ POWERInterpreter::runFunction(llvm::Function *F,
   for (unsigned i = 0; i < ArgCount; ++i)
     ActualArgs.push_back(ArgValues[i]);
 
+  if(conf.ee_store_trace){
+    TB.enable_tracing();
+  }
+
   // Set up the function call.
   callFunction(F, ActualArgs);
 

--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -246,15 +246,21 @@ bool PSOTraceBuilder::check_for_cycles(){
 Trace *PSOTraceBuilder::get_trace() const{
   std::vector<IID<CPid> > cmp;
   std::vector<const llvm::MDNode*> cmp_md;
+  std::vector<VClock<CPid> > cmp_vc;
   std::vector<std::unique_ptr<Error>> errs;
+  std::vector<CPid> cpids;
+  for (const Thread &t : threads){
+    cpids.push_back(t.cpid);
+  }
   for(unsigned i = 0; i < prefix.size(); ++i){
-    cmp.push_back(IID<CPid>(threads[prefix[i].iid.get_pid()].cpid,prefix[i].iid.get_index()));
+    cmp.push_back(IID<CPid>(cpids[prefix[i].iid.get_pid()],prefix[i].iid.get_index()));
+    cmp_vc.emplace_back(prefix[i].clock, cpids);
     cmp_md.push_back(prefix[i].md);
   }
   for(unsigned i = 0; i < errors.size(); ++i){
     errs.emplace_back(errors[i]->clone());
   }
-  Trace *t = new IIDSeqTrace(cmp,cmp_md,std::move(errs));
+  Trace *t = new IIDVCSeqTrace(cmp,cmp_md,cmp_vc,std::move(errs));
   t->set_blocked(!sleepset_is_empty());
   return t;
 }

--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -237,7 +237,7 @@ bool PSOTraceBuilder::check_for_cycles(){
   {
     assert(prefix.size());
     IID<CPid> c_iid(threads[i_iid.get_pid()].cpid,i_iid.get_index());
-    errors.push_back(new RobustnessError(c_iid));
+    errors.emplace_back(new RobustnessError(c_iid));
   }
 
   return true;

--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -246,15 +246,15 @@ bool PSOTraceBuilder::check_for_cycles(){
 Trace *PSOTraceBuilder::get_trace() const{
   std::vector<IID<CPid> > cmp;
   std::vector<const llvm::MDNode*> cmp_md;
-  std::vector<Error*> errs;
+  std::vector<std::unique_ptr<Error>> errs;
   for(unsigned i = 0; i < prefix.size(); ++i){
     cmp.push_back(IID<CPid>(threads[prefix[i].iid.get_pid()].cpid,prefix[i].iid.get_index()));
     cmp_md.push_back(prefix[i].md);
   }
   for(unsigned i = 0; i < errors.size(); ++i){
-    errs.push_back(errors[i]->clone());
+    errs.emplace_back(errors[i]->clone());
   }
-  Trace *t = new IIDSeqTrace(cmp,cmp_md,errs);
+  Trace *t = new IIDSeqTrace(cmp,cmp_md,std::move(errs));
   t->set_blocked(!sleepset_is_empty());
   return t;
 }

--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -260,7 +260,7 @@ Trace *PSOTraceBuilder::get_trace() const{
   for(unsigned i = 0; i < errors.size(); ++i){
     errs.emplace_back(errors[i]->clone());
   }
-  Trace *t = new IIDVCSeqTrace(cmp,cmp_md,cmp_vc,std::move(errs));
+  Trace *t = new IIDVCSeqTrace(cmp,cmp_md,cmp_vc,std::move(errs),replay_point);
   t->set_blocked(!sleepset_is_empty());
   return t;
 }
@@ -283,6 +283,7 @@ bool PSOTraceBuilder::reset(){
     /* No more branching is possible. */
     return false;
   }
+  replay_point = i;
 
   /* Setup the new Event at prefix[i] */
   {

--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -321,6 +321,7 @@ bool PSOTraceBuilder::reset(){
   mutexes.clear();
   cond_vars.clear();
   mem.clear();
+  errors.clear();
   last_full_memory_conflict = -1;
   prefix_idx = -1;
   dryrun = false;

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -266,7 +266,7 @@ bool TSOTraceBuilder::check_for_cycles(){
   {
     assert(prefix.len());
     IID<CPid> c_iid(threads[i_iid.get_pid()].cpid,i_iid.get_index());
-    errors.push_back(new RobustnessError(c_iid));
+    errors.emplace_back(new RobustnessError(c_iid));
   }
 
   return true;

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -360,6 +360,7 @@ bool TSOTraceBuilder::reset(){
   mutexes.clear();
   cond_vars.clear();
   mem.clear();
+  errors.clear();
   last_full_memory_conflict = -1;
   prefix_idx = -1;
   dryrun = false;

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -289,7 +289,7 @@ Trace *TSOTraceBuilder::get_trace() const{
   for(unsigned i = 0; i < errors.size(); ++i){
     errs.emplace_back(errors[i]->clone());
   }
-  Trace *t = new IIDVCSeqTrace(cmp,cmp_md,cmp_vc,std::move(errs));
+  Trace *t = new IIDVCSeqTrace(cmp,cmp_md,cmp_vc,std::move(errs),replay_point);
   t->set_blocked(!sleepset_is_empty());
   return t;
 }

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -275,15 +275,21 @@ bool TSOTraceBuilder::check_for_cycles(){
 Trace *TSOTraceBuilder::get_trace() const{
   std::vector<IID<CPid> > cmp;
   std::vector<const llvm::MDNode*> cmp_md;
+  std::vector<VClock<CPid> > cmp_vc;
   std::vector<std::unique_ptr<Error>> errs;
+  std::vector<CPid> cpids;
+  for (const Thread &t : threads){
+    cpids.push_back(t.cpid);
+  }
   for(unsigned i = 0; i < prefix.len(); ++i){
-    cmp.push_back(IID<CPid>(threads[prefix[i].iid.get_pid()].cpid,prefix[i].iid.get_index()));
+    cmp.push_back(IID<CPid>(cpids[prefix[i].iid.get_pid()],prefix[i].iid.get_index()));
+    cmp_vc.emplace_back(prefix[i].clock, cpids);
     cmp_md.push_back(prefix[i].md);
   };
   for(unsigned i = 0; i < errors.size(); ++i){
     errs.emplace_back(errors[i]->clone());
   }
-  Trace *t = new IIDSeqTrace(cmp,cmp_md,std::move(errs));
+  Trace *t = new IIDVCSeqTrace(cmp,cmp_md,cmp_vc,std::move(errs));
   t->set_blocked(!sleepset_is_empty());
   return t;
 }

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -275,15 +275,15 @@ bool TSOTraceBuilder::check_for_cycles(){
 Trace *TSOTraceBuilder::get_trace() const{
   std::vector<IID<CPid> > cmp;
   std::vector<const llvm::MDNode*> cmp_md;
-  std::vector<Error*> errs;
+  std::vector<std::unique_ptr<Error>> errs;
   for(unsigned i = 0; i < prefix.len(); ++i){
     cmp.push_back(IID<CPid>(threads[prefix[i].iid.get_pid()].cpid,prefix[i].iid.get_index()));
     cmp_md.push_back(prefix[i].md);
   };
   for(unsigned i = 0; i < errors.size(); ++i){
-    errs.push_back(errors[i]->clone());
+    errs.emplace_back(errors[i]->clone());
   }
-  Trace *t = new IIDSeqTrace(cmp,cmp_md,errs);
+  Trace *t = new IIDSeqTrace(cmp,cmp_md,std::move(errs));
   t->set_blocked(!sleepset_is_empty());
   return t;
 }

--- a/src/TSO_test.cpp
+++ b/src/TSO_test.cpp
@@ -39,7 +39,7 @@ define i32 @main(){
   DPORDriver::Result res = driver->run();
 
   BOOST_CHECK(res.all_traces.size() == 1);
-  BOOST_CHECK(static_cast<const IIDSeqTrace*>(res.all_traces[0])->get_computation() == std::vector<IID<CPid> >({{CPid(),1}}));
+  BOOST_CHECK(static_cast<const IIDVCSeqTrace*>(res.all_traces[0])->get_computation() == std::vector<IID<CPid> >({{CPid(),1}}));
 
   delete driver;
 
@@ -48,7 +48,7 @@ define i32 @main(){
   DPORDriver::Result opt_res = driver->run();
 
   BOOST_CHECK(opt_res.all_traces.size() == 1);
-  BOOST_CHECK(static_cast<const IIDSeqTrace*>(opt_res.all_traces[0])->get_computation() == std::vector<IID<CPid> >({{CPid(),1}}));
+  BOOST_CHECK(static_cast<const IIDVCSeqTrace*>(opt_res.all_traces[0])->get_computation() == std::vector<IID<CPid> >({{CPid(),1}}));
 
   delete driver;
   BOOST_CHECK(DPORDriver_test::check_optimal_equiv(res, opt_res, conf));

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -54,14 +54,16 @@ Trace::Trace(std::vector<std::unique_ptr<Error>> errors, bool blk)
 Trace::~Trace(){
 }
 
-IIDSeqTrace::IIDSeqTrace(const std::vector<IID<CPid> > &cmp,
-                         const std::vector<const llvm::MDNode*> &cmpmd,
-                         std::vector<std::unique_ptr<Error>> errors,
-                         bool blk)
-  : Trace(std::move(errors),blk), computation(cmp), computation_md(cmpmd) {
+IIDVCSeqTrace::IIDVCSeqTrace(const std::vector<IID<CPid> > &cmp,
+                             const std::vector<const llvm::MDNode*> &cmpmd,
+                             const std::vector<VClock<CPid> > &cmpvc,
+                             std::vector<std::unique_ptr<Error>> errors,
+                             bool blk)
+  : Trace(std::move(errors),blk), computation(cmp), computation_md(cmpmd),
+    computation_clocks(cmpvc) {
 }
 
-IIDSeqTrace::~IIDSeqTrace(){
+IIDVCSeqTrace::~IIDVCSeqTrace(){
 }
 
 std::string Trace::to_string(int _ind) const{
@@ -76,7 +78,7 @@ std::string Trace::to_string(int _ind) const{
   }
 }
 
-std::string IIDSeqTrace::to_string(int _ind) const{
+std::string IIDVCSeqTrace::to_string(int _ind) const{
   std::string s;
   std::string ind;
   assert(_ind >= 0);

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -78,6 +78,27 @@ std::string Trace::to_string(int _ind) const{
   }
 }
 
+std::string IIDVCSeqTrace::event_desc(int i) const{
+  std::string s = "";
+  if(computation[i].get_pid().is_auxiliary()){
+    s+=" UPDATE";
+  }
+  {
+    int ln;
+    std::string fname, dname;
+    if(get_location(computation_md[i],&ln,&fname,&dname)){
+      std::stringstream ss;
+      ss << " " << basename(fname) << ":" << ln;
+      std::string src_line = get_src_line_verbatim(computation_md[i]);
+      if (src_line != ""){
+        ss << ": " << src_line;
+      }
+      s += ss.str();
+    }
+  }
+  return s;
+}
+
 std::string IIDVCSeqTrace::to_string(int _ind) const{
   std::string s;
   std::string ind;
@@ -122,20 +143,8 @@ std::string IIDVCSeqTrace::to_string(int _ind) const{
   for(unsigned i = 0; i < computation.size(); ++i){
     std::string iid_str = ind + cpind[computation[i].get_pid()] + computation[i].to_string();
     s += iid_str;
-    if(computation[i].get_pid().is_auxiliary()){
-      s+=" UPDATE";
-    }
-    {
-      int ln;
-      std::string fname, dname;
-      if(get_location(computation_md[i],&ln,&fname,&dname)){
-        std::stringstream ss;
-        ss << " " << basename(fname) << ":" << ln;
-        ss << ": " << get_src_line_verbatim(computation_md[i]);
-        s += ss.str();
-      }
-      s += "\n";
-    }
+    s += event_desc(i);
+    s += "\n";
     if(error_locs.count(i)){
       // Indentation
       {

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -47,8 +47,8 @@
 #include <llvm/BinaryFormat/Dwarf.h>
 #endif
 
-Trace::Trace(std::vector<std::unique_ptr<Error>> errors, bool blk)
-  : errors(std::move(errors)), blocked(blk) {
+Trace::Trace(std::vector<std::unique_ptr<Error>> errors, int replay_point, bool blk)
+: errors(std::move(errors)), blocked(blk), first_new_event(replay_point) {
 }
 
 Trace::~Trace(){
@@ -58,8 +58,9 @@ IIDVCSeqTrace::IIDVCSeqTrace(const std::vector<IID<CPid> > &cmp,
                              const std::vector<const llvm::MDNode*> &cmpmd,
                              const std::vector<VClock<CPid> > &cmpvc,
                              std::vector<std::unique_ptr<Error>> errors,
+                             int replay_point,
                              bool blk)
-  : Trace(std::move(errors),blk), computation(cmp), computation_md(cmpmd),
+  : Trace(std::move(errors),replay_point,blk), computation(cmp), computation_md(cmpmd),
     computation_clocks(cmpvc) {
 }
 

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -47,21 +47,18 @@
 #include <llvm/BinaryFormat/Dwarf.h>
 #endif
 
-Trace::Trace(const std::vector<Error*> &errors, bool blk)
-  : errors(errors), blocked(blk) {
+Trace::Trace(std::vector<std::unique_ptr<Error>> errors, bool blk)
+  : errors(std::move(errors)), blocked(blk) {
 }
 
 Trace::~Trace(){
-  for(unsigned i = 0; i < errors.size(); ++i){
-    delete errors[i];
-  }
 }
 
 IIDSeqTrace::IIDSeqTrace(const std::vector<IID<CPid> > &cmp,
                          const std::vector<const llvm::MDNode*> &cmpmd,
-                         const std::vector<Error*> &errors,
+                         std::vector<std::unique_ptr<Error>> errors,
                          bool blk)
-  : Trace(errors,blk), computation(cmp), computation_md(cmpmd) {
+  : Trace(std::move(errors),blk), computation(cmp), computation_md(cmpmd) {
 }
 
 IIDSeqTrace::~IIDSeqTrace(){
@@ -70,7 +67,7 @@ IIDSeqTrace::~IIDSeqTrace(){
 std::string Trace::to_string(int _ind) const{
   if(errors.size()){
     std::string s = "Errors found:\n";
-    for(Error *e : errors){
+    for(const std::unique_ptr<Error> &e : errors){
       s += e->to_string()+"\n";
     }
     return s;
@@ -116,7 +113,7 @@ std::string IIDSeqTrace::to_string(int _ind) const{
         }
       }
       assert(0 <= loc);
-      error_locs[loc] = errors[i];
+      error_locs[loc] = errors[i].get();
     }
   }
 

--- a/src/Trace.h
+++ b/src/Trace.h
@@ -139,16 +139,14 @@ private:
  */
 class Trace{
 public:
-  /* A Trace containing some errors.
-   *
-   * This object takes ownership of errors.
-   */
-  Trace(const std::vector<Error*> &errors, bool blocked = false);
+  /* A Trace containing some errors. */
+  Trace(std::vector<std::unique_ptr<Error>> errors, bool blocked = false);
   virtual ~Trace();
   Trace(const Trace&) = delete;
   Trace &operator=(const Trace&) = delete;
-  /* The trace keeps ownership of the errors. */
-  const std::vector<Error*> &get_errors() const { return errors; };
+  const std::vector<std::unique_ptr<Error>> &get_errors() const {
+    return errors;
+  };
   bool has_errors() const { return errors.size(); };
   /* A multi-line, human-readable string representation of this
    * Trace. Indentation will be in multiples of ind spaces.
@@ -158,7 +156,7 @@ public:
   virtual bool is_blocked() const { return blocked; };
   virtual void set_blocked(bool b = true) { blocked = b; };
 protected:
-  std::vector<Error*> errors;
+  std::vector<std::unique_ptr<Error>> errors;
   bool blocked;
 
   /* Attempt to find the directory, file name and line number
@@ -195,13 +193,10 @@ public:
    * case that either computation_md[i] points to the LLVM Metadata
    * (kind "dbg") for the event computation[i], or computation_md[i]
    * is null.
-   *
-   * errors contains all errors that were discovered in this
-   * trace. This object takes ownership of errors.
    */
   IIDSeqTrace(const std::vector<IID<CPid> > &computation,
               const std::vector<const llvm::MDNode*> &computation_md,
-              const std::vector<Error*> &errors,
+              std::vector<std::unique_ptr<Error>> errors,
               bool blocked = false);
   virtual ~IIDSeqTrace();
   IIDSeqTrace(const IIDSeqTrace&) = delete;

--- a/src/Trace.h
+++ b/src/Trace.h
@@ -219,6 +219,8 @@ public:
     return computation_clocks;
   };
   virtual std::string to_string(int ind = 0) const;
+  /* Human-readable representation description of event, excluding IID. */
+  std::string event_desc(int event_index) const;
 protected:
   std::vector<IID<CPid> > computation;
   std::vector<const llvm::MDNode*> computation_md;

--- a/src/Trace.h
+++ b/src/Trace.h
@@ -153,6 +153,10 @@ public:
    * Trace. Indentation will be in multiples of ind spaces.
    */
   virtual std::string to_string(int ind = 0) const;
+  /* IID of the event with index event_index. */
+  virtual IID<CPid> get_iid(int event_index) const = 0;
+  /* Numer of events in trace. */
+  virtual std::size_t size() const = 0;
   /* Was the exploration of this execution (sleep set) blocked? */
   virtual bool is_blocked() const { return blocked; };
   virtual void set_blocked(bool b = true) { blocked = b; };
@@ -210,17 +214,17 @@ public:
   IIDVCSeqTrace &operator=(const IIDVCSeqTrace&) = delete;
   /* The sequence of events. */
   virtual const std::vector<IID<CPid> > &get_computation() const { return computation; };
-  /* The sequence of metadata (see above). */
-  virtual const std::vector<const llvm::MDNode*> &get_computation_metadata() const{
-    return computation_md;
-  };
-  /* The sequence of vector clocks. */
-  virtual const std::vector<VClock<CPid> > &get_computation_clocks() const{
-    return computation_clocks;
+  /* The vector clock of the event with index event_index. */
+  const VClock<CPid> &get_clock(int event_index) const{
+    return computation_clocks[event_index];
   };
   virtual std::string to_string(int ind = 0) const;
   /* Human-readable representation description of event, excluding IID. */
   std::string event_desc(int event_index) const;
+  virtual IID<CPid> get_iid(int index) const override {
+    return computation[index];
+  }
+  virtual std::size_t size() const override { return computation.size(); }
 protected:
   std::vector<IID<CPid> > computation;
   std::vector<const llvm::MDNode*> computation_md;

--- a/src/Trace.h
+++ b/src/Trace.h
@@ -29,6 +29,7 @@
 
 #include "CPid.h"
 #include "IID.h"
+#include "VClock.h"
 
 #include <string>
 #include <vector>
@@ -183,9 +184,9 @@ protected:
 };
 
 /* This class represents traces that are expressed as sequences of
- * IIDs.
+ * IIDs and VClocks.
  */
-class IIDSeqTrace : public Trace {
+class IIDVCSeqTrace : public Trace {
 public:
   /* A Trace corresponding to the event sequence computation.
    *
@@ -193,24 +194,35 @@ public:
    * case that either computation_md[i] points to the LLVM Metadata
    * (kind "dbg") for the event computation[i], or computation_md[i]
    * is null.
+   *
+   * computation_clocks contains vector clocks corresponding to the
+   * events in computation, and represents the partial ordering of
+   * events that identify the equivalence class of traces that
+   * computation belongs to.
    */
-  IIDSeqTrace(const std::vector<IID<CPid> > &computation,
-              const std::vector<const llvm::MDNode*> &computation_md,
-              std::vector<std::unique_ptr<Error>> errors,
-              bool blocked = false);
-  virtual ~IIDSeqTrace();
-  IIDSeqTrace(const IIDSeqTrace&) = delete;
-  IIDSeqTrace &operator=(const IIDSeqTrace&) = delete;
+  IIDVCSeqTrace(const std::vector<IID<CPid> > &computation,
+                const std::vector<const llvm::MDNode*> &computation_md,
+                const std::vector<VClock<CPid> > &computation_clocks,
+                std::vector<std::unique_ptr<Error>> errors,
+                bool blocked = false);
+  virtual ~IIDVCSeqTrace();
+  IIDVCSeqTrace(const IIDVCSeqTrace&) = delete;
+  IIDVCSeqTrace &operator=(const IIDVCSeqTrace&) = delete;
   /* The sequence of events. */
   virtual const std::vector<IID<CPid> > &get_computation() const { return computation; };
   /* The sequence of metadata (see above). */
   virtual const std::vector<const llvm::MDNode*> &get_computation_metadata() const{
     return computation_md;
   };
+  /* The sequence of vector clocks. */
+  virtual const std::vector<VClock<CPid> > &get_computation_clocks() const{
+    return computation_clocks;
+  };
   virtual std::string to_string(int ind = 0) const;
 protected:
   std::vector<IID<CPid> > computation;
   std::vector<const llvm::MDNode*> computation_md;
+  std::vector<VClock<CPid> > computation_clocks;
 };
 
 

--- a/src/Trace.h
+++ b/src/Trace.h
@@ -156,9 +156,6 @@ public:
   /* Was the exploration of this execution (sleep set) blocked? */
   virtual bool is_blocked() const { return blocked; };
   virtual void set_blocked(bool b = true) { blocked = b; };
-protected:
-  std::vector<std::unique_ptr<Error>> errors;
-  bool blocked;
 
   /* Attempt to find the directory, file name and line number
    * corresponding to the metadata m.
@@ -180,7 +177,10 @@ protected:
    */
   static std::string get_src_line_verbatim(const llvm::MDNode *m);
   static std::string basename(const std::string &fname);
+protected:
   static bool is_absolute_path(const std::string &fname);
+  std::vector<std::unique_ptr<Error>> errors;
+  bool blocked;
 };
 
 /* This class represents traces that are expressed as sequences of

--- a/src/TraceBuilder.cpp
+++ b/src/TraceBuilder.cpp
@@ -19,7 +19,7 @@
 
 #include "TraceBuilder.h"
 
-TraceBuilder::TraceBuilder(const Configuration &C) : conf(C) {
+TraceBuilder::TraceBuilder(const Configuration &C) : conf(C), replay_point(0) {
 }
 
 TraceBuilder::~TraceBuilder() = default;

--- a/src/TraceBuilder.cpp
+++ b/src/TraceBuilder.cpp
@@ -22,53 +22,49 @@
 TraceBuilder::TraceBuilder(const Configuration &C) : conf(C) {
 }
 
-TraceBuilder::~TraceBuilder(){
-  for(unsigned i = 0; i < errors.size(); ++i){
-    delete errors[i];
-  }
-}
+TraceBuilder::~TraceBuilder() = default;
 
 void TraceBuilder::assertion_error(std::string cond, const IID<CPid> &loc){
   if(loc.is_null()){
-    errors.push_back(new AssertionError(get_iid(),cond));
+    errors.emplace_back(new AssertionError(get_iid(),cond));
   }else{
-    errors.push_back(new AssertionError(loc,cond));
+    errors.emplace_back(new AssertionError(loc,cond));
   }
   if(conf.debug_print_on_error) debug_print();
 }
 
 void TraceBuilder::pthreads_error(std::string msg, const IID<CPid> &loc){
   if(loc.is_null()){
-    errors.push_back(new PthreadsError(get_iid(),msg));
+    errors.emplace_back(new PthreadsError(get_iid(),msg));
   }else{
-    errors.push_back(new PthreadsError(loc,msg));
+    errors.emplace_back(new PthreadsError(loc,msg));
   }
   if(conf.debug_print_on_error) debug_print();
 }
 
 void TraceBuilder::segmentation_fault_error(const IID<CPid> &loc){
   if(loc.is_null()){
-    errors.push_back(new SegmentationFaultError(get_iid()));
+    errors.emplace_back(new SegmentationFaultError(get_iid()));
   }else{
-    errors.push_back(new SegmentationFaultError(loc));
+    errors.emplace_back(new SegmentationFaultError(loc));
   }
   if(conf.debug_print_on_error) debug_print();
 }
 
 void TraceBuilder::memory_error(std::string msg, const IID<CPid> &loc){
   if(loc.is_null()){
-    errors.push_back(new MemoryError(get_iid(),msg));
+    errors.emplace_back(new MemoryError(get_iid(),msg));
   }else{
-    errors.push_back(new MemoryError(loc,msg));
+    errors.emplace_back(new MemoryError(loc,msg));
   }
   if(conf.debug_print_on_error) debug_print();
 }
 
 void TraceBuilder::nondeterminism_error(std::string cond, const IID<CPid> &loc){
   if(loc.is_null()){
-    errors.push_back(new NondeterminismError(get_iid(),cond));
+    errors.emplace_back(new NondeterminismError(get_iid(),cond));
   }else{
-    errors.push_back(new NondeterminismError(loc,cond));
+    errors.emplace_back(new NondeterminismError(loc,cond));
   }
   if(conf.debug_print_on_error) debug_print();
 }

--- a/src/TraceBuilder.h
+++ b/src/TraceBuilder.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 /* A TraceBuilder object is maintained throughout DPOR trace
  * exploration. The TraceBuilder provides scheduling for each trace
@@ -111,7 +112,7 @@ public:
   virtual int estimate_trace_count() const { return 1; };
 protected:
   const Configuration &conf;
-  std::vector<Error*> errors;
+  std::vector<std::unique_ptr<Error>> errors;
 };
 
 #endif

--- a/src/TraceBuilder.h
+++ b/src/TraceBuilder.h
@@ -113,6 +113,8 @@ public:
 protected:
   const Configuration &conf;
   std::vector<std::unique_ptr<Error>> errors;
+  /* The number of events that were replayed in the current computation. */
+  int replay_point;
 };
 
 #endif

--- a/src/TraceDumper.cpp
+++ b/src/TraceDumper.cpp
@@ -111,11 +111,13 @@ namespace TraceDumper {
     std::fstream out;
     if (!open_file(out, conf.trace_dump_file)) return;
     out << "strict digraph {\n";
+    out << "  packmode=array_tuc1\n"; // Speed up layout
     out << "  node [shape=box,fontname=Monospace]\n";
     for (unsigned ti = 0; ti < res.all_traces.size(); ++ti) {
       const IIDVCSeqTrace &t = static_cast<IIDVCSeqTrace&>(*res.all_traces[ti]);
       std::map<IID<CPid>,std::vector<Error*>> errors = sort_errors(t);
       out << "  subgraph trace_" << ti << " {\n";
+      out << "    sortv = " << ti << "\n";
       out << "    start_" << ti << " [label=\"Trace " << (ti+1) << "\"]\n";
       out << "    start_" << ti << " -> " << node_name(ti, t.get_iid(0)) << "\n";
       for (unsigned ei = 0; ei < t.size(); ++ei) {

--- a/src/TraceDumper.cpp
+++ b/src/TraceDumper.cpp
@@ -316,15 +316,14 @@ namespace TraceDumper {
    */
   static void delete_implied(trace_set_spec &set, const DPORDriver::Result &res) {
     for (trace_spec &spec : set) {
-      for (auto it = spec.begin(); it != spec.end();) {
+      for (auto it = spec.end(); it != spec.begin();) {
+        --it;
         auto traces = get_traces(res);
         for (auto it2 = spec.begin(); it2 != spec.end(); ++it2) {
           if (it2 != it) filter_traces(traces, *it2);
         }
         if (traces.size() == 1) {
           it = spec.erase(it);
-        } else {
-          ++it;
         }
       }
     }

--- a/src/TraceDumper.h
+++ b/src/TraceDumper.h
@@ -1,0 +1,32 @@
+/* Copyright (C) 2017 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#include "Configuration.h"
+#include "DPORDriver.h"
+
+#ifndef __TRACE_DUMPER_H__
+#define __TRACE_DUMPER_H__
+
+namespace TraceDumper {
+  void dump(const DPORDriver::Result &res, const Configuration &conf);
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "DPORDriver.h"
 #include "GlobalContext.h"
 #include "Transform.h"
+#include "TraceDumper.h"
 
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/ManagedStatic.h>
@@ -120,6 +121,8 @@ int main(int argc, char *argv[]){
       }else{
         std::cout << "No errors were detected." << std::endl;
       }
+
+      TraceDumper::dump(res,conf);
 
       delete driver;
     }


### PR DESCRIPTION
This PR adds three flags.

* `--dump-traces` writes a graphviz graph of the happens-before order of all explored traces to a file.
![traces dot](https://user-images.githubusercontent.com/1678250/32611520-37f536f0-c566-11e7-996e-afadf853f784.png)
* `--dump-tree` writes a graphviz graph of the exploration tree to a file.
![tree dot](https://user-images.githubusercontent.com/1678250/32611538-411ceebc-c566-11e7-8499-05a99cad25fd.png)
* `--dump-spec` writes a minimal `DPORDriver_test::trace_set_spec` of all explored equivalence classes to a file.
    ```c++
    CPid P;
    CPid P0 = P.spawn(0);
    DPORDriver_test::trace_set_spec expected = {
      {{{P,5},{P0,1}}},
      {{{P0,1},{P,5}}},
    };
    ```

Missing features:
* A flag like Concuerror's `--show-races`, that draws red edges in the exploration tree of all races that had a reversal scheduled.
* Yellow event boxes indicating that a thread has been terminated due to violating an assumption.