### PR TITLE
Do not hard-code nidhugg path in nidhuggc

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,6 +94,5 @@ nidhuggc$(EXEEXT): $(srcdir)/nidhuggc.py
 	| sed 's|%%PYTHON%%|@PYTHON@|g' \
 	| sed 's|%%CLANG%%|@CLANG@|g' \
 	| sed 's|%%CLANGXX%%|@CLANGXX@|g' \
-	| sed 's|%%NIDHUGGPATH%%|$(bindir)/nidhugg|g' \
 	> nidhuggc
 	chmod a+x nidhuggc

--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -11,7 +11,7 @@ import time
 # Default Configuration #
 #########################
 
-NIDHUGG='%%NIDHUGGPATH%%'
+NIDHUGG=os.path.join(sys.path[0], 'nidhugg')
 CLANG='%%CLANG%%'
 CLANGXX='%%CLANGXX%%'
 


### PR DESCRIPTION
Instead, make `nidhuggc` look for the `nidhugg` binary in the directory that it is installed in.
`sys.path[0]` [contains](https://docs.python.org/2/library/sys.html#sys.path) the install directory of the currently running python script.

This allows `nidhuggc` to be used from the build directory, without installing `nidhugg` first.