### PR TITLE
Fix linking against LLVM in nonstandard locations

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,8 +52,8 @@ EXTRA_PROGRAMS = nidhuggc
 bin_PROGRAMS = nidhugg @NIDHUGGCBIN@
 nidhugg_SOURCES = main.cpp
 nidhugg_LDADD = libnidhugg.a @BOOST_SYSTEM_LIB@
-nidhugg_LDFLAGS = -pthread @BOOST_LDFLAGS@
-nidhugg_CXXFLAGS = -fno-rtti @BOOST_CPPFLAGS@
+nidhugg_LDFLAGS = -pthread
+nidhugg_CXXFLAGS = -fno-rtti
 nidhuggc_SOURCES = nidhuggc.py
 
 TESTS = unittest
@@ -83,8 +83,7 @@ unittest_SOURCES = \
   VClock_int_test.cpp \
   unittest.cpp
 unittest_LDADD=libnidhugg.a @BOOST_SYSTEM_LIB@ @BOOST_UNIT_TEST_FRAMEWORK_LIB@
-unittest_LDFLAGS=-pthread @BOOST_LDFLAGS@
-unittest_CXXFLAGS=@BOOST_CPPFLAGS@
+unittest_LDFLAGS=-pthread
 
 
 ## Run only the tests matching UTEST. Default: all.


### PR DESCRIPTION
Due to incorrect ordering of linker flags of dependencies, trying to
compile against an LLVM build in a nonstandard location would still have
the linker search the system library directory first, leading to the
wrong copy of LLVM being linked against.

Fixes: d93c5f0b3 "configure: Add boost flags to global flags"