### PR TITLE
configure: Autodetect immer from submodule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_script:
   - export PATH=$LLVM_DIR/bin:$PATH
   - export LD_LIBRARY_PATH="$LLVM_DIR/lib:$PWD/cache/boost/lib"
   - autoreconf --install
-  - ./configure CXXFLAGS="-I"`pwd`"/deps/immer/" $CONFIGURE_FLAGS || (cat config.log; false)
+  - ./configure $CONFIGURE_FLAGS || (cat config.log; false)
   - make -Csrc -j6 all unittest
 script:
   - make test && make valtest

--- a/README
+++ b/README
@@ -88,11 +88,10 @@ Basic Installation
 
       $ autoreconf --install
 
-   3. Build as usual. Make sure to pass the include flag for the immer
-      dependency, as shown below. See Installation Options below for options
-      about e.g. installation location.
+   3. Build as usual. See Installation Options below for options about e.g.
+      installation location.
 
-      $ ./configure CXXFLAGS="-I../deps/immer"
+      $ ./configure
       $ make
 
    4. Install:

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,22 @@ PKG_CHECK_MODULES([FFI], [libffi], [
 ],[
   AC_CHECK_LIB([ffi], [ffi_call],[],[AC_MSG_FAILURE([Could not find library libffi.])])
 ])
+AC_CHECK_HEADER([immer/vector.hpp],[],[
+    AC_MSG_NOTICE([Using immer library from submodule.])
+    old_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS -I$srcdir/deps/immer"
+    # Hack: Undo caching of test
+    unset ac_cv_header_immer_vector_hpp
+    AC_CHECK_HEADER([immer/vector.hpp],[
+        CPPFLAGS="$old_CPPFLAGS -I$(realpath --relative-to="./src" "$srcdir/deps/immer")"
+    ],[
+        AC_MSG_WARN([Nidhugg requires the "immer" library.])
+        AC_MSG_WARN([It is included as a submodule, but it seems like it has not been updated.])
+        AC_MSG_WARN([Run "git submodule update --init" and then try configuring again.])
+        AC_MSG_FAILURE([Could not find immer headers.])
+    ])
+])
+
 BUILDNIDHUGGC='yes'
 AC_ARG_ENABLE([nidhuggc],[AS_HELP_STRING([--disable-nidhuggc],[Don't build the script nidhuggc.])],
               [if test "x$enableval" = "xno"; then

--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,11 @@ AC_CHECK_HEADER([immer/vector.hpp],[],[
     # Hack: Undo caching of test
     unset ac_cv_header_immer_vector_hpp
     AC_CHECK_HEADER([immer/vector.hpp],[
-        CPPFLAGS="$old_CPPFLAGS -I$(realpath --relative-to="./src" "$srcdir/deps/immer")"
+        case "$srcdir" in
+            (/*) immer_dir=$srcdir/deps/immer;;
+            (*)  immer_dir=../$srcdir/deps/immer;;
+        esac
+        CPPFLAGS="$old_CPPFLAGS -I$immer_dir"
     ],[
         AC_MSG_WARN([Nidhugg requires the "immer" library.])
         AC_MSG_WARN([It is included as a submodule, but it seems like it has not been updated.])


### PR DESCRIPTION
Now, the ugly `CXXFLAGS=` argument is not required, and `configure` prints a
helpful message if the user forgets to pull the submodule.