### PR TITLE
Travis: Fix building against older libstdc++ with clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,28 +35,26 @@ _bionic-clang-env-conf:
 
 matrix:
   include:
-    ## Immer dependency is currently incompatible with libstdc++ on the
-    ## following builds:
-    # - <<: *xenial
-    #   env:
-    #     - *xenial-clang-env
-    #     - LLVM_VERSION=3.8.1  # default on Debian stretch - does NOT work yet
-    # - <<: *xenial
-    #   env:
-    #     - *xenial-clang-env
-    #     - LLVM_VERSION=3.9.1
-    # - <<: *xenial
-    #   env:
-    #     - *xenial-clang-env
-    #     - LLVM_VERSION=4.0.0
-    # - <<: *xenial
-    #   env:
-    #     - *xenial-clang-env
-    #     - LLVM_VERSION=5.0.2
-    # - <<: *xenial
-    #   env:
-    #     - *xenial-clang-env
-    #     - LLVM_VERSION=6.0.1
+    - <<: *xenial
+      env:
+        - *xenial-clang-env
+        - LLVM_VERSION=3.8.1  # default on Debian stretch - does NOT work yet
+    - <<: *xenial
+      env:
+        - *xenial-clang-env
+        - LLVM_VERSION=3.9.1
+    - <<: *xenial
+      env:
+        - *xenial-clang-env
+        - LLVM_VERSION=4.0.0
+    - <<: *xenial
+      env:
+        - *xenial-clang-env
+        - LLVM_VERSION=5.0.2
+    - <<: *xenial
+      env:
+        - *xenial-clang-env
+        - LLVM_VERSION=6.0.1
     - <<: *bionic
       env:
         - *bionic-clang-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,16 @@ _bionic-clang-env-conf:
 matrix:
   include:
     - <<: *xenial
+      addons:
+        apt:
+          packages:
+            - *baseline-packages
+            - llvm-3.8-dev
+            - clang-3.8
       env:
-        - *xenial-clang-env
-        - LLVM_VERSION=3.8.1  # default on Debian stretch - does NOT work yet
+        - DOWNLOAD_BOOST=1.64.0
+        - CONFIGURE_FLAGS="--with-llvm=/usr/lib/llvm-3.8/ --with-boost=`pwd`/cache/boost"
+      compiler: clang # Not working with GCC
     - <<: *xenial
       env:
         - *xenial-clang-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ _bionic-conf: &bionic
   dist: bionic
   addons:
     apt:
-      packages:
+      packages: &bionic-packages
         - *baseline-packages
         - libboost-test-dev
         - libboost-system-dev
@@ -51,10 +51,14 @@ matrix:
       env:
         - *xenial-clang-env
         - LLVM_VERSION=5.0.2
-    - <<: *xenial
-      env:
-        - *xenial-clang-env
-        - LLVM_VERSION=6.0.1
+    - <<: *bionic
+      addons:
+        apt:
+          packages:
+            - *bionic-packages
+            - llvm-6.0-dev
+            - clang-6.0
+      env: CONFIGURE_FLAGS=--with-llvm=/usr/lib/llvm-6.0/
     - <<: *bionic
       env:
         - *bionic-clang-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before_script:
   - ./travis/install_deps.sh
   - export LLVM_DIR=$PWD/cache/clang+llvm-$LLVM_VERSION
   - export PATH=$LLVM_DIR/bin:$PATH
-  - export LD_LIBRARY_PATH="$LLVM_DIR/lib $PWD/cache/boost/lib"
+  - export LD_LIBRARY_PATH="$LLVM_DIR/lib:$PWD/cache/boost/lib"
   - autoreconf --install
   - ./configure CXXFLAGS="-I"`pwd`"/deps/immer/" $CONFIGURE_FLAGS || (cat config.log; false)
   - make -Csrc -j6 all unittest

--- a/travis/install_deps.sh
+++ b/travis/install_deps.sh
@@ -71,7 +71,7 @@ if [ -n "$DOWNLOAD_BOOST" ]; then
         pushd $BOOST_DIR
 
         echo "Building Boost"
-        ./bootstrap.sh --prefix=../cache/boost --with-libraries=test,system
+        ./bootstrap.sh --prefix=../cache/boost --with-libraries=test,system,timer
         ./b2 -j6 -d0
         ./b2 install -d0
 

--- a/travis/install_deps.sh
+++ b/travis/install_deps.sh
@@ -2,57 +2,59 @@
 mkdir -p cache
 
 # LLVM
