### PR TITLE
Fix edge case in nondet detection for PSO

### DIFF
--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -209,7 +209,7 @@ void PSOTraceBuilder::mark_unavailable(int proc, int aux){
 }
 
 bool PSOTraceBuilder::is_replaying() const {
-  return replay;
+  return replay && (prefix_idx + 1 < int(prefix.size()));
 }
 
 void PSOTraceBuilder::cancel_replay(){


### PR DESCRIPTION
If the initial event from the backtrack set was a branch (control flow),
the nondeterminism detection from ac12d1ab would mistakenly assume that
it must go the same way (true/false) as the next branch in the previous
execution of the program, which might be by a different thread entirely.
This can cause spurious nondeterminism error reports.

Already fixed for SC&TSO in 702d4388. Does not affect POWER/ARM.

Test will be added by a separate pull request, due to it triggering multiple bugs.