### PR TITLE
Fix merging non-unity events under Optimal

### DIFF
--- a/src/Regression_test.cpp
+++ b/src/Regression_test.cpp
@@ -146,6 +146,207 @@ declare i32 @pthread_create(i64*, %attr_t*, i8* (i8*)*, i8*)
   BOOST_CHECK(!res.has_errors());
 }
 
+BOOST_AUTO_TEST_CASE(mcs_spinlock_SC_Optimal){
+  /* Regression test for "Fix merging non-unity events under Optimal" */
+  Configuration conf = DPORDriver_test::get_sc_conf();
+  conf.dpor_algorithm = Configuration::OPTIMAL;
+  std::string module = StrModule::portasm(R"(
+%mcs_spinlock = type { %mcs_spinlock*, i32, i32 }
+%attr_t = type { i64, [48 x i8] }
+
+@lock = global %mcs_spinlock* null, align 8
+@nodes = global [4 x %mcs_spinlock] zeroinitializer, align 16
+@shared = global i32 0, align 4
+@idx = global [4 x i32] zeroinitializer, align 16
+
+define i8* @thread_n(i8* ) {
+  %2 = bitcast i8* %0 to i32*
+  %3 = load i32, i32* %2, align 4
+  %4 = sext i32 %3 to i64
+  %5 = getelementptr inbounds [4 x %mcs_spinlock], [4 x %mcs_spinlock]* @nodes, i64 0, i64 %4
+  tail call void @mcs_spin_lock(%mcs_spinlock* %5)
+  store i32 42, i32* @shared, align 4
+  tail call void @mcs_spin_unlock(%mcs_spinlock* %5)
+  ret i8* null
+}
+
+define void @mcs_spin_lock(%mcs_spinlock*) {
+  %2 = getelementptr inbounds %mcs_spinlock, %mcs_spinlock* %0, i64 0, i32 1
+  store atomic i32 0, i32* %2 monotonic, align 8
+  %3 = bitcast %mcs_spinlock* %0 to i64*
+  store atomic i64 0, i64* %3 monotonic, align 8
+  %4 = ptrtoint %mcs_spinlock* %0 to i64
+  %5 = atomicrmw xchg i64* bitcast (%mcs_spinlock** @lock to i64*), i64 %4 acq_rel
+  %6 = icmp eq i64 %5, 0
+  br i1 %6, label %12, label %7
+
+; <label>:7:                                      ; preds = %1
+  %8 = inttoptr i64 %5 to i64*
+  store atomic i64 %4, i64* %8 monotonic, align 8
+  br label %9
+
+; <label>:9:                                      ; preds = %7
+  %10 = load atomic i32, i32* %2 acquire, align 8
+  %11 = icmp eq i32 %10, 0
+  %notcond = xor i1 %11, true
+  call void @__VERIFIER_assume(i1 %notcond)
+  br label %12
+
+; <label>:12:                                     ; preds = %9, %1
+  ret void
+}
+
+define internal void @mcs_spin_unlock(%mcs_spinlock*) unnamed_addr {
+  %2 = bitcast %mcs_spinlock* %0 to i64*
+  %3 = load atomic i64, i64* %2 monotonic, align 8
+  %4 = icmp eq i64 %3, 0
+  br i1 %4, label %5, label %14
+
+; <label>:5:                                      ; preds = %1
+  %6 = ptrtoint %mcs_spinlock* %0 to i64
+)"
+#if defined(LLVM_CMPXCHG_SEPARATE_SUCCESS_FAILURE_ORDERING)
+R"(
+  %7 = cmpxchg i64* bitcast (%mcs_spinlock** @lock to i64*), i64 %6, i64 0 release monotonic
+  %8 = extractvalue { i64, i1 } %7, 0)"
+#else
+R"(
+  %7 = cmpxchg i64* bitcast (%mcs_spinlock** @lock to i64*), i64 %6, i64 0 release
+  %8 = add i64 %7, 0)"
+#endif
+R"(
+  %9 = inttoptr i64 %8 to %mcs_spinlock*
+  %10 = icmp eq %mcs_spinlock* %9, %0
+  br i1 %10, label %18, label %11
+
+; <label>:11:                                     ; preds = %5
+  %12 = load atomic i64, i64* %2 monotonic, align 8
+  %13 = icmp eq i64 %12, 0
+  %notcond = xor i1 %13, true
+  call void @__VERIFIER_assume(i1 %notcond)
+  br label %14
+
+; <label>:14:                                     ; preds = %11, %1
+  %15 = phi i64 [ %3, %1 ], [ %12, %11 ]
+  %16 = inttoptr i64 %15 to %mcs_spinlock*
+  %17 = getelementptr inbounds %mcs_spinlock, %mcs_spinlock* %16, i64 0, i32 1
+  store atomic i32 1, i32* %17 release, align 8
+  br label %18
+
+; <label>:18:                                     ; preds = %14, %5
+  ret void
+}
+
+define i32 @main() {
+  %1 = alloca [4 x i64], align 16
+  %2 = bitcast [4 x i64]* %1 to i8*
+  br label %6
+
+; <label>:3:                                      ; preds = %6
+  %4 = icmp ult i64 %14, 4
+  br i1 %4, label %16, label %5
+
+; <label>:5:                                      ; preds = %58, %47, %36, %25, %3
+  ret i32 0
+
+; <label>:6:                                      ; preds = %0
+  %7 = phi i64 [ 0, %0 ]
+  %8 = getelementptr inbounds [4 x i32], [4 x i32]* @idx, i64 0, i64 %7
+  %9 = trunc i64 %7 to i32
+  store i32 %9, i32* %8, align 4
+  %10 = getelementptr inbounds [4 x i64], [4 x i64]* %1, i64 0, i64 %7
+  %11 = bitcast i32* %8 to i8*
+  %12 = call i32 @pthread_create(i64* %10, %attr_t* null, i8* (i8*)* @thread_n, i8* %11)
+  %13 = icmp eq i32 %12, 0
+  %14 = add nuw nsw i64 %7, 1
+  br i1 %13, label %3, label %15
+
+; <label>:15:                                     ; preds = %49, %38, %27, %16, %6
+  call void @abort()
+  unreachable
+
+diverge:                                          ; preds = %58, %diverge
+  call void @__VERIFIER_assume(i1 false)
+  br label %diverge
+
+; <label>:16:                                     ; preds = %3
+  %17 = phi i64 [ %14, %3 ]
+  %18 = getelementptr inbounds [4 x i32], [4 x i32]* @idx, i64 0, i64 %17
+  %19 = trunc i64 %17 to i32
+  store i32 %19, i32* %18, align 4
+  %20 = getelementptr inbounds [4 x i64], [4 x i64]* %1, i64 0, i64 %17
+  %21 = bitcast i32* %18 to i8*
+  %22 = call i32 @pthread_create(i64* %20, %attr_t* null, i8* (i8*)* @thread_n, i8* %21)
+  %23 = icmp eq i32 %22, 0
+  %24 = add nuw nsw i64 %17, 1
+  br i1 %23, label %25, label %15
+
+; <label>:25:                                     ; preds = %16
+  %26 = icmp ult i64 %24, 4
+  br i1 %26, label %27, label %5
+
+; <label>:27:                                     ; preds = %25
+  %28 = phi i64 [ %24, %25 ]
+  %29 = getelementptr inbounds [4 x i32], [4 x i32]* @idx, i64 0, i64 %28
+  %30 = trunc i64 %28 to i32
+  store i32 %30, i32* %29, align 4
+  %31 = getelementptr inbounds [4 x i64], [4 x i64]* %1, i64 0, i64 %28
+  %32 = bitcast i32* %29 to i8*
+  %33 = call i32 @pthread_create(i64* %31, %attr_t* null, i8* (i8*)* @thread_n, i8* %32)
+  %34 = icmp eq i32 %33, 0
+  %35 = add nuw nsw i64 %28, 1
+  br i1 %34, label %36, label %15
+
+; <label>:36:                                     ; preds = %27
+  %37 = icmp ult i64 %35, 4
+  br i1 %37, label %38, label %5
+
+; <label>:38:                                     ; preds = %36
+  %39 = phi i64 [ %35, %36 ]
+  %40 = getelementptr inbounds [4 x i32], [4 x i32]* @idx, i64 0, i64 %39
+  %41 = trunc i64 %39 to i32
+  store i32 %41, i32* %40, align 4
+  %42 = getelementptr inbounds [4 x i64], [4 x i64]* %1, i64 0, i64 %39
+  %43 = bitcast i32* %40 to i8*
+  %44 = call i32 @pthread_create(i64* %42, %attr_t* null, i8* (i8*)* @thread_n, i8* %43)
+  %45 = icmp eq i32 %44, 0
+  %46 = add nuw nsw i64 %39, 1
+  br i1 %45, label %47, label %15
+
+; <label>:47:                                     ; preds = %38
+  %48 = icmp ult i64 %46, 4
+  br i1 %48, label %49, label %5
+
+; <label>:49:                                     ; preds = %47
+  %50 = phi i64 [ %46, %47 ]
+  %51 = getelementptr inbounds [4 x i32], [4 x i32]* @idx, i64 0, i64 %50
+  %52 = trunc i64 %50 to i32
+  store i32 %52, i32* %51, align 4
+  %53 = getelementptr inbounds [4 x i64], [4 x i64]* %1, i64 0, i64 %50
+  %54 = bitcast i32* %51 to i8*
+  %55 = call i32 @pthread_create(i64* %53, %attr_t* null, i8* (i8*)* @thread_n, i8* %54)
+  %56 = icmp eq i32 %55, 0
+  %57 = add nuw nsw i64 %50, 1
+  br i1 %56, label %58, label %15
+
+; <label>:58:                                     ; preds = %49
+  %59 = icmp ult i64 %57, 4
+  br i1 %59, label %diverge, label %5
+}
+
+declare i32 @pthread_create(i64*, %attr_t*, i8* (i8*)*, i8*)
+declare void @abort()
+declare void @__VERIFIER_assume(i1)
+)");
+
+  std::unique_ptr<DPORDriver> driver(DPORDriver::parseIR(module,conf));
+  DPORDriver::Result res = driver->run();
+
+  /* No trace_set_spec is provided, as it is too big to express in C++ */
+  BOOST_CHECK(!res.has_errors());
+  BOOST_CHECK(res.trace_count == 3024);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 #endif

