### PR TITLE
Fix bug in dependency analysis of mutex_trylock

### DIFF
--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -678,6 +678,7 @@ void PSOTraceBuilder::mutex_lock(const SymAddrSize &ml){
   }
 
   mutex.last_lock = mutex.last_access = prefix_idx;
+  mutex.locked = true;
 }
 
 void PSOTraceBuilder::mutex_lock_fail(const SymAddrSize &ml){
@@ -713,6 +714,7 @@ void PSOTraceBuilder::mutex_unlock(const SymAddrSize &ml){
   see_events({mutex.last_access,last_full_memory_conflict});
 
   mutex.last_access = prefix_idx;
+  mutex.locked = false;
 }
 
 void PSOTraceBuilder::mutex_trylock(const SymAddrSize &ml){
@@ -731,8 +733,9 @@ void PSOTraceBuilder::mutex_trylock(const SymAddrSize &ml){
   see_events({mutex.last_access,last_full_memory_conflict});
 
   mutex.last_access = prefix_idx;
-  if(mutex.last_lock < 0){ // Mutex is free
+  if(!mutex.locked){ // Mutex is free
     mutex.last_lock = prefix_idx;
+    mutex.locked = true;
   }
 }
 

--- a/src/PSOTraceBuilder.h
+++ b/src/PSOTraceBuilder.h
@@ -278,10 +278,11 @@ protected:
    */
   class Mutex{
   public:
-    Mutex() : last_access(-1), last_lock(-1) {};
-    Mutex(int lacc) : last_access(lacc), last_lock(-1) {};
+    Mutex() : last_access(-1), last_lock(-1), locked(false) {};
+    Mutex(int lacc) : last_access(lacc), last_lock(-1), locked(false) {};
     int last_access;
     int last_lock;
+    bool locked;
   };
   /* A map containing all pthread mutex objects in the current
    * execution. The key is the position in memory of the actual

--- a/src/PSO_test2.cpp
+++ b/src/PSO_test2.cpp
@@ -236,6 +236,70 @@ declare i32 @pthread_mutex_unlock(i32*) nounwind
   BOOST_CHECK(DPORDriver_test::check_all_traces(res,expected,conf));
 }
 
+BOOST_AUTO_TEST_CASE(Mutex_trylock_2){
+  Configuration conf = DPORDriver_test::get_pso_conf();
+  DPORDriver *driver =
+    DPORDriver::parseIR(StrModule::portasm(R"(
+@lck = global i32 0, align 8
+
+define i8* @l(i8*) {
+  call i32 @pthread_mutex_lock(i32* @lck)
+  call i32 @pthread_mutex_unlock(i32* @lck)
+  ret i8* null
+}
+
+define i8* @tl(i8*) {
+  %lckret = call i32 @pthread_mutex_trylock(i32* @lck)
+  %lcksuc = icmp eq i32 %lckret, 0
+  br i1 %lcksuc, label %CS, label %exit
+CS:
+  call i32 @pthread_mutex_unlock(i32* @lck)
+  br label %exit
+exit:
+  ret i8* null
+}
+
+define i32 @main() {
+  %il1 = alloca i64, align 8
+  %il2 = alloca i64, align 8
+  %itl = alloca i64, align 8
+  call i32 @pthread_mutex_init(i32* @lck, i32* null) #3
+  call i32 @pthread_create(i64* %il1, %attr_t* null, i8* (i8*)* @l, i8* null) #3
+  call i32 @pthread_create(i64* %itl, %attr_t* null, i8* (i8*)* @tl, i8* null) #3
+  call i32 @pthread_create(i64* %il2, %attr_t* null, i8* (i8*)* @l, i8* null) #3
+  ret i32 0
+}
+
+%attr_t = type { i64, [48 x i8] }
+declare i32 @pthread_create(i64*, %attr_t*, i8* (i8*)*, i8*)
+declare i32 @pthread_mutex_lock(i32*)
+declare i32 @pthread_mutex_unlock(i32*)
+declare i32 @pthread_mutex_trylock(i32*)
+declare i32 @pthread_mutex_init(i32*, i32*)
+)"),conf);
+
+  DPORDriver::Result res = driver->run();
+  delete driver;
+
+  CPid P0, PL1 = P0.spawn(0), PTL = P0.spawn(1), PL2 = P0.spawn(2);
+  IID<CPid> lck1(PL1,1), ulck1(PL1,2), lck2(PL2,1), ulck2(PL2,2),
+    tlck(PTL,1), tulck(PTL,4);
+  DPORDriver_test::trace_set_spec expected =
+    {{{ulck1,lck2},{ulck2,tlck}},             // L1, L2,      TL
+     {{ulck1,lck2},{lck2,tlck},{tlck,ulck2}}, // L1, L2,      TL-fail
+     {{ulck1,tlck},{tulck,lck2}},             // L1, TL,      L2
+     {{lck1,tlck},{tlck,ulck1},{ulck1,lck2}}, // L1, TL-fail, L2
+     {{tulck,lck1},{ulck1,lck2}},             // TL, L1,      L2
+     {{tulck,lck2},{ulck2,lck1}},             // TL, L2,      L1
+     {{ulck2,lck1},{ulck1,tlck}},             // L2, L1,      TL
+     {{ulck2,lck1},{lck1,tlck},{tlck,ulck1}}, // L2, L1,      TL-fail
+     {{ulck2,tlck},{tulck,lck1}},             // L2, TL,      L1
+     {{lck2,tlck},{tlck,ulck2},{ulck2,lck1}}, // L2, TL-fail, L1
+    };
+  BOOST_CHECK(!res.has_errors());
+  BOOST_CHECK(DPORDriver_test::check_all_traces(res,expected,conf));
+}
+
 BOOST_AUTO_TEST_CASE(Condvar_1){
   Configuration conf = DPORDriver_test::get_pso_conf();
   DPORDriver *driver =

--- a/src/SC_test.cpp
+++ b/src/SC_test.cpp
@@ -1191,6 +1191,75 @@ declare i32 @pthread_mutex_unlock(i32*) nounwind
   BOOST_CHECK(DPORDriver_test::check_all_traces(res,expected,conf,&opt_res));
 }
 
+BOOST_AUTO_TEST_CASE(Mutex_trylock_2){
+  Configuration conf = DPORDriver_test::get_sc_conf();
+  std::string module = StrModule::portasm(R"(
+@lck = global i32 0, align 8
+
+define i8* @l(i8*) {
+  call i32 @pthread_mutex_lock(i32* @lck)
+  call i32 @pthread_mutex_unlock(i32* @lck)
+  ret i8* null
+}
+
+define i8* @tl(i8*) {
+  %lckret = call i32 @pthread_mutex_trylock(i32* @lck)
+  %lcksuc = icmp eq i32 %lckret, 0
+  br i1 %lcksuc, label %CS, label %exit
+CS:
+  call i32 @pthread_mutex_unlock(i32* @lck)
+  br label %exit
+exit:
+  ret i8* null
+}
+
+define i32 @main() {
+  %il1 = alloca i64, align 8
+  %il2 = alloca i64, align 8
+  %itl = alloca i64, align 8
+  call i32 @pthread_mutex_init(i32* @lck, i32* null) #3
+  call i32 @pthread_create(i64* %il1, %attr_t* null, i8* (i8*)* @l, i8* null) #3
+  call i32 @pthread_create(i64* %itl, %attr_t* null, i8* (i8*)* @tl, i8* null) #3
+  call i32 @pthread_create(i64* %il2, %attr_t* null, i8* (i8*)* @l, i8* null) #3
+  ret i32 0
+}
+
+%attr_t = type { i64, [48 x i8] }
+declare i32 @pthread_create(i64*, %attr_t*, i8* (i8*)*, i8*)
+declare i32 @pthread_mutex_lock(i32*)
+declare i32 @pthread_mutex_unlock(i32*)
+declare i32 @pthread_mutex_trylock(i32*)
+declare i32 @pthread_mutex_init(i32*, i32*)
+)");
+
+  DPORDriver *driver = DPORDriver::parseIR(module, conf);
+  DPORDriver::Result res = driver->run();
+  delete driver;
+
+  conf.dpor_algorithm = Configuration::OPTIMAL;
+  driver = DPORDriver::parseIR(module, conf);
+  DPORDriver::Result opt_res = driver->run();
+  delete driver;
+
+  CPid P0, PL1 = P0.spawn(0), PTL = P0.spawn(1), PL2 = P0.spawn(2);
+  IID<CPid> lck1(PL1,1), ulck1(PL1,2), lck2(PL2,1), ulck2(PL2,2),
+    tlck(PTL,1), tulck(PTL,4);
+  DPORDriver_test::trace_set_spec expected =
+    {{{ulck1,lck2},{ulck2,tlck}},             // L1, L2,      TL
+     {{ulck1,lck2},{lck2,tlck},{tlck,ulck2}}, // L1, L2,      TL-fail
+     {{ulck1,tlck},{tulck,lck2}},             // L1, TL,      L2
+     {{lck1,tlck},{tlck,ulck1},{ulck1,lck2}}, // L1, TL-fail, L2
+     {{tulck,lck1},{ulck1,lck2}},             // TL, L1,      L2
+     {{tulck,lck2},{ulck2,lck1}},             // TL, L2,      L1
+     {{ulck2,lck1},{ulck1,tlck}},             // L2, L1,      TL
+     {{ulck2,lck1},{lck1,tlck},{tlck,ulck1}}, // L2, L1,      TL-fail
+     {{ulck2,tlck},{tulck,lck1}},             // L2, TL,      L1
+     {{lck2,tlck},{tlck,ulck2},{ulck2,lck1}}, // L2, TL-fail, L1
+    };
+  BOOST_CHECK(!res.has_errors());
+  BOOST_CHECK(DPORDriver_test::check_all_traces(res,expected,conf,&opt_res));
+}
+
 BOOST_AUTO_TEST_CASE(Condvar_1){
   Configuration conf = DPORDriver_test::get_sc_conf();
   std::string module = StrModule::portasm(R"(

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -917,6 +917,7 @@ void TSOTraceBuilder::mutex_lock(const SymAddrSize &ml){
   }
 
   mutex.last_lock = mutex.last_access = prefix_idx;
+  mutex.locked = true;
 }
 
 void TSOTraceBuilder::mutex_lock_fail(const SymAddrSize &ml){
@@ -956,8 +957,9 @@ void TSOTraceBuilder::mutex_trylock(const SymAddrSize &ml){
   see_events({mutex.last_access,last_full_memory_conflict});
 
   mutex.last_access = prefix_idx;
-  if(mutex.last_lock < 0){ // Mutex is free
+  if(!mutex.locked){ // Mutex is free
     mutex.last_lock = prefix_idx;
+    mutex.locked = true;
   }
 }
 
@@ -984,6 +986,7 @@ void TSOTraceBuilder::mutex_unlock(const SymAddrSize &ml){
   see_events({mutex.last_access,last_full_memory_conflict});
 
   mutex.last_access = prefix_idx;
+  mutex.locked = false;
 }
 
 void TSOTraceBuilder::mutex_init(const SymAddrSize &ml){

--- a/src/TSOTraceBuilder.h
+++ b/src/TSOTraceBuilder.h
@@ -251,10 +251,11 @@ protected:
    */
   class Mutex{
   public:
-    Mutex() : last_access(-1), last_lock(-1) {};
-    Mutex(int lacc) : last_access(lacc), last_lock(-1) {};
+    Mutex() : last_access(-1), last_lock(-1), locked(false) {};
+    Mutex(int lacc) : last_access(lacc), last_lock(-1), locked(false) {};
     int last_access;
     int last_lock;
+    bool locked;
   };
   /* A map containing all pthread mutex objects in the current
    * execution. The key is the position in memory of the actual

--- a/src/TSO_test2.cpp
+++ b/src/TSO_test2.cpp
@@ -86,6 +86,77 @@ declare i32 @pthread_mutex_unlock(i32*) nounwind
                                                 ));
 }
 
+BOOST_AUTO_TEST_CASE(Mutex_trylock_2){
+  Configuration conf = DPORDriver_test::get_tso_conf();
+  std::string module = StrModule::portasm(R"(
+@lck = global i32 0, align 8
+
+define i8* @l(i8*) {
+  call i32 @pthread_mutex_lock(i32* @lck)
+  call i32 @pthread_mutex_unlock(i32* @lck)
+  ret i8* null
+}
+
+define i8* @tl(i8*) {
+  %lckret = call i32 @pthread_mutex_trylock(i32* @lck)
+  %lcksuc = icmp eq i32 %lckret, 0
+  br i1 %lcksuc, label %CS, label %exit
+CS:
+  call i32 @pthread_mutex_unlock(i32* @lck)
+  br label %exit
+exit:
+  ret i8* null
+}
+
+define i32 @main() {
+  %il1 = alloca i64, align 8
+  %il2 = alloca i64, align 8
+  %itl = alloca i64, align 8
+  call i32 @pthread_mutex_init(i32* @lck, i32* null) #3
+  call i32 @pthread_create(i64* %il1, %attr_t* null, i8* (i8*)* @l, i8* null) #3
+  call i32 @pthread_create(i64* %itl, %attr_t* null, i8* (i8*)* @tl, i8* null) #3
+  call i32 @pthread_create(i64* %il2, %attr_t* null, i8* (i8*)* @l, i8* null) #3
+  ret i32 0
+}
+
+%attr_t = type { i64, [48 x i8] }
+declare i32 @pthread_create(i64*, %attr_t*, i8* (i8*)*, i8*)
+declare i32 @pthread_mutex_lock(i32*)
+declare i32 @pthread_mutex_unlock(i32*)
+declare i32 @pthread_mutex_trylock(i32*)
+declare i32 @pthread_mutex_init(i32*, i32*)
+)");
+
+  DPORDriver *driver = DPORDriver::parseIR(module,conf);
+  DPORDriver::Result res = driver->run();
+  delete driver;
+
+  /* TODO: Optimal-DPOR */
+  // conf.dpor_algorithm = Configuration::OPTIMAL;
+  // driver = DPORDriver::parseIR(module,conf);
+  // DPORDriver::Result opt_res = driver->run();
+  // delete driver;
+
+  CPid P0, PL1 = P0.spawn(0), PTL = P0.spawn(1), PL2 = P0.spawn(2);
+  IID<CPid> lck1(PL1,1), ulck1(PL1,2), lck2(PL2,1), ulck2(PL2,2),
+    tlck(PTL,1), tulck(PTL,4);
+  DPORDriver_test::trace_set_spec expected =
+    {{{ulck1,lck2},{ulck2,tlck}},             // L1, L2,      TL
+     {{ulck1,lck2},{lck2,tlck},{tlck,ulck2}}, // L1, L2,      TL-fail
+     {{ulck1,tlck},{tulck,lck2}},             // L1, TL,      L2
+     {{lck1,tlck},{tlck,ulck1},{ulck1,lck2}}, // L1, TL-fail, L2
+     {{tulck,lck1},{ulck1,lck2}},             // TL, L1,      L2
+     {{tulck,lck2},{ulck2,lck1}},             // TL, L2,      L1
+     {{ulck2,lck1},{ulck1,tlck}},             // L2, L1,      TL
+     {{ulck2,lck1},{lck1,tlck},{tlck,ulck1}}, // L2, L1,      TL-fail
+     {{ulck2,tlck},{tulck,lck1}},             // L2, TL,      L1
+     {{lck2,tlck},{tlck,ulck2},{ulck2,lck1}}, // L2, TL-fail, L1
+    };
+  BOOST_CHECK(!res.has_errors());
+  BOOST_CHECK(DPORDriver_test::check_all_traces(res,expected,conf// ,&opt_res
+                                                ));
+}
+
 BOOST_AUTO_TEST_CASE(Condvar_1){
   Configuration conf = DPORDriver_test::get_tso_conf();
   std::string module = StrModule::portasm(R"(


### PR DESCRIPTION
The dependency analysis in `TSOTraceBuilder` and `PSOTraceBuilder` would consider a `trylock` operation to always fail on a mutex that has been locked previously, leading to incomplete exploration.