### PR TITLE
TSOTraceBuilder: Fix merging different sizes in WuT

### DIFF
--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -1989,8 +1989,41 @@ void TSOTraceBuilder::race_detect_optimal
             return;
           }
 
-          /* Drop ve from v and recurse into this node */
-          v.erase(vei);
+          /* We will recurse into this node. To do that we first need to
+           * drop all events in child_it.branch() from v.
+           */
+          if (ve.size < child_it.branch().size) {
+            /* child_it.branch() contains more events than just ve.
+             * We need to scan v to find all of them.
+             */
+            int missing = child_it.branch().size - ve.size;
+            IPid pid = ve.pid;
+            for (auto vri = v.erase(vei); missing != 0 && vri != v.end();) {
+              if (vri->pid == pid) {
+                assert(vri->sym.empty());
+                if (vri->size > missing) {
+                  vri->size = missing;
+                  missing = 0;
+                  break;
+                } else {
+                  missing -= vri->size;
+                  vri =  v.erase(vri);
+                }
+              } else {
+                ++vri;
+              }
+            }
+          } else if (ve.size > child_it.branch().size) {
+            /* ve is larger than child_it.branch(). Delete the common
+             * prefix from ve.
+             */
+            vei->size -= child_it.branch().size;
+            vei->sym.clear();
+            vei->alt = 0;
+          } else {
+            /* Drop ve from v. */
+            v.erase(vei);
+          }
           break;
         }
 


### PR DESCRIPTION
When inserting into the wakeup tree, the code would not consider the
sizes of the events. If a sequence where a big event had been split into
several smaller ones was merged with an existing branch where the big
event existed, only the first of the split events would be removed from
the wakeup sequence, and the latter ones would incorrectly remain and
cause nonexistent program steps to be replayed.

I have not yet been able to construct a minimal test case for this bug. The test case which initially hit this bug is 10395 traces, way too long to fit in the test suite. I have been able to construct a 4 trace program which hits the new code path, but it does not crash or misbehave without this patch.

So, TODO:
- [ ] A test