### PR TITLE
Remove harmful and unused macros from configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1022,7 +1022,6 @@ AC_SUBST(NIDHUGGCBIN)
 AM_CONDITIONAL([BUILDPDFDOCUMENTATION],[test "x$BUILDPDFDOCUMENTATION" = "xyes"])
 
 # Checks for library functions.
-AC_FUNC_MALLOC
 AC_CHECK_FUNCS([atexit memset setenv])
 
 # Warn about compiling with clang++ for llvm version >= 3.9

--- a/configure.ac
+++ b/configure.ac
@@ -991,8 +991,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 
 
 # Checks for typedefs, structures, and compiler characteristics.
-#AC_CHECK_HEADER_STDBOOL macro is defined with autoconf version >= 2.67
-m4_ifdef([AC_CHECK_HEADER_STDBOOL], [AC_CHECK_HEADER_STDBOOL])
 AC_C_INLINE
 AC_TYPE_INT16_T
 AC_TYPE_INT32_T
@@ -1020,9 +1018,6 @@ fi
 
 AC_SUBST(NIDHUGGCBIN)
 AM_CONDITIONAL([BUILDPDFDOCUMENTATION],[test "x$BUILDPDFDOCUMENTATION" = "xyes"])
-
-# Checks for library functions.
-AC_CHECK_FUNCS([atexit memset setenv])
 
 # Warn about compiling with clang++ for llvm version >= 3.9
 if test "x$CXX" = "xclang" || test "x$CXX" = "xclang++" ; then


### PR DESCRIPTION
Remove some parts of `configure` that are unused or even directly harmful.

Here's the justification from the corresponding commit message why `AC_FUNC_MALLOC` is directly harmful and should be removed:

`AC_FUNC_MALLOC` is harmful. First of all, it is fundamentally incompatible with C++ (since it does `#define malloc rpl_malloc` when it takes issue with the system malloc or something else in the configuration). Second of all, even when used for C, a project using it must contain a `malloc.c` that provides a fallback implementation, which nidhugg is not.

In practice, it only serves to mask misconfiguration errors by causing strange build errors in the C++ standard library (`error: ‘::malloc’ has not been declared`), so remove it.