### PR TITLE
Rename some options and cleanup --help

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -296,7 +296,7 @@ int main(int argc, char *argv[]){
   \textbf{Optimal-DPOR, Optimal-DPOR with Observers, and Optimal
     Reads-From-centric SMC algorithms are supported only for the SC memory
     model.}
-\item{\texttt{--robustness}}
+\item{\texttt{--check-robustness}}
 %
   Perform a robustness analysis. In addition to considering the usual
   safety criteria, also check robustness, and report an error if a

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -320,7 +320,7 @@ int main(int argc, char *argv[]){
   analyzed.
 %
   \limitsupport{SC, TSO, PSO}
-\item{\texttt{--disable-mutex-init-requirement}}
+\item{\texttt{--no-check-mutex-init}}
 %
   If this switch is given, the operations lock, trylock, unlock,
   destroy, cond\_wait are allowed to operate on mutex variables

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -32,9 +32,15 @@ cl_transform("transform",llvm::cl::init(""),
              llvm::cl::desc("Transform the input module and store it (as LLVM assembly) to OUTFILE."),
              llvm::cl::NotHidden,llvm::cl::value_desc("OUTFILE"));
 
-static llvm::cl::opt<bool> cl_explore_all("explore-all",llvm::cl::NotHidden,
+static llvm::cl::opt<bool> cl_keep_going("keep-going",llvm::cl::NotHidden,
                                           llvm::cl::desc("Continue exploring all traces, "
                                                          "even after the first error"));
+static llvm::cl::alias cl_k("k",llvm::cl::Hidden,llvm::cl::desc("Alias for --keep-going"),
+                            llvm::cl::aliasopt(cl_keep_going));
+// Previous name
+static llvm::cl::alias cl_explore_all("explore-all",llvm::cl::Hidden,
+                                      llvm::cl::desc("Alias for --keep-going"),
+                                      llvm::cl::aliasopt(cl_keep_going));
 
 static llvm::cl::opt<bool> cl_malloc_may_fail("malloc-may-fail",llvm::cl::NotHidden,
                                               llvm::cl::desc("If set then the case of malloc failure is also explored."));
@@ -122,7 +128,7 @@ static llvm::cl::opt<bool> cl_debug_print_on_reset
 
 const std::set<std::string> &Configuration::commandline_opts(){
   static std::set<std::string> opts = {
-    "dpor-explore-all",
+    "keep-going",
     "extfun-no-race",
     "malloc-may-fail",
     "disable-mutex-init-requirement",
@@ -142,7 +148,7 @@ const std::set<std::string> &Configuration::commandline_opts(){
 const Configuration Configuration::default_conf;
 
 void Configuration::assign_by_commandline(){
-  explore_all_traces = cl_explore_all;
+  explore_all_traces = cl_keep_going;
   for(std::string f : cl_extfun_no_race){
     extfun_no_full_memory_conflict.insert(f);
   }

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -45,8 +45,13 @@ static llvm::cl::alias cl_explore_all("explore-all",llvm::cl::Hidden,
 static llvm::cl::opt<bool> cl_malloc_may_fail("malloc-may-fail",llvm::cl::NotHidden,
                                               llvm::cl::desc("If set then the case of malloc failure is also explored."));
 
-static llvm::cl::opt<bool> cl_disable_mutex_init_requirement("disable-mutex-init-requirement",llvm::cl::NotHidden,
-                                                             llvm::cl::desc("If set, then allow use of mutexes without a preceding call to pthread_mutex_init.\nThis switch is necessary when using static mutex initialization."));
+static llvm::cl::opt<bool> cl_no_check_mutex_init("no-check-mutex-init",llvm::cl::NotHidden,
+                                                  llvm::cl::desc("If set, then allow use of mutexes without a preceding call to pthread_mutex_init.\nThis switch is necessary when using static mutex initialization."));
+// Previous name
+static llvm::cl::alias cl_disable_mutex_init_requirement
+("disable-mutex-init-requirement",llvm::cl::Hidden,
+ llvm::cl::desc("Alias for --no-check-mutex-init"),
+ llvm::cl::aliasopt(cl_no_check_mutex_init));
 
 static llvm::cl::opt<int>
 cl_max_search_depth("max-search-depth",
@@ -131,7 +136,7 @@ const std::set<std::string> &Configuration::commandline_opts(){
     "keep-going",
     "extfun-no-race",
     "malloc-may-fail",
-    "disable-mutex-init-requirement",
+    "no-check-mutex-init",
     "max-search-depth",
     "sc","tso","pso","power","arm",
     "smtlib",
@@ -153,7 +158,7 @@ void Configuration::assign_by_commandline(){
     extfun_no_full_memory_conflict.insert(f);
   }
   malloc_may_fail = cl_malloc_may_fail;
-  mutex_require_init = !cl_disable_mutex_init_requirement;
+  mutex_require_init = !cl_no_check_mutex_init;
   max_search_depth = cl_max_search_depth;
   memory_model = cl_memory_model;
   c11 = cl_c11;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -100,8 +100,12 @@ cl_dpor_algorithm(llvm::cl::NotHidden, llvm::cl::init(Configuration::SOURCE),
 #endif
                                  ));
 
-static llvm::cl::opt<bool> cl_check_robustness("robustness",llvm::cl::NotHidden,
+static llvm::cl::opt<bool> cl_check_robustness("check-robustness",llvm::cl::NotHidden,
                                                llvm::cl::desc("Check for robustness as a correctness criterion."));
+// Previous name
+static llvm::cl::alias cl_robustness("robustness",llvm::cl::Hidden,
+                                     llvm::cl::desc("Alias for --check-robustness"),
+                                     llvm::cl::aliasopt(cl_check_robustness));
 
 static llvm::cl::OptionCategory cl_transformation_cat("Module Transformation Passes");
 
@@ -141,7 +145,7 @@ const std::set<std::string> &Configuration::commandline_opts(){
     "sc","tso","pso","power","arm",
     "smtlib",
     "source","optimal","observers","rf",
-    "robustness",
+    "check-robustness",
     "no-spin-assume",
     "unroll",
     "print-progress",

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -23,6 +23,10 @@
 #include "Debug.h"
 #include "SmtlibSatSolver.h"
 
+/* Please keep (non-hidden) option names to 23 characters and
+ * descriptions wrapped to 47 characters.
+ */
+
 llvm::cl::list<std::string>
 cl_program_arguments(llvm::cl::desc("[-- <program arguments>...]"),
                      llvm::cl::Positional,
@@ -33,8 +37,8 @@ cl_transform("transform",llvm::cl::init(""),
              llvm::cl::NotHidden,llvm::cl::value_desc("OUTFILE"));
 
 static llvm::cl::opt<bool> cl_keep_going("keep-going",llvm::cl::NotHidden,
-                                          llvm::cl::desc("Continue exploring all traces, "
-                                                         "even after the first error"));
+                                          llvm::cl::desc("Continue exploring all traces,\n"
+                                                         "even after the first error (also -k)"));
 static llvm::cl::alias cl_k("k",llvm::cl::Hidden,llvm::cl::desc("Alias for --keep-going"),
                             llvm::cl::aliasopt(cl_keep_going));
 // Previous name
@@ -43,10 +47,13 @@ static llvm::cl::alias cl_explore_all("explore-all",llvm::cl::Hidden,
                                       llvm::cl::aliasopt(cl_keep_going));
 
 static llvm::cl::opt<bool> cl_malloc_may_fail("malloc-may-fail",llvm::cl::NotHidden,
-                                              llvm::cl::desc("If set then the case of malloc failure is also explored."));
+                                              llvm::cl::desc("Also explore the case of malloc failure."));
 
 static llvm::cl::opt<bool> cl_no_check_mutex_init("no-check-mutex-init",llvm::cl::NotHidden,
-                                                  llvm::cl::desc("If set, then allow use of mutexes without a preceding call to pthread_mutex_init.\nThis switch is necessary when using static mutex initialization."));
+                                                  llvm::cl::desc("If set, then allow use of mutexes without a\n"
+                                                                 "preceding call to pthread_mutex_init.\n"
+                                                                 "This switch is necessary when using static mutex\n"
+                                                                 "initialization."));
 // Previous name
 static llvm::cl::alias cl_disable_mutex_init_requirement
 ("disable-mutex-init-requirement",llvm::cl::Hidden,
@@ -56,7 +63,8 @@ static llvm::cl::alias cl_disable_mutex_init_requirement
 static llvm::cl::opt<int>
 cl_max_search_depth("max-search-depth",
                     llvm::cl::NotHidden,llvm::cl::init(-1),
-                    llvm::cl::desc("Bound the length of the analysed computations (# instructions/events per process)"));
+                    llvm::cl::desc("Bound the length of the analysed computations\n"
+                                   "(# instructions/events per process)"));
 
 static llvm::cl::opt<int>
 cl_verifier_nondet_int("verifier-nondet-int",
@@ -110,26 +118,28 @@ static llvm::cl::alias cl_robustness("robustness",llvm::cl::Hidden,
 static llvm::cl::OptionCategory cl_transformation_cat("Module Transformation Passes");
 
 static llvm::cl::opt<bool> cl_transform_no_spin_assume("no-spin-assume",llvm::cl::NotHidden,llvm::cl::cat(cl_transformation_cat),
-                                                       llvm::cl::desc("Disable the spin assume pass in module transformation."));
+                                                       llvm::cl::desc("Disable the spin assume pass in module\n"
+                                                                      "transformation."));
 
 static llvm::cl::opt<int>
 cl_transform_loop_unroll("unroll",
                          llvm::cl::NotHidden,llvm::cl::init(-1),llvm::cl::value_desc("N"),
                          llvm::cl::cat(cl_transformation_cat),
-                         llvm::cl::desc("Bound executions by allowing loops to iterate at most N times."));
+                         llvm::cl::desc("Bound executions by allowing loops to iterate at\n"
+                                        "most N times."));
 
 static llvm::cl::opt<bool> cl_print_progress("print-progress",llvm::cl::NotHidden,
                                              llvm::cl::desc("Continually print analysis progress to stdout."));
 
 static llvm::cl::opt<bool> cl_print_progress_estimate("print-progress-estimate",llvm::cl::NotHidden,
-                                                      llvm::cl::desc("Continually print analysis progress and trace "
+                                                      llvm::cl::desc("Continually print analysis progress and trace\n"
                                                                      "number estimate to stdout."));
 
 static llvm::cl::list<std::string> cl_extfun_no_race("extfun-no-race",llvm::cl::NotHidden,
                                                          llvm::cl::value_desc("FUN"),
-                                                         llvm::cl::desc("Assume that the external function FUN, when called as blackbox,\n"
-                                                                        "does not participate in any races. (See manual.)\n"
-                                                                        "May be given multiple times."));
+                                                         llvm::cl::desc("Assume that the external function FUN, when called\n"
+                                                                        "as blackbox, does not participate in any races.\n"
+                                                                        "(See manual) May be given multiple times."));
 
 static llvm::cl::opt<bool> cl_debug_print_on_reset
 ("debug-print-on-reset",llvm::cl::Hidden,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,6 +96,16 @@ int main(int argc, char *argv[]){
       if(visible_options.count(it->getKey()) == 0){
         it->getValue()->setHiddenFlag(llvm::cl::Hidden);
       }
+      if (it->getKey() == "help-list") {
+        /* Hide --help-list-hidden from --help-list description; there
+         * be dragons ('s options that we are pulling in due to how we
+         * link)
+         *
+         * This also fixes the problem that the --help-link description
+         * used to wrap
+         */
+        it->second->setDescription("Display list of available options");
+      }
     }
   }
   llvm::cl::ParseCommandLineOptions(argc, argv);


### PR DESCRIPTION
Wrap `--help` text to 80 characters and perform the following renames for consistency:

| Old name | New name |
| --- | --- | 
| `--explore-all` | `--keep-going` |
| `--disable-mutex-init-requirement` | `--no-check-mutex-init` |
| `--robustness` | `--check-robustness` |

All the old names are still available as aliases, they are just undocumented.