### PR TITLE
Make mallopt() optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,11 @@ AC_CHECK_HEADERS([ffi.h],[],[
   AC_CHECK_HEADERS([ffi/ffi.h],[],[AC_MSG_FAILURE([Could not find header ffi.h.])],[AC_INCLUDES_DEFAULT])
 ],[AC_INCLUDES_DEFAULT])
 
-AC_CHECK_HEADERS([valgrind/valgrind.h])
+AC_CHECK_HEADERS([ \
+  valgrind/valgrind.h \
+  malloc.h
+])
+AC_CHECK_FUNCS([mallopt])
 
 # Check various functions in LLVM
 

--- a/src/Execution.cpp
+++ b/src/Execution.cpp
@@ -3131,6 +3131,11 @@ void Interpreter::callFree(Function *F,
     abort();
     return;
   }
+  if(!AllocatedMemHeap.count(ptr)){
+    TB.memory_error("Attempt to free address not returned by malloc.");
+    abort();
+    return;
+  }
 
   auto pr = FreedMem.insert({ptr,TB.get_iid()});
 

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -38,7 +38,9 @@
 
 #include <csetjmp>
 #include <csignal>
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #ifdef HAVE_VALGRIND_VALGRIND_H
 #include <valgrind/valgrind.h>
 #endif
@@ -144,7 +146,9 @@ static void cf_handler(int signum){
 }
 
 static void CheckedFree(void *ptr, std::function<void()> &on_error){
+#ifdef HAVE_MALLOPT
   mallopt(M_CHECK_ACTION,2);
+#endif
   struct sigaction act, orig_act_segv, orig_act_abrt;
   act.sa_handler = cf_handler;
   act.sa_flags = SA_RESETHAND;
@@ -170,7 +174,9 @@ static void CheckedFree(void *ptr, std::function<void()> &on_error){
   }
   sigaction(SIGABRT,&orig_act_abrt,0);
   sigaction(SIGSEGV,&orig_act_segv,0);
+#ifdef HAVE_MALLOPT
   mallopt(M_CHECK_ACTION,3);
+#endif
 }
 
 Interpreter::~Interpreter() {


### PR DESCRIPTION
This allows builds with libc's that lack `mallopt()`, such as that on mac.