--- a/src/StrModule.cpp
+++ b/src/StrModule.cpp
@@ -174,7 +174,7 @@ namespace StrModule {
        *
        * load rettype* addr
        */
-      s = nregex::regex_replace(s,"load [^,]*,","load ");
+      s = nregex::regex_replace(s,"load *((atomic)?) [^,]*,","load $1 ");
     }
     {
       /* Remove explicit return types for getelementptr.*/

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -138,10 +138,11 @@ bool TSOTraceBuilder::schedule(int *proc, int *aux, int *alt, bool *dryrun){
     assert(prefix[prefix.len()-1].wakeup.empty());
     assert(curev().sym.empty()); /* Would need to be copied */
     assert(curbranch().sym.empty()); /* Can't happen */
+    unsigned size = curbranch().size;
     prefix.delete_last();
     --prefix_idx;
     Branch b = curbranch();
-    ++b.size;
+    b.size += size;
     prefix.set_last_branch(std::move(b));
     assert(int(threads[curev().iid.get_pid()].event_indices.back()) == prefix_idx + 1);
     threads[curev().iid.get_pid()].event_indices.back() = prefix_idx;


### PR DESCRIPTION
Wakeup sequences may contain final events that are local, but have a
`size`>1. This broke merging of events in `TSOTraceBuilder`, which assumed
all mergeable events were of size 1.