### PR TITLE
.travis.yml: speedup: Reverse order of LLVM versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,34 @@ _bionic-clang-env-conf:
 
 matrix:
   include:
+    - <<: *bionic
+      env: LLVM_VERSION=9.0.0
+    - <<: *bionic
+      env: LLVM_VERSION=8.0.0
+    - <<: *bionic
+      env:
+        - *bionic-clang-env
+        - LLVM_VERSION=7.0.1
+    - <<: *bionic
+      addons:
+        apt:
+          packages:
+            - *bionic-packages
+            - llvm-6.0-dev
+            - clang-6.0
+      env: CONFIGURE_FLAGS=--with-llvm=/usr/lib/llvm-6.0/
+    - <<: *xenial
+      env:
+        - *xenial-clang-env
+        - LLVM_VERSION=5.0.2
+    - <<: *xenial
+      env:
+        - *xenial-clang-env
+        - LLVM_VERSION=4.0.0
+    - <<: *xenial
+      env:
+        - *xenial-clang-env
+        - LLVM_VERSION=3.9.1
     - <<: *xenial
       addons:
         apt:
@@ -46,34 +74,6 @@ matrix:
         - DOWNLOAD_BOOST=1.64.0
         - CONFIGURE_FLAGS="--with-llvm=/usr/lib/llvm-3.8/ --with-boost=`pwd`/cache/boost"
       compiler: clang # Not working with GCC
-    - <<: *xenial
-      env:
-        - *xenial-clang-env
-        - LLVM_VERSION=3.9.1
-    - <<: *xenial
-      env:
-        - *xenial-clang-env
-        - LLVM_VERSION=4.0.0
-    - <<: *xenial
-      env:
-        - *xenial-clang-env
-        - LLVM_VERSION=5.0.2
-    - <<: *bionic
-      addons:
-        apt:
-          packages:
-            - *bionic-packages
-            - llvm-6.0-dev
-            - clang-6.0
-      env: CONFIGURE_FLAGS=--with-llvm=/usr/lib/llvm-6.0/
-    - <<: *bionic
-      env:
-        - *bionic-clang-env
-        - LLVM_VERSION=7.0.1
-    - <<: *bionic
-      env: LLVM_VERSION=8.0.0
-    - <<: *bionic
-      env: LLVM_VERSION=9.0.0
 
 before_script:
   - ./travis/install_deps.sh


### PR DESCRIPTION
This speeds up the total time to completion because of better
utilisation of parallel resources, as the latest LLVM versions are the
slowest to check against (mostly due to valgrind running much slower on
binaries produced by gcc).