### PR TITLE
Count assume-blocked traces separately

### DIFF
--- a/src/ARM_test.cpp
+++ b/src/ARM_test.cpp
@@ -2982,7 +2982,8 @@ declare i32 @pthread_create(i64*,%attr_t*,i8*(i8*)*,i8*)
   DPORDriver::Result res = driver->run();
   delete driver;
   BOOST_CHECK(!res.has_errors());
-  BOOST_CHECK(res.trace_count == 3);
+  BOOST_CHECK_EQUAL(res.trace_count, 2);
+  BOOST_CHECK_EQUAL(res.assume_blocked_trace_count, 1);
 }
 
 BOOST_AUTO_TEST_CASE(LB_assume_2){
@@ -3015,7 +3016,8 @@ declare i32 @pthread_create(i64*,%attr_t*,i8*(i8*)*,i8*)
   DPORDriver::Result res = driver->run();
   delete driver;
   BOOST_CHECK(!res.has_errors());
-  BOOST_CHECK(res.trace_count == 4);
+  BOOST_CHECK_EQUAL(res.trace_count, 4);
+  BOOST_CHECK_EQUAL(res.assume_blocked_trace_count, 0);
 }
 
 BOOST_AUTO_TEST_CASE(LB_assume_3){
@@ -3048,7 +3050,8 @@ declare i32 @pthread_create(i64*,%attr_t*,i8*(i8*)*,i8*)
   DPORDriver::Result res = driver->run();
   delete driver;
   BOOST_CHECK(!res.has_errors());
-  BOOST_CHECK(res.trace_count == 1);
+  BOOST_CHECK_EQUAL(res.trace_count, 0);
+  BOOST_CHECK_EQUAL(res.assume_blocked_trace_count, 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/DPORDriver.h
+++ b/src/DPORDriver.h
@@ -25,6 +25,7 @@
 #include "Configuration.h"
 #include "Trace.h"
 #include "TraceBuilder.h"
+#include "DPORInterpreter.h"
 
 #if defined(HAVE_LLVM_IR_MODULE_H)
 #include <llvm/IR/Module.h>
@@ -63,7 +64,8 @@ public:
   class Result{
   public:
     /* Empty result */
-    Result() : trace_count(0), sleepset_blocked_trace_count(0), error_trace(0) {};
+    Result() : trace_count(0), sleepset_blocked_trace_count(0),
+               assume_blocked_trace_count(0), error_trace(0) {};
     ~Result(){
       if(all_traces.empty()){ // Otherwise error_trace also appears in all_traces.
         delete error_trace;
@@ -76,6 +78,8 @@ public:
     uint64_t trace_count;
     /* The number of explored sleepset-blocked traces */
     uint64_t sleepset_blocked_trace_count;
+    /* The number of explored assume-blocked traces */
+    uint64_t assume_blocked_trace_count;
     /* An empty trace if no error has been encountered. Otherwise some
      * error trace.
      */
@@ -108,7 +112,7 @@ private:
   std::string src;
 
   DPORDriver(const Configuration &conf);
-  Trace *run_once(TraceBuilder &TB) const;
+  Trace *run_once(TraceBuilder &TB, bool &assume_blocked) const;
   void reparse();
   /* Opens and reads the file filename. Stores the entire content in
    * tgt. Throws an exception on failure.
@@ -118,7 +122,8 @@ private:
    * the TraceBuilder TB. The kind of execution engine is determined
    * by conf.memory_model.
    */
-  llvm::ExecutionEngine *create_execution_engine(TraceBuilder &TB, const Configuration &conf) const;
+  std::unique_ptr<DPORInterpreter>
+  create_execution_engine(TraceBuilder &TB, const Configuration &conf) const;
 };
 
 #endif

--- a/src/DPORDriver_test.cpp
+++ b/src/DPORDriver_test.cpp
@@ -147,10 +147,10 @@ namespace DPORDriver_test {
         retval = false;
       }
     }
-    if(res.trace_count != int(spec.size())){
+    if((res.trace_count + res.assume_blocked_trace_count) != spec.size()){
       llvm::dbgs() << "DPORDriver_test::check_all_traces: expected number of traces: "
                    << spec.size() << ", actual number: "
-                   << res.trace_count
+                   << res.trace_count << "+" << res.assume_blocked_trace_count
                    << " (" << res.all_traces.size() << ")\n";
       retval = false;
     }

--- a/src/DPORInterpreter.h
+++ b/src/DPORInterpreter.h
@@ -1,0 +1,47 @@
+/* Copyright (C) 2019 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#ifndef __DPOR_INTERPRETER_H__
+#define __DPOR_INTERPRETER_H__
+
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+
+/* Common base class for all Interpreter instances used in nidhugg */
+class DPORInterpreter : public llvm::ExecutionEngine {
+  /* True if we have executed a false assume statement.
+   */
+  bool AssumeBlocked;
+protected:
+  void setAssumeBlocked(bool value) { AssumeBlocked = value; }
+public:
+  DPORInterpreter(llvm::Module *M)
+#ifdef LLVM_EXECUTIONENGINE_MODULE_UNIQUE_PTR
+  : llvm::ExecutionEngine(std::unique_ptr<llvm::Module>(M))
+#else
+  : llvm::ExecutionEngine(M)
+#endif
+  {
+    AssumeBlocked = false;
+  }
+  bool assumeBlocked() const { return AssumeBlocked; }
+};
+
+#endif

--- a/src/Execution.cpp
+++ b/src/Execution.cpp
@@ -3071,6 +3071,7 @@ void Interpreter::callAssume(Function *F, const std::vector<GenericValue> &ArgVa
       }
       return;
     }
+    setAssumeBlocked(true);
     ECStack()->clear();
     AtExitHandlers.clear();
     Threads[CurrentThread].AssumeBlocked = true;

--- a/src/Interpreter.h
+++ b/src/Interpreter.h
@@ -43,6 +43,7 @@
 #include "VClock.h"
 #include "Option.h"
 #include "TSOPSOTraceBuilder.h"
+#include "DPORInterpreter.h"
 
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/GenericValue.h>
@@ -99,7 +100,7 @@ struct ExecutionContext {
 
 // Interpreter - This class represents the entirety of the interpreter.
 //
-class Interpreter : public ExecutionEngine, public InstVisitor<Interpreter> {
+class Interpreter : public DPORInterpreter, public InstVisitor<Interpreter> {
 protected:
   GenericValue ExitValue;          // The return value of the called function
   DataLayout TD;
@@ -265,9 +266,10 @@ public:
 
   /// create - Create an interpreter ExecutionEngine. This can never fail.
   ///
-  static ExecutionEngine *create(Module *M, TSOPSOTraceBuilder &TB,
-                                 const Configuration &conf = Configuration::default_conf,
-                                 std::string *ErrorStr = 0);
+  static std::unique_ptr<Interpreter>
+  create(Module *M, TSOPSOTraceBuilder &TB,
+         const Configuration &conf = Configuration::default_conf,
+         std::string *ErrorStr = 0);
 
   /// run - Start execution with the specified function and arguments.
   ///

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,7 @@ libnidhugg_a_SOURCES = \
   Debug.cpp Debug.h \
   DetCheckTraceBuilder.cpp DetCheckTraceBuilder.h \
   DPORDriver.cpp DPORDriver.h \
+  DPORInterpreter.h \
   Execution.cpp \
   ExternalFunctions.cpp \
   FBVClock.cpp FBVClock.h \

--- a/src/Observers_test.cpp
+++ b/src/Observers_test.cpp
@@ -1005,7 +1005,8 @@ declare void @__VERIFIER_assume(i64)
     {{{P1,13},{P0,8}},{{P0,33},{P,8}}},
     {{{P1,13},{P0,8}},{{P1,20},{P0,9}}},
   };
-  BOOST_CHECK_EQUAL(res.trace_count, 26);
+  BOOST_CHECK_EQUAL(res.trace_count, 14);
+  BOOST_CHECK_EQUAL(res.assume_blocked_trace_count, 12);
   BOOST_CHECK(DPORDriver_test::check_all_traces(res,expected,conf));
 }
 

--- a/src/POWERExecution.cpp
+++ b/src/POWERExecution.cpp
@@ -2293,6 +2293,7 @@ llvm::GenericValue POWERInterpreter::getConstantValue(llvm::Constant *CPV){
 void POWERInterpreter::callAssume(llvm::Function *F){
   bool cond = getOperandValue(0).IntVal.getBoolValue();
   if(!cond){
+    setAssumeBlocked(true);
     Threads[CurrentThread].ECStack.clear();
     AtExitHandlers.clear();
     /* Do not call terminate. We don't want to explicitly terminate

--- a/src/POWERInterpreter.h
+++ b/src/POWERInterpreter.h
@@ -41,6 +41,7 @@
 #include "CPid.h"
 #include "POWERARMTraceBuilder.h"
 #include "vecset.h"
+#include "DPORInterpreter.h"
 
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/GenericValue.h>
@@ -79,7 +80,7 @@ namespace llvm{
 
 // Interpreter - This class represents the entirety of the interpreter.
 //
-class POWERInterpreter : public llvm::ExecutionEngine, public llvm::InstVisitor<POWERInterpreter> {
+class POWERInterpreter : public DPORInterpreter, public llvm::InstVisitor<POWERInterpreter> {
 public:
   typedef llvm::generic_gep_type_iterator<llvm::User::const_op_iterator> gep_type_iterator;
 
@@ -256,9 +257,10 @@ public:
 
   /// Create an interpreter ExecutionEngine.
   ///
-  static llvm::ExecutionEngine *create(llvm::Module *M, POWERARMTraceBuilder &TB,
-                                       const Configuration &conf = Configuration::default_conf,
-                                       std::string *ErrorStr = nullptr);
+  static std::unique_ptr<POWERInterpreter>
+  create(llvm::Module *M, POWERARMTraceBuilder &TB,
+         const Configuration &conf = Configuration::default_conf,
+         std::string *ErrorStr = nullptr);
 
   /// run - Start execution with the specified function and arguments.
   ///

--- a/src/POWER_test.cpp
+++ b/src/POWER_test.cpp
@@ -2982,7 +2982,8 @@ declare i32 @pthread_create(i64*,%attr_t*,i8*(i8*)*,i8*)
   DPORDriver::Result res = driver->run();
   delete driver;
   BOOST_CHECK(!res.has_errors());
-  BOOST_CHECK(res.trace_count == 3);
+  BOOST_CHECK_EQUAL(res.trace_count, 2);
+  BOOST_CHECK_EQUAL(res.assume_blocked_trace_count, 1);
 }
 
 BOOST_AUTO_TEST_CASE(LB_assume_2){
@@ -3015,7 +3016,8 @@ declare i32 @pthread_create(i64*,%attr_t*,i8*(i8*)*,i8*)
   DPORDriver::Result res = driver->run();
   delete driver;
   BOOST_CHECK(!res.has_errors());
-  BOOST_CHECK(res.trace_count == 4);
+  BOOST_CHECK_EQUAL(res.trace_count, 4);
+  BOOST_CHECK_EQUAL(res.assume_blocked_trace_count, 0);
 }
 
 BOOST_AUTO_TEST_CASE(LB_assume_3){
@@ -3048,7 +3050,8 @@ declare i32 @pthread_create(i64*,%attr_t*,i8*(i8*)*,i8*)
   DPORDriver::Result res = driver->run();
   delete driver;
   BOOST_CHECK(!res.has_errors());
-  BOOST_CHECK(res.trace_count == 1);
+  BOOST_CHECK_EQUAL(res.trace_count, 0);
+  BOOST_CHECK_EQUAL(res.assume_blocked_trace_count, 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/PSOInterpreter.cpp
+++ b/src/PSOInterpreter.cpp
@@ -50,9 +50,9 @@ bool PSOInterpreter::PSOThread::readable(const SymAddrSize &ml) const {
   return true;
 }
 
-llvm::ExecutionEngine *PSOInterpreter::create(llvm::Module *M, PSOTraceBuilder &TB,
-                                              const Configuration &conf,
-                                              std::string *ErrorStr){
+std::unique_ptr<PSOInterpreter> PSOInterpreter::
+create(llvm::Module *M, PSOTraceBuilder &TB, const Configuration &conf,
+       std::string *ErrorStr){
 #ifdef LLVM_MODULE_MATERIALIZE_ALL_PERMANENTLY_ERRORCODE_BOOL
   if(std::error_code EC = M->materializeAllPermanently()){
     // We got an error, just return 0
@@ -83,7 +83,7 @@ llvm::ExecutionEngine *PSOInterpreter::create(llvm::Module *M, PSOTraceBuilder &
   }
 #endif
 
-  return new PSOInterpreter(M,TB,conf);
+  return std::unique_ptr<PSOInterpreter>(new PSOInterpreter(M,TB,conf));
 }
 
 void PSOInterpreter::runAux(int proc, int aux){

--- a/src/PSOInterpreter.h
+++ b/src/PSOInterpreter.h
@@ -34,9 +34,10 @@ public:
                           const Configuration &conf = Configuration::default_conf);
   virtual ~PSOInterpreter();
 
-  static llvm::ExecutionEngine *create(llvm::Module *M, PSOTraceBuilder &TB,
-                                 const Configuration &conf = Configuration::default_conf,
-                                 std::string *ErrorStr = 0);
+  static std::unique_ptr<PSOInterpreter>
+  create(llvm::Module *M, PSOTraceBuilder &TB,
+         const Configuration &conf = Configuration::default_conf,
+         std::string *ErrorStr = 0);
 
   virtual void visitLoadInst(llvm::LoadInst &I);
   virtual void visitStoreInst(llvm::StoreInst &I);

--- a/src/Regression_test.cpp
+++ b/src/Regression_test.cpp
@@ -344,7 +344,8 @@ declare void @__VERIFIER_assume(i1)
 
   /* No trace_set_spec is provided, as it is too big to express in C++ */
   BOOST_CHECK(!res.has_errors());
-  BOOST_CHECK(res.trace_count == 3024);
+  BOOST_CHECK_EQUAL(res.trace_count, 1080);
+  BOOST_CHECK_EQUAL(res.assume_blocked_trace_count, 1944);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/TSOInterpreter.cpp
+++ b/src/TSOInterpreter.cpp
@@ -39,9 +39,9 @@ TSOInterpreter::TSOInterpreter(llvm::Module *M, TSOTraceBuilder &TB,
 TSOInterpreter::~TSOInterpreter(){
 }
 
-llvm::ExecutionEngine *TSOInterpreter::create(llvm::Module *M, TSOTraceBuilder &TB,
-                                              const Configuration &conf,
-                                              std::string *ErrorStr){
+std::unique_ptr<TSOInterpreter> TSOInterpreter::
+create(llvm::Module *M, TSOTraceBuilder &TB, const Configuration &conf,
+       std::string *ErrorStr){
 #ifdef LLVM_MODULE_MATERIALIZE_ALL_PERMANENTLY_ERRORCODE_BOOL
   if(std::error_code EC = M->materializeAllPermanently()){
     // We got an error, just return 0
@@ -72,7 +72,7 @@ llvm::ExecutionEngine *TSOInterpreter::create(llvm::Module *M, TSOTraceBuilder &
   }
 #endif
 
-  return new TSOInterpreter(M,TB,conf);
+  return std::unique_ptr<TSOInterpreter>(new TSOInterpreter(M,TB,conf));
 }
 
 void TSOInterpreter::runAux(int proc, int aux){

--- a/src/TSOInterpreter.h
+++ b/src/TSOInterpreter.h
@@ -34,9 +34,10 @@ public:
                           const Configuration &conf = Configuration::default_conf);
   virtual ~TSOInterpreter();
 
-  static llvm::ExecutionEngine *create(llvm::Module *M, TSOTraceBuilder &TB,
-                                 const Configuration &conf = Configuration::default_conf,
-                                 std::string *ErrorStr = 0);
+  static std::unique_ptr<TSOInterpreter>
+  create(llvm::Module *M, TSOTraceBuilder &TB,
+         const Configuration &conf = Configuration::default_conf,
+         std::string *ErrorStr = 0);
 
   virtual void visitLoadInst(llvm::LoadInst &I);
   virtual void visitStoreInst(llvm::StoreInst &I);

--- a/src/Unroll_test.cpp
+++ b/src/Unroll_test.cpp
@@ -220,9 +220,10 @@ declare i32 @pthread_create(i64*, %attr_t*, i8*(i8*)*, i8*) nounwind
   DPORDriver::Result res = driver->run();
   delete driver;
 
-  BOOST_CHECK(!res.has_errors());
   BOOST_CHECK(!tres.has_errors());
-  BOOST_CHECK(res.trace_count == tres.trace_count);
+  BOOST_CHECK(!res.has_errors());
+  BOOST_CHECK_EQUAL(tres.trace_count + tres.assume_blocked_trace_count,
+                    res.trace_count);
 }
 
 BOOST_AUTO_TEST_CASE(Termination_1){
@@ -391,7 +392,8 @@ declare i32 @pthread_create(i64*, %attr_t*, i8*(i8*)*, i8*) nounwind
   delete driver;
 
   BOOST_CHECK(tres.has_errors() == res.has_errors());
-  BOOST_CHECK(tres.trace_count == res.trace_count);
+  BOOST_CHECK_EQUAL(tres.trace_count + tres.assume_blocked_trace_count,
+                    res.trace_count);
 }
 
 BOOST_AUTO_TEST_CASE(PHI_exit){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,9 +110,13 @@ int main(int argc, char *argv[]){
         DPORDriver::parseIRFile(cl_input_file,conf);
 
       DPORDriver::Result res = driver->run();
-      std::cout << "Trace count: " << res.trace_count
-                << " (also " << res.sleepset_blocked_trace_count
-                << " sleepset blocked)" << std::endl;
+      std::cout << "Trace count: " << res.trace_count << std::endl;
+      if (res.assume_blocked_trace_count > 0)
+        std::cout << "Assume-blocked trace count: "
+                  << res.assume_blocked_trace_count << std::endl;
+      if (res.sleepset_blocked_trace_count > 0)
+        std::cout << "Sleepset-blocked trace count: "
+                  << res.sleepset_blocked_trace_count << std::endl;
       if(res.has_errors()){
         errors_detected = true;
         std::cout << "\n Error detected:\n"


### PR DESCRIPTION
Trace count will now be subdivided into consistent traces, and
assume-blocked traces. The output format for trace counts at the end of
exploration is changed to print each class on a separate line, easing
readability for humans and parsability for scripts:
```
Trace count: 1080
Assume-blocked trace count: 1944
Sleepset-blocked trace count: 1188
No errors were detected.
Total wall-clock time: 1.41 s
```

