### PR TITLE
Use "long double" for trace count estimation

### DIFF
--- a/src/DPORDriver.cpp
+++ b/src/DPORDriver.cpp
@@ -33,6 +33,8 @@
 
 #include <fstream>
 #include <stdexcept>
+#include <iomanip>
+#include <cfloat>
 
 #if defined(HAVE_LLVM_IR_LLVMCONTEXT_H)
 #include <llvm/IR/LLVMContext.h>
@@ -223,7 +225,7 @@ DPORDriver::Result DPORDriver::run(){
   }
 
   int computation_count = 0;
-  int estimate = 1;
+  long double estimate = 1;
   do{
     if(conf.print_progress && (computation_count+1) % 100 == 0){
       llvm::dbgs() << esc << "[u" // Restore cursor position
@@ -231,10 +233,12 @@ DPORDriver::Result DPORDriver::run(){
                    << esc << "[K" // Erase the line
                    << "Computation #" << computation_count+1;
       if(conf.print_progress_estimate){
+        std::stringstream ss;
+        ss << std::setprecision(LDBL_DIG) << estimate;
         llvm::dbgs() << " ("
-                     << int(100.0*float(computation_count+1)/float(estimate))
+                     << int(100.0*(long double)(computation_count+1)/estimate)
                      << "% of total estimate: "
-                     << estimate << ")";
+                     << ss.str() << ")";
       }
     }
     if((computation_count+1) % 1000 == 0){
@@ -262,7 +266,7 @@ DPORDriver::Result DPORDriver::run(){
     }
     if(has_errors && !conf.explore_all_traces) break;
     if(conf.print_progress_estimate && (computation_count+1) % 100 == 0){
-      estimate = TB->estimate_trace_count();
+      estimate = std::round(TB->estimate_trace_count());
     }
   }while(TB->reset());
 

--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -1270,15 +1270,15 @@ bool PSOTraceBuilder::has_cycle(IID<IPid> *loc) const{
   }
 }
 
-int PSOTraceBuilder::estimate_trace_count() const{
+long double PSOTraceBuilder::estimate_trace_count() const{
   return estimate_trace_count(0);
 }
 
-int PSOTraceBuilder::estimate_trace_count(int idx) const{
+long double PSOTraceBuilder::estimate_trace_count(int idx) const{
   if(idx > int(prefix.size())) return 0;
   if(idx == int(prefix.size())) return 1;
 
-  int count = 1;
+  long double count = 1;
   for(int i = int(prefix.size())-1; idx <= i; --i){
     count += prefix[i].sleep_branch_trace_count;
     count += prefix[i].branch.size()*(count / (1 + prefix[i].sleep.size()));

--- a/src/PSOTraceBuilder.h
+++ b/src/PSOTraceBuilder.h
@@ -65,7 +65,7 @@ public:
   virtual bool cond_awake(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml);
   virtual int cond_destroy(const SymAddrSize &ml);
   virtual void register_alternatives(int alt_count);
-  virtual int estimate_trace_count() const;
+  virtual long double estimate_trace_count() const override;
 protected:
   /* An identifier for a thread. An index into this->threads.
    *
@@ -387,7 +387,7 @@ protected:
      * explored. sleep_branch_trace_count is the total number of such
      * explored traces.
      */
-    int sleep_branch_trace_count;
+    uint64_t sleep_branch_trace_count;
   };
 
   /* The fixed prefix of events in the current execution. This may be
@@ -477,7 +477,7 @@ protected:
   /* Estimate the total number of traces that have the same prefix as
    * the current one, up to the first idx events.
    */
-  int estimate_trace_count(int idx) const;
+  long double estimate_trace_count(int idx) const;
   /* Same as mark_available, but takes an IPid as thread
    * identifier.
    */

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -321,7 +321,7 @@ bool TSOTraceBuilder::reset(){
 
   /* Setup the new Event at prefix[i] */
   {
-    int sleep_branch_trace_count =
+    uint64_t sleep_branch_trace_count =
       prefix[i].sleep_branch_trace_count + estimate_trace_count(i+1);
     Event prev_evt = std::move(prefix[i]);
     while (ssize_t(prefix.len()) > i) prefix.delete_last();
@@ -2466,15 +2466,15 @@ bool TSOTraceBuilder::has_cycle(IID<IPid> *loc) const{
   }
 }
 
-int TSOTraceBuilder::estimate_trace_count() const{
+long double TSOTraceBuilder::estimate_trace_count() const{
   return estimate_trace_count(0);
 }
 
-int TSOTraceBuilder::estimate_trace_count(int idx) const{
+long double TSOTraceBuilder::estimate_trace_count(int idx) const{
   if(idx > int(prefix.len())) return 0;
   if(idx == int(prefix.len())) return 1;
 
-  int count = 1;
+  long double count = 1;
   for(int i = int(prefix.len())-1; idx <= i; --i){
     count += prefix[i].sleep_branch_trace_count;
     count += std::max(0, int(prefix.children_after(i)))

--- a/src/TSOTraceBuilder.h
+++ b/src/TSOTraceBuilder.h
@@ -70,7 +70,7 @@ public:
   virtual bool cond_awake(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml);
   virtual int cond_destroy(const SymAddrSize &ml);
   virtual void register_alternatives(int alt_count);
-  virtual int estimate_trace_count() const;
+  virtual long double estimate_trace_count() const override;
 protected:
   /* An identifier for a thread. An index into this->threads.
    *
@@ -434,7 +434,7 @@ protected:
      * explored. sleep_branch_trace_count is the total number of such
      * explored traces.
      */
-    int sleep_branch_trace_count;
+    uint64_t sleep_branch_trace_count;
   };
 
   /* The fixed prefix of events in the current execution. This may be
@@ -704,7 +704,7 @@ protected:
   /* Estimate the total number of traces that have the same prefix as
    * the current one, up to the first idx events.
    */
-  int estimate_trace_count(int idx) const;
+  long double estimate_trace_count(int idx) const;
 };
 
 #endif

--- a/src/TraceBuilder.h
+++ b/src/TraceBuilder.h
@@ -108,7 +108,7 @@ public:
   /* Estimate the total number of traces for this program based on the
    * traces that have been seen.
    */
-  virtual int estimate_trace_count() const { return 1; };
+  virtual long double estimate_trace_count() const { return 1; };
 protected:
   const Configuration &conf;
   std::vector<Error*> errors;


### PR DESCRIPTION
The trace count estimate frequently overflows on some benchmarks. Use a
floating-point type for this calculation so that overflow is graceful
rather than producing bogus or negative numbers.