-LLVM_TRIPLE=x86_64-linux-gnu
-LLVM_OS=ubuntu
-LLVM_REL_EXT=tar.xz
+if [ -n "$LLVM_VERSION" ]; then
+    LLVM_TRIPLE=x86_64-linux-gnu
+    LLVM_OS=ubuntu
+    LLVM_REL_EXT=tar.xz
 
-case $LLVM_VERSION in
-    3.[89]*|[4-6].*)
-        LLVM_UBUNTU_VER=16.04
-        ;;
-    ?*)
-        LLVM_UBUNTU_VER=18.04
-        ;;
-esac
-LLVM_URL="http://releases.llvm.org/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-$LLVM_TRIPLE-$LLVM_OS-$LLVM_UBUNTU_VER.$LLVM_REL_EXT"
-LLVM_DEP="cache/$LLVM_VERSION.$LLVM_REL_EXT"
-LLVM_DIR="cache/clang+llvm-$LLVM_VERSION"
-
-echo $LLVM_URL
-echo $LLVM_DEP
-echo $LLVM_DIR
-
-# download and install
-if [ ! -f $LLVM_DEP ] ; then
-    echo "Downloading LLVM"
-    wget $LLVM_URL -O $LLVM_DEP
-    if [ ! $? -eq 0 ]; then
-	echo "Error: Download failed"
-	rm $LLVM_DEP || true
-	exit 1
-    fi
-else
-    echo "Found Cached Archive"
-fi
-
-if [ ! -d $LLVM_DIR ] ; then
-    echo "Extracting LLVM"
-    tar -xf $LLVM_DEP -C cache/
-    if [ ! $? -eq 0 ]; then
-	echo "Error: Extraction Failed"
-	rm $LLVM_DEP || true
-	exit 1
-    fi
     case $LLVM_VERSION in
-        3.5.*)
-	    mv cache/clang+llvm-$LLVM_VERSION-$LLVM_TRIPLE cache/clang+llvm-$LLVM_VERSION
-	    ;;
+        3.[89]*|[4-6].*)
+            LLVM_UBUNTU_VER=16.04
+            ;;
         ?*)
-            mv cache/clang+llvm-$LLVM_VERSION-$LLVM_TRIPLE-$LLVM_OS-$LLVM_UBUNTU_VER cache/clang+llvm-$LLVM_VERSION
-	    ;;
+            LLVM_UBUNTU_VER=18.04
+            ;;
     esac
-else
-    echo "Found Cached Installation"
+    LLVM_URL="http://releases.llvm.org/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-$LLVM_TRIPLE-$LLVM_OS-$LLVM_UBUNTU_VER.$LLVM_REL_EXT"
+    LLVM_DEP="cache/$LLVM_VERSION.$LLVM_REL_EXT"
+    LLVM_DIR="cache/clang+llvm-$LLVM_VERSION"
+
+    echo $LLVM_URL
+    echo $LLVM_DEP
+    echo $LLVM_DIR
+
+    # download and install
+    if [ ! -f $LLVM_DEP ] ; then
+        echo "Downloading LLVM"
+        wget $LLVM_URL -O $LLVM_DEP
+        if [ ! $? -eq 0 ]; then
+	    echo "Error: Download failed"
+	    rm $LLVM_DEP || true
+	    exit 1
+        fi
+    else
+        echo "Found Cached Archive"
+    fi
+
+    if [ ! -d $LLVM_DIR ] ; then
+        echo "Extracting LLVM"
+        tar -xf $LLVM_DEP -C cache/
+        if [ ! $? -eq 0 ]; then
+	    echo "Error: Extraction Failed"
+	    rm $LLVM_DEP || true
+	    exit 1
+        fi
+        case $LLVM_VERSION in
+            3.5.*)
+	        mv cache/clang+llvm-$LLVM_VERSION-$LLVM_TRIPLE cache/clang+llvm-$LLVM_VERSION
+	        ;;
+            ?*)
+                mv cache/clang+llvm-$LLVM_VERSION-$LLVM_TRIPLE-$LLVM_OS-$LLVM_UBUNTU_VER cache/clang+llvm-$LLVM_VERSION
+	        ;;
+        esac
+    else
+        echo "Found Cached Installation"
+    fi
 fi
 
 # Boost


### PR DESCRIPTION
There was a problem with building against libstdc++ 5.4 with clang, which we required for our Travis CI. Now, our immer dependency has fixed this problem, and so we can test against all supported versions of LLVM on Travis again.

Additionally, our Travis script was not building boost correctly, which is also fixed here.

Finally, we use native Ubuntu LLVM versions where possible, to have a testing environment closer to what users might have.