### PR TITLE
Use uint64_t for trace count

### DIFF
--- a/src/DPORDriver.cpp
+++ b/src/DPORDriver.cpp
@@ -224,7 +224,7 @@ DPORDriver::Result DPORDriver::run(){
     llvm::dbgs() << esc << "[s"; // Save terminal cursor position
   }
 
-  int computation_count = 0;
+  uint64_t computation_count = 0;
   long double estimate = 1;
   do{
     if(conf.print_progress && (computation_count+1) % 100 == 0){

--- a/src/DPORDriver.h
+++ b/src/DPORDriver.h
@@ -73,9 +73,9 @@ public:
       }
     };
     /* The number of explored (non-sleepset-blocked) traces */
-    int trace_count;
+    uint64_t trace_count;
     /* The number of explored sleepset-blocked traces */
-    int sleepset_blocked_trace_count;
+    uint64_t sleepset_blocked_trace_count;
     /* An empty trace if no error has been encountered. Otherwise some
      * error trace.
      */


### PR DESCRIPTION
This prevents overflow of the trace count in very-long-running tests