### PR TITLE
Block when trying to join an assume-blocked thread

### DIFF
--- a/src/Execution.cpp
+++ b/src/Execution.cpp
@@ -3070,6 +3070,7 @@ void Interpreter::callAssume(Function *F, const std::vector<GenericValue> &ArgVa
     }
     ECStack()->clear();
     AtExitHandlers.clear();
+    Threads[CurrentThread].AssumeBlocked = true;
     /* Do not call terminate. We don't want to explicitly terminate
      * since that would allow other processes to join with this
      * process.
@@ -3357,7 +3358,7 @@ bool Interpreter::checkRefuse(Instruction &I){
     int tid;
     if(isPthreadJoin(I,&tid)){
       if(0 <= tid && tid < int(Threads.size()) && tid != CurrentThread){
-        if(Threads[tid].ECStack.size()){
+        if(Threads[tid].ECStack.size() || Threads[tid].AssumeBlocked) {
           /* The awaited thread is still executing. */
           TB.refuse_schedule();
           Threads[tid].AwaitingJoin.push_back(CurrentThread);

--- a/src/Interpreter.h
+++ b/src/Interpreter.h
@@ -115,13 +115,14 @@ protected:
   /* A Thread object keeps track of each running thread. */
   class Thread{
   public:
-    Thread() : RandEng(42), pending_mutex_lock(0), pending_condvar_awake(0) {};
+    Thread() : AssumeBlocked(false), RandEng(42), pending_mutex_lock(0), pending_condvar_awake(0) {};
     /* The complex thread identifier of this thread. */
     CPid cpid;
     /* The runtime stack of executing code. The top of the stack is the
      * current function record.
      */
     std::vector<ExecutionContext> ECStack;
+    bool AssumeBlocked;
     /* Contains the IDs (index into Threads) of all other threads
      * which are awaiting the termination of this thread to perform a
      * join.


### PR DESCRIPTION
If a thread tries to pthread_join another thread that has been
permanently suspended due to calling __VERIFIER_assume(0), the
pthread_join call will succeed and return. This is a bug, as it makes
nidhugg explore behaviours that are not actually feasible.

Fixes #32.