### PR TITLE
Less verbose make output by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,8 @@ m4_include([m4/ax_clang.m4])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 # AC_CONFIG_SRCDIR([TSOTraceBuilder.cpp])
 
+AM_SILENT_RULES([yes])
+
 AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_RANLIB

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,9 +91,9 @@ valtest: unittest
 		`test -z "$(UTEST)" || echo "--run_test=$(UTEST)"`
 
 nidhuggc$(EXEEXT): $(srcdir)/nidhuggc.py
-	cat $(srcdir)/nidhuggc.py \
+	$(AM_V_GEN)cat $(srcdir)/nidhuggc.py \
 	| sed 's|%%PYTHON%%|@PYTHON@|g' \
 	| sed 's|%%CLANG%%|@CLANG@|g' \
 	| sed 's|%%CLANGXX%%|@CLANGXX@|g' \
 	> nidhuggc
-	chmod a+x nidhuggc
+	$(AM_V_at)chmod a+x nidhuggc


### PR DESCRIPTION
Can be overriden back to the verbose old default by `./configure --disable-silent-rules` or `make V=1`. 