### PR TITLE
configure: Add check for llvm::TerminatorInst

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1026,6 +1026,22 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
          AC_MSG_RESULT([yes])],
         [AC_MSG_RESULT([no])])
 
+## Check whether the llvm::TerminatorInst class exists (LLVM<8)
+AC_MSG_CHECKING([for llvm::TerminatorInst])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_IR_INSTRUCTIONS_H)
+#include <llvm/IR/Instructions.h>
+#elif defined(HAVE_LLVM_INSTRUCTIONS_H)
+#include <llvm/Instructions.h>
+#endif
+]],[[
+  llvm::TerminatorInst *I = nullptr;
+]])],
+        [AC_DEFINE([LLVM_HAS_TERMINATORINST],[1],
+         [Define if llvm::TerminatorInst exists.])
+         AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE

--- a/src/LoopUnrollPass.cpp
+++ b/src/LoopUnrollPass.cpp
@@ -36,6 +36,12 @@
 #endif
 #include <llvm/Transforms/Utils/Cloning.h>
 
+#ifdef LLVM_HAS_TERMINATORINST
+typedef llvm::TerminatorInst TerminatorInst;
+#else
+typedef llvm::Instruction TerminatorInst;
+#endif
+
 void LoopUnrollPass::getAnalysisUsage(llvm::AnalysisUsage &AU) const{
   llvm::LoopPass::getAnalysisUsage(AU);
   AU.addRequired<DeclareAssumePass>();
@@ -95,7 +101,7 @@ bool LoopUnrollPass::runOnLoop(llvm::Loop *L, llvm::LPPassManager &LPM){
   for(int i = 0; i < unroll_depth; ++i){
     for(int j = 0; j < int(bodies[i].size()); ++j){
       /* Branches */
-      llvm::TerminatorInst *TI = bodies[i][j]->getTerminator();
+      TerminatorInst *TI = bodies[i][j]->getTerminator();
       int nsucc = TI->getNumSuccessors();
       for(int k = 0; k < nsucc; ++k){
         llvm::BasicBlock *succ0 = TI->getSuccessor(k);

--- a/src/SpinAssumePass.cpp
+++ b/src/SpinAssumePass.cpp
@@ -63,6 +63,12 @@ typedef llvm::AttributeList AttributeList;
 typedef llvm::AttributeSet AttributeList;
 #endif
 
+#ifdef LLVM_HAS_TERMINATORINST
+typedef llvm::TerminatorInst TerminatorInst;
+#else
+typedef llvm::Instruction TerminatorInst;
+#endif
+
 void SpinAssumePass::getAnalysisUsage(llvm::AnalysisUsage &AU) const{
   AU.addRequired<llvm::LLVM_DOMINATOR_TREE_PASS>();
   AU.addRequired<DeclareAssumePass>();
@@ -128,7 +134,7 @@ void SpinAssumePass::remove_disconnected(llvm::Loop *l){
       // Search for basic blocks without in-loop successors
       // Simultaneously collect blocks with in-loop predecessors
       for(auto it = l->block_begin(); done && it != l->block_end(); ++it){
-        llvm::TerminatorInst *T = (*it)->getTerminator();
+        TerminatorInst *T = (*it)->getTerminator();
         bool has_loop_successor = false;
         for(unsigned i = 0; i < T->getNumSuccessors(); ++i){
           if(l->contains(T->getSuccessor(i))){
@@ -158,7 +164,7 @@ bool SpinAssumePass::assumify_loop(llvm::Loop *l,llvm::LPPassManager &LPM){
   if(!EB) return false; // Too complicated loop
   llvm::BranchInst *BI;
   {
-    llvm::TerminatorInst *EI = EB->getTerminator();
+    TerminatorInst *EI = EB->getTerminator();
     assert(EI);
     BI = llvm::dyn_cast<llvm::BranchInst>(EI);
   }


### PR DESCRIPTION
This class is removed from upstream LLVM in r344769.