### PR TITLE
Transform: Fix LLVM linker data layout warning

### DIFF
--- a/src/AddLibPass.cpp
+++ b/src/AddLibPass.cpp
@@ -68,6 +68,8 @@ bool AddLibPass::optAddFunction(llvm::Module &M,
   for(auto it = srces.begin(); !added_def && it != srces.end(); ++it){
     std::string src = StrModule::portasm(*it);
     llvm::Module *M2 = StrModule::read_module_src(src);
+    /* Not really true, but silences linker warnings */
+    M2->setDataLayout(M.getDataLayout());
 
     if(!tgtTy || M2->getFunction(name)->getType() == tgtTy){
 #ifdef LLVM_LINKER_LINKINMODULE_PTR_BOOL


### PR DESCRIPTION
In recent LLVM versions, the bitcode rewrites have started printing
messages like

```
  warning: Linking two modules of different data layouts: '' is ''
  whereas '/tmp/tmpc5wuazqs/tmp4ekn5mwm.ll' is
  'e-m:e-i64:64-f80:128-n8:16:32:64-S128'
```

These are caused by AddLibPass when it inserts definitions of common
functions into the module, since these do not have a set data layout.

However, AddLibPass has its own mechanism for matching the data layout
of the module it is modifying, so we set the data layout of the
functions we are adding to the same as of the module we're modifying.