### PR TITLE
TSOTraceBuilder: Fix TSO being slow sometimes

### DIFF
--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -103,6 +103,7 @@ bool TSOTraceBuilder::schedule(int *proc, int *aux, int *alt, bool *dryrun){
       if (prefix_idx < int(prefix.len())) {
         /* The event is already in prefix */
         pid = curev().iid.get_pid();
+        curev().happens_after.clear();
       } else {
         /* We are replaying from the wakeup tree */
         pid = prefix.first_child().pid;


### PR DESCRIPTION
On some benchmarks, such as mcs_spinlock, TSO was showing significant
slowdown over time. Turns out, the issue was caused by the
`TSOTraceBuilder::Event::happens_after` vector not being cleared after
each trace, leading to multiple copies of the same happens-after edge
accumulating, meaning very large amounts of time were spent computing
the vector clocks.

By simply clearing this vector during replay, we fix this performance
issue.