### PR TITLE
Run travis tests on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: C++
 sudo: false
-branches:
-  only:
-    - master
 env:
   - LLVM_VERSION=3.5.0  # default on Debian jessie
   - LLVM_VERSION=3.6.2


### PR DESCRIPTION
I was planning to make this change once I got the time to extend the travisfile to test all supported LLVM versions, but now having been bitten by this, I am making the change immediately.