### PR TITLE
Use pkg-config to autodetect flags for libffi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,14 @@ AX_BOOST_UNIT_TEST_FRAMEWORK
 AX_LLVM(,[AC_MSG_FAILURE(LLVM is required.)])
 CXXFLAGS="`echo " $CXXFLAGS " | sed 's/ -fno-rtti / /' | sed 's/ -fno-exceptions / /'`"
 AC_CHECK_LIB([dl], [dlopen],[],[AC_MSG_FAILURE([Could not find library libdl.])])
-AC_CHECK_LIB([ffi], [ffi_call],[],[AC_MSG_FAILURE([Could not find library libffi.])])
+PKG_CHECK_MODULES([FFI], [libffi], [
+  AC_DEFINE([HAVE_LIBFFI], [1], [Define to 1 if we have libffi])
+  CFLAGS="$CFLAGS $FFI_CFLAGS"
+  CXXFLAGS="$CXXFLAGS $FFI_CFLAGS"
+  LIBS="$LIBS $FFI_LIBS"
+],[
+  AC_CHECK_LIB([ffi], [ffi_call],[],[AC_MSG_FAILURE([Could not find library libffi.])])
+])
 BUILDNIDHUGGC='yes'
 AC_ARG_ENABLE([nidhuggc],[AS_HELP_STRING([--disable-nidhuggc],[Don't build the script nidhuggc.])],
               [if test "x$enableval" = "xno"; then
@@ -174,8 +181,8 @@ AC_CHECK_HEADERS_ALT([llvm/Support/Dwarf.h llvm/BinaryFormat/Dwarf.h],[],[AC_MSG
 AC_CHECK_HEADERS_ALT([llvm/Support/ErrorOr.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])
 AC_CHECK_HEADERS([llvm/Support/system_error.h],[],[],[AC_INCLUDES_DEFAULT])
 
-AC_CHECK_HEADERS([ffi/ffi.h],[],[
-  AC_CHECK_HEADERS([ffi.h],[],[AC_MSG_FAILURE([Could not find header ffi.h.])],[AC_INCLUDES_DEFAULT])
+AC_CHECK_HEADERS([ffi.h],[],[
+  AC_CHECK_HEADERS([ffi/ffi.h],[],[AC_MSG_FAILURE([Could not find header ffi.h.])],[AC_INCLUDES_DEFAULT])
 ],[AC_INCLUDES_DEFAULT])
 
 AC_CHECK_HEADERS([valgrind/valgrind.h])


### PR DESCRIPTION
By default libffi is installed outside the include path, and multiple
Linux distributions (Arch & Gentoo, among others) do not override this.
Instead of trying to hard-code all possible locations it could be
installed in in configure, use pkg-config to get the right include
directory directly.

The old library detection has been left as a fallback, should there be
systems without pkg-config.

This might subsume `AC_CHECK_HEADERS([ffi/ffi.h], ...` later in the
script, but since I don't know which system this was introduced to
support, I cannot test if this is the case, and so I have left it be.
The order has been permuted so that the standard `#include <ffi.h>` is
preferred, however.