### PR TITLE
Replace immer with new "generational" data structures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/immer"]
-	path = deps/immer
-	url = https://github.com/arximboldi/immer

--- a/README
+++ b/README
@@ -85,25 +85,21 @@ Basic Installation
    The following assumes that you are in a shell in the main directory
    of Nidhugg.
 
-   1. Pull all dependency submodules
-
-      $ git submodule update --init
-
-   2. Use GNU Autotools to build the configure script:
+   1. Use GNU Autotools to generate the configure script:
 
       $ autoreconf --install
 
-   3. Build as usual. See Installation Options below for options about e.g.
+   2. Build as usual. See Installation Options below for options about e.g.
       installation location.
 
       $ ./configure
       $ make
 
-   4. Install:
+   3. Install:
 
       $ make install
 
-   5. Optionally run test suite (Boost Unit Test Framework required):
+   4. Optionally run test suite (Boost Unit Test Framework required):
 
       $ make test
 

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,46 @@ AC_ARG_ENABLE([build-documentation],
    BUILDPDFDOCUMENTATION='no']
   )
 
+# Check if we can enable the x86 popcnt instruction
+AC_CANONICAL_HOST
+case "$host_cpu" in
+  (i?86|x86_64) popcnt_flag="-mpopcnt";;
+  (*)           popcnt_flag="no";;
+esac
+AC_ARG_ENABLE([popcnt], [AS_HELP_STRING([--disable-popcnt],[Do not try to use the popcnt instruction])] ,
+  [if test "x$enableval" != "xno"; then
+      if test "x$enableval" != "xyes"; then
+         popcnt_flag="$enableval"
+      fi
+      AC_MSG_NOTICE([Forcing popcnt usage on with flag $enableval.])
+      old_CXXFLAGS="$CXXFLAGS"
+      old_CFLAGS="$CFLAGS"
+      CFLAGS="$CFLAGS $popcnt_flag"
+      CXXFLAGS="$CXXFLAGS $popcnt_flag"
+   else
+      AC_MSG_NOTICE([Forcing popcnt usage unchanged.])
+   fi
+  ],[
+   if test "$popcnt_flag" != "no"; then
+     AC_MSG_CHECKING([If cpu supports $popcnt_flag])
+     CFLAGS="$CFLAGS $popcnt_flag"
+     CXXFLAGS="$CXXFLAGS $popcnt_flag"
+     AC_RUN_IFELSE([AC_LANG_SOURCE([[int main(int argc, char *argv[]) {
+                      return __builtin_popcount(argc-1);
+                    }]])],[AC_MSG_RESULT([yes])],[
+         AC_MSG_RESULT([no])
+         CXXFLAGS="$old_CXXFLAGS"
+         CFLAGS="$old_CFLAGS"
+       ],[
+         AC_MSG_RESULT([cross-compiling, assuming no])
+         CXXFLAGS="$old_CXXFLAGS"
+         CFLAGS="$old_CFLAGS"
+       ])
+   else
+      AC_MSG_WARN([Don't know how to enable popcount instruction for $host_cpu.])
+   fi
+  ])
+
 # Checks for header files
 AC_DEFUN([AC_CHECK_HEADERS_ALT],
 [

--- a/configure.ac
+++ b/configure.ac
@@ -45,25 +45,6 @@ ifdef([PKG_CHECK_MODULES],[
 ])
   AC_CHECK_LIB([ffi], [ffi_call],[],[AC_MSG_FAILURE([Could not find library libffi.])])
 ])
-AC_CHECK_HEADER([immer/vector.hpp],[],[
-    AC_MSG_NOTICE([Using immer library from submodule.])
-    old_CPPFLAGS="$CPPFLAGS"
-    CPPFLAGS="$CPPFLAGS -I$srcdir/deps/immer"
-    # Hack: Undo caching of test
-    unset ac_cv_header_immer_vector_hpp
-    AC_CHECK_HEADER([immer/vector.hpp],[
-        case "$srcdir" in
-            (/*) immer_dir=$srcdir/deps/immer;;
-            (*)  immer_dir=../$srcdir/deps/immer;;
-        esac
-        CPPFLAGS="$old_CPPFLAGS -I$immer_dir"
-    ],[
-        AC_MSG_WARN([Nidhugg requires the "immer" library.])
-        AC_MSG_WARN([It is included as a submodule, but it seems like it has not been updated.])
-        AC_MSG_WARN([Run "git submodule update --init" and then try configuring again.])
-        AC_MSG_FAILURE([Could not find immer headers.])
-    ])
-])
 
 BUILDNIDHUGGC='yes'
 AC_ARG_ENABLE([nidhuggc],[AS_HELP_STRING([--disable-nidhuggc],[Don't build the script nidhuggc.])],

--- a/src/GenHash.h
+++ b/src/GenHash.h
@@ -1,0 +1,39 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#ifndef __GEN_HASH_H__
+#define __GEN_HASH_H__
+
+#include <functional>
+
+namespace gen {
+
+  template<typename T> struct hash {
+    std::size_t operator()(const T &v) const {
+      std::uint64_t hash = std::hash<T>()(v);
+      hash *= UINT64_C(0xc6a4a7935bd1e995);
+      hash ^= hash > 47;
+      return hash;
+    }
+  };
+
+} // namespace gen
+
+#endif

--- a/src/GenMap.h
+++ b/src/GenMap.h
@@ -1,0 +1,487 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#ifndef __GEN_MAP_H__
+#define __GEN_MAP_H__
+
+#include "GenHash.h"
+
+#ifndef NDEBUG
+/* For reference-count */
+#  include <atomic>
+#  include <memory>
+#endif
+#include <utility>
+#include <cstdint>
+
+namespace gen {
+
+  template<typename Key, typename T, typename Hash = hash<Key>,
+           class KeyEqual = std::equal_to<Key>, class ValueType = std::pair<const Key, T>>
+  class map;
+
+  namespace impl {
+    template<typename Key, typename T, class ValueType>
+    struct map_value_container {
+      map_value_container(const Key &k) : value(k, T()) {}
+      ValueType value;
+    };
+    template<typename Key, typename T>
+    struct map_value_container<Key, T, std::tuple<const Key, T>> {
+      map_value_container(const Key &k)
+        : value(std::piecewise_construct, std::make_tuple<const Key &>(k),
+                std::make_tuple<>()) {}
+      std::tuple<const Key, T> value;
+    };
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual,
+           class ValueType>
+  class map {
+    const unsigned log2_arity = 5;
+    const unsigned arity = 1 << log2_arity; // 32
+    typedef uint32_t bitmap_type;
+    typedef int32_t gen_type;
+    typedef uint32_t size_type;
+    typedef uint_fast32_t fast_size_type;
+    typedef ValueType value_type;
+    /* Just as to not require */
+    typedef typename std::remove_cv<
+      typename std::remove_reference<
+        typename std::result_of<Hash(const Key&)>::type>::type>::type hash_type;
+    static_assert(std::is_same<hash_type, std::size_t>::value, "Coward");
+    static hash_type hash_key(const Key &k) { return Hash()(k); }
+
+    struct child {
+      /* negative generation encodes a leaf */
+      gen_type _generation;
+      bool is_leaf() const { return _generation < 0; }
+      gen_type get_generation() const {
+        return _generation < 0 ? -1-_generation : _generation;
+      }
+    };
+
+    typedef impl::map_value_container<Key, T, ValueType> value_container;
+
+    /* TODO: Can we shrink memory use of this one somehow? */
+    struct leaf : child, value_container {
+      leaf(gen_type generation, const Key &k) : value_container(k) {
+        child::_generation = -1-generation;
+      }
+      leaf(gen_type generation, const leaf &other)
+        : value_container(other), next(other.next) {
+        child::_generation = -1-generation;
+      };
+      leaf(const leaf&) = delete;
+      /* Always a leaf */
+      child *next;
+    };
+
+    struct node : child {
+      node(gen_type generation, bitmap_type bitmap) : bitmap(bitmap) {
+        child::_generation = generation;
+      }
+      bitmap_type bitmap;
+      /* This is a variable-sized array. I believe this is not legal C++, so if
+       * there are weird heisenbugs, blame this. */
+      child *array[1];
+    };
+
+    gen_type generation = 0;
+    size_type _size = 0;
+    child *root = 0;
+
+    node *uncow_node(child **);
+    void uncow_leaf(child **);
+    node *alloc_node(fast_size_type arity, bitmap_type bitmap);
+    node *realloc_node(node *, fast_size_type arity);
+    void free_child(child *);
+
+#ifndef NDEBUG
+    typedef std::atomic_uint_fast32_t _debug_refcount_type;
+    _debug_refcount_type *_debug_parent = nullptr;
+    std::unique_ptr<_debug_refcount_type> _debug_refcount =
+      std::make_unique<_debug_refcount_type>(0);
+    void assert_writable() const;
+#else
+    inline constexpr void assert_writable() const {};
+#endif
+
+    template<typename Fn>
+    static void for_each(const child *, Fn &f);
+
+  public:
+    /* Empty */
+    map(){};
+    /* Copy-on-write duplicate another map. It must not be modified after this. */
+    explicit map(const map &);
+    /* Steal another map. It will be empty after this. It is allowed to steal
+     * a map that has COW references, but then the new map may not be
+     * modified. */
+    map(map &&other) { swap(other); }
+    ~map();
+    /* Copy-on-write duplicate another map. It must not be modified after this. */
+    map &operator=(const map &other);
+    /* Steal another map. Its contents will be swapped with this one. It
+     * is allowed to steal a map that has COW references, but then *this
+     * may not be modified further. */
+    map &operator=(map &&other) { assert_writable(); swap(other); return *this; }
+
+    /* Swap contents and ownership with another map */
+    void swap(map &other);
+
+    size_type size() const noexcept { return _size; }
+    const T *find(const Key &k) const;
+    T &mut(const Key &k);
+    const T &at(const Key &k) const;
+    /* If possible, use find or at instead. Use of operator[] instantiates a
+     * global default T variable to be returned if the key is missing
+     */
+    const T &operator[](const Key &k) const;
+    fast_size_type count(const Key &k) const { return find(k) != nullptr; }
+
+    template<class Fn> void for_each(Fn &&f) const;
+  };
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  inline void swap(map<Key,T,Hash,KeyEqual,VT> &a, map<Key,T,Hash,KeyEqual,VT> &b) {
+    a.swap(b);
+  }
+
+  template<class K, class T, class H, class KE, class VT, class Fn>
+  inline void for_each(const map<K,T,H,KE,VT> &v, Fn&& f) {
+    return v.for_each(std::forward<Fn>(f));
+  }
+}
+
+/* Start implementation */
+
+#include <cassert>
+
+namespace gen {
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  map<Key,T,Hash,KeyEqual,VT>::map(const map &other) {
+    _size = other._size;
+    if ((root = other.root)) {
+#ifndef NDEBUG
+      ++*(_debug_parent = other._debug_refcount.get());
+#endif
+      generation = other.generation + 1;
+    }
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  map<Key,T,Hash,KeyEqual,VT>::~map() {
+    assert_writable();
+#ifndef NDEBUG
+    if (_debug_parent) --*_debug_parent;
+#endif
+    free_child(root);
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  auto map<Key,T,Hash,KeyEqual,VT>::operator=(const map &other) -> map & {
+    this->~map();
+    new(this) map(other);
+    return *this;
+  }
+
+#ifndef NDEBUG
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  void map<Key,T,Hash,KeyEqual,VT>::assert_writable() const {
+    assert((*_debug_refcount) == 0 && "Writable");
+  }
+#endif
+
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  void map<Key,T,Hash,KeyEqual,VT>::swap(map &other) {
+    std::swap(generation, other.generation);
+    std::swap(_size, other._size);
+    std::swap(root, other.root);
+#ifndef NDEBUG
+    std::swap(_debug_parent, other._debug_parent);
+    std::swap(_debug_refcount, other._debug_refcount);
+#endif
+  }
+
+  namespace impl {
+    inline unsigned popcount(uint32_t bitmap) {
+      static_assert(sizeof(unsigned) >= sizeof(uint32_t), "No truncation");
+// #ifdef HAVE___POPCNT
+//       return __popcount(bitmap);
+// #elif HAVE__mm_popcnt_u32
+//       return _mm_popcnt_u32(bitmap);
+// #elif defined(HAVE___BUILTIN_POPCOUNT)
+      return __builtin_popcount(bitmap);
+// #else
+// #  error "A popcount intrinsic is needed for good performance"
+// #endif
+    }
+
+    template<typename T> struct const_ref_provider {
+      static const T val;
+    };
+    template<typename T> const T const_ref_provider<T>::val = T();
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  void map<Key,T,Hash,KeyEqual,VT>::free_child(child *child) {
+    if (!child || child->get_generation() != generation) return;
+    if (child->is_leaf()) {
+      leaf *leaf = static_cast<struct leaf *>(child);
+      do {
+        struct leaf *next = static_cast<struct leaf*>(leaf->next);
+        delete leaf;
+        leaf = next;
+      } while(leaf && leaf->get_generation() == generation);
+    } else {
+      node *node = static_cast<struct node *>(child);
+      fast_size_type size = impl::popcount(node->bitmap);
+      while(size) {
+        free_child(node->array[--size]);
+      }
+      node->~node();
+      ::free(node);
+    }
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  const T *map<Key,T,Hash,KeyEqual,VT>::find(const Key &k) const {
+    hash_type hash = hash_key(k);
+    const child *child = root;
+    while (child && !child->is_leaf()) {
+      const node *node = static_cast<const struct node*>(child);
+      fast_size_type index = hash % arity;
+      hash = hash / arity;
+      if (((node->bitmap >> index) & 1) != 1) return nullptr;
+      fast_size_type position = impl::popcount(node->bitmap >> index)-1;
+      child = node->array[position];
+    }
+    KeyEqual eq;
+    while(child) {
+      assert(child->is_leaf());
+      const leaf *leaf = static_cast<const struct leaf*>(child);
+      if (eq(k,std::get<0>(leaf->value))) {
+        return std::addressof(std::get<1>(leaf->value));
+      }
+      child = leaf->next;
+    }
+    return nullptr;
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  const T &map<Key,T,Hash,KeyEqual,VT>::operator[](const Key &k) const {
+    if (const T *p = find(k)) {
+      return *p;
+    } else {
+      return impl::const_ref_provider<T>::val;
+    }
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  const T &map<Key,T,Hash,KeyEqual,VT>::at(const Key &k) const {
+    if (const T *p = find(k)) {
+      return *p;
+    } else {
+      throw new std::out_of_range("k not in map");
+      assert(false && "Key not found in at()");
+      abort();
+    }
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  T &map<Key,T,Hash,KeyEqual,VT>::mut(const Key &k) {
+    assert_writable();
+    hash_type hash = hash_key(k);
+    fast_size_type depth = 0;
+    child **child = &root;
+    while (*child && !(*child)->is_leaf()) {
+      node *node = static_cast<struct node*>(*child);
+      fast_size_type index = hash % arity;
+      hash /= arity;
+      depth += log2_arity;
+      if (((node->bitmap >> index) & 1) == 1) {
+        fast_size_type position = impl::popcount(node->bitmap >> index)-1;
+        if ((*child)->get_generation() != generation) {
+          node = uncow_node(child);
+          node = static_cast<struct node*>(*child);
+        }
+        child = &node->array[position];
+      } else {
+        /* Grow the node to include the new child */
+        bitmap_type old_bitmap = node->bitmap;
+        size_t count = impl::popcount(old_bitmap)+1;
+        /* Notice the lack of -1 here; we're using the old bitmap */
+        fast_size_type position = impl::popcount(old_bitmap >> index);
+        bitmap_type new_bitmap = old_bitmap | (1 << index);
+        const struct node *old_node;
+        if ((*child)->get_generation() == generation) {
+          *child = node = realloc_node(node, count);
+          old_node = node;
+          node->bitmap = new_bitmap;
+        } else {
+          old_node = node;
+          *child = node = alloc_node(count, new_bitmap);
+          for (fast_size_type i = 0; i < position; ++i) {
+            node->array[i] = old_node->array[i];
+          }
+        }
+        for (fast_size_type i = count-1; i > position; --i) {
+          /* Might alias, thus the reverse iteration order. */
+          node->array[i] = old_node->array[i-1];
+        }
+        node->array[position] = nullptr;
+        child = &node->array[position];
+        break;
+      }
+    }
+    /* There are many cases now:
+     * 1. It exists in child list, and is not cow (victory, return reference)
+     * 2. It exists in child list, but is cow (uncow it and all nodes before it)
+     * 3a. It does not exist in child list (insert it first; no need to uncow
+     *     any other)
+     * 3b. The child list is empty (can be handled by same code as 3a)
+     *
+     * Is there any way we can handle 2 in one pass without uncowing other
+     * elements in case 3a?
+     */
+    leaf *leaf = static_cast<struct leaf *>(*child);
+    KeyEqual eq;
+    while (leaf && !eq(k,std::get<0>(leaf->value))) {
+      leaf = static_cast<struct leaf*>(leaf->next);
+    }
+    if (leaf) {
+      if (leaf->get_generation() != generation) {
+        /* We have to uncow all the way to leaf */
+        while ((*child)->get_generation() == generation) {
+          child = &static_cast<struct leaf*>(*child)->next;
+        }
+        while (*child != leaf) {
+          uncow_leaf(child);
+          child = &static_cast<struct leaf*>(*child)->next;
+        }
+        uncow_leaf(child);
+        leaf = static_cast<struct leaf *>(*child);
+        assert(eq(k, std::get<0>(leaf->value)));
+      }
+      return std::get<1>(leaf->value);
+    } else {
+      if (*child) {
+        hash_type first_hash
+          = hash_key(std::get<0>(static_cast<struct leaf *>(*child)->value));
+        first_hash >>= depth;
+        if (first_hash != hash) {
+          while(1) {
+            /* We have to introduce a new node to disambiguate */
+            const fast_size_type index_for_existing = first_hash % arity;
+            const fast_size_type index_for_new = hash % arity;
+            const fast_size_type new_node_arity
+              = index_for_existing == index_for_new ? 1 : 2;
+            bitmap_type bitmap = (1 << index_for_existing) | (1 << index_for_new);
+            struct node *node = alloc_node(new_node_arity, bitmap);
+            const fast_size_type position_for_existing = index_for_existing < index_for_new;
+            const fast_size_type position_for_new = index_for_new < index_for_existing;
+            node->array[position_for_new] = nullptr;
+            node->array[position_for_existing] = std::exchange(*child, node);
+            child = &node->array[position_for_new];
+            if (index_for_existing != index_for_new) {
+              break;
+            } else {
+              hash /= arity;
+              first_hash /= arity;
+            }
+          }
+        }
+      }
+      leaf = new struct leaf(generation, k);
+      leaf->next = std::exchange(*child, leaf);
+      ++_size;
+      return std::get<1>(leaf->value);
+    }
+  }
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  auto map<Key,T,Hash,KeyEqual,VT>::uncow_node(child **old_p) -> node * {
+    const node *old = static_cast<const node*>(*old_p);
+    fast_size_type arity = impl::popcount(old->bitmap);
+    node *n = alloc_node(arity, old->bitmap);
+    for (fast_size_type i = 0; i < arity; ++i) {
+      n->array[i] = old->array[i];
+    }
+    *old_p = n;
+    return n;
+  }
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  void map<Key,T,Hash,KeyEqual,VT>::uncow_leaf(child **node) {
+    *node = new leaf(generation, *static_cast<leaf*>(*node));
+  }
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  auto map<Key,T,Hash,KeyEqual,VT>::alloc_node(fast_size_type arity, bitmap_type bitmap) -> node * {
+    assert(impl::popcount(bitmap) == arity);
+    assert(arity > 0);
+    std::size_t size = sizeof(struct node) + sizeof(struct child*)*(arity-1);
+    struct node *node = static_cast<struct node*>(::malloc(size));
+    if (!node) {
+      throw std::bad_alloc();
+      abort();
+    }
+    new (node) struct node(generation, bitmap);
+    return node;
+  }
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  auto map<Key,T,Hash,KeyEqual,VT>::realloc_node(node *old, fast_size_type arity) -> node * {
+    std::size_t size = sizeof(struct node) + sizeof(struct child*)*(arity-1);
+    struct node *n = static_cast<struct node*>(::realloc(old, size));
+    if (!n) {
+      throw std::bad_alloc();
+      abort();
+    }
+    return n;
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  template<typename Fn>
+  void map<Key,T,Hash,KeyEqual,VT>::for_each(Fn &&f) const {
+    if (!root) return;
+    map::for_each<Fn>(root, f);
+  }
+
+  template<typename Key, typename T, typename Hash, class KeyEqual, class VT>
+  template<typename Fn>
+  void map<Key,T,Hash,KeyEqual,VT>::for_each(const child *child, Fn &f) {
+    if (child->is_leaf()) {
+      const leaf *leaf = static_cast<const struct leaf *>(child);
+      do {
+        f(leaf->value);
+        assert(!leaf->next || leaf->next->is_leaf());
+      } while ((leaf = static_cast<const struct leaf*>(leaf->next)));
+    } else {
+      const node *node = static_cast<const struct node *>(child);
+      const fast_size_type size = impl::popcount(node->bitmap);
+      const struct child *const *const end = node->array + size;
+      for (const struct child *const *elem = node->array; elem != end; ++elem) {
+        for_each(*elem, f);
+      }
+    }
+  }
+}
+
+#endif

--- a/src/GenMap_test.cpp
+++ b/src/GenMap_test.cpp
@@ -1,0 +1,473 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#ifdef HAVE_BOOST_UNIT_TEST_FRAMEWORK
+#include <boost/test/unit_test.hpp>
+
+#include "GenMap.h"
+
+#include <random>
+#include <set>
+#include <functional>
+
+namespace {
+  /* This checks for double free, and lets us check for leaks with valgrind */
+  struct heap_int {
+    heap_int() : heap_int(0) {}
+    heap_int(int v) : p(new int(v)) {}
+    heap_int(const heap_int &i) : heap_int(*i.p) {}
+    heap_int &operator=(const heap_int &i) { *p = *i.p; return *this; }
+    heap_int &operator=(int i) { *p = i; return *this; }
+    ~heap_int() {
+      if(!p) BOOST_TEST_ERROR("Double free!");
+      else delete(std::exchange(p, nullptr));
+    }
+    operator int() const { return *p; }
+  private:
+    int *p = nullptr;
+  };
+
+  std::mt19937_64 random(std::uint_fast64_t seed = std::mt19937_64::default_seed) {
+    std::mt19937_64 engine(seed);
+    return engine;
+  }
+
+  template<typename Hash>
+  void test_iterate(const gen::map<heap_int,heap_int,Hash> &m,
+                    std::size_t expected_size) {
+    std::size_t size = 0;
+    static volatile int sum = 0; // Grr, don't optimise me away
+    gen::for_each(m, [&] (const std::pair<const heap_int,heap_int> &pair) {
+                       ++size;
+                       sum += pair.first + pair.second;
+                     });
+    BOOST_CHECK_EQUAL(size, expected_size);
+  }
+
+  struct id_hash {
+    std::size_t operator()(heap_int i) { return static_cast<int>(i); }
+  };
+
+  struct constant_hash {
+    std::size_t operator()(heap_int i) { return 42; }
+  };
+
+  typedef gen::map<heap_int,heap_int,constant_hash> id_hash_map;
+}
+
+namespace std {
+  template <> struct hash<heap_int> {
+    typedef std::size_t result_type;
+    typedef const heap_int &argument_type;
+    std::size_t operator()(const heap_int &i) {
+      return std::hash<int>()(i);
+    }
+  };
+}
+
+/* Workaround broken boost version */
+#if BOOST_VERSION < 106700 // 1.67
+void boost::test_tools::tt_detail::
+print_log_value<std::nullptr_t>::operator()(std::ostream &os, std::nullptr_t) {
+    os << "null";
+}
+#endif
+
+
+BOOST_AUTO_TEST_SUITE(GenMap_test)
+
+BOOST_AUTO_TEST_CASE(Init_default) {
+  BOOST_CHECK_EQUAL((id_hash_map().size()),0);
+}
+
+BOOST_AUTO_TEST_CASE(Init_foreach) {
+  id_hash_map m;
+  test_iterate(m, 0);
+}
+
+BOOST_AUTO_TEST_CASE(Put_get){
+  id_hash_map m;
+  BOOST_CHECK_EQUAL(m.find(3),nullptr);
+  m.mut(3) = 4;
+  BOOST_CHECK_EQUAL(m.size(),1);
+  test_iterate(m, 1);
+  BOOST_CHECK_EQUAL(m.at(3),4);
+  BOOST_CHECK_EQUAL(m.find(4),nullptr);
+  BOOST_CHECK_EQUAL(m.find(3+32),nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Put_two){
+  id_hash_map m;
+  m.mut(3) = 4;
+  m.mut(5) = 6;
+  BOOST_CHECK_EQUAL(m.size(),2);
+  test_iterate(m, 2);
+  BOOST_CHECK_EQUAL(m.at(3),4);
+  BOOST_CHECK_EQUAL(m.at(5),6);
+  BOOST_CHECK_EQUAL(m.find(6),nullptr);
+  BOOST_CHECK_EQUAL(m.find(5+32),nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Put_two_reverse){
+  id_hash_map m;
+  m.mut(5) = 4;
+  m.mut(3) = 2;
+  BOOST_CHECK_EQUAL(m.size(),2);
+  test_iterate(m, 2);
+  BOOST_CHECK_EQUAL(m.at(3),2);
+  BOOST_CHECK_EQUAL(m.at(5),4);
+  BOOST_CHECK_EQUAL(m.find(5+32),nullptr);
+  BOOST_CHECK_EQUAL(m.find(3+32),nullptr);
+  BOOST_CHECK_EQUAL(m.find(6),nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Put_two_prefix_collision){
+  id_hash_map m;
+  m.mut(3) = 4;
+  m.mut(3+32) = 5;
+  BOOST_CHECK_EQUAL(m.size(),2);
+  test_iterate(m, 2);
+  BOOST_CHECK_EQUAL(m.at(3),4);
+  BOOST_CHECK_EQUAL(m.at(3+32),5);
+  BOOST_CHECK_EQUAL(m.find(4),nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Put_three_above){
+  id_hash_map m;
+  m.mut(3) = 4;
+  m.mut(5) = 6;
+  m.mut(7) = 8;
+  BOOST_CHECK_EQUAL(m.size(),3);
+  test_iterate(m, 3);
+  BOOST_CHECK_EQUAL(m.at(3),4);
+  BOOST_CHECK_EQUAL(m.at(5),6);
+  BOOST_CHECK_EQUAL(m.at(7),8);
+  BOOST_CHECK_EQUAL(m.find(4),nullptr);
+  BOOST_CHECK_EQUAL(m.find(6),nullptr);
+  BOOST_CHECK_EQUAL(m.find(5+32),nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Put_three_middle){
+  id_hash_map m;
+  m.mut(3) = 6;
+  m.mut(5) = 7;
+  m.mut(4) = 8;
+  BOOST_CHECK_EQUAL(m.size(),3);
+  test_iterate(m, 3);
+  BOOST_CHECK_EQUAL(m.at(3),6);
+  BOOST_CHECK_EQUAL(m.at(4),8);
+  BOOST_CHECK_EQUAL(m.at(5),7);
+  BOOST_CHECK_EQUAL(m.find(2),nullptr);
+  BOOST_CHECK_EQUAL(m.find(6),nullptr);
+  BOOST_CHECK_EQUAL(m.find(4+32),nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Put_three_below){
+  id_hash_map m;
+  m.mut(3) = 4;
+  m.mut(5) = 6;
+  m.mut(2) = 7;
+  BOOST_CHECK_EQUAL(m.size(),3);
+  test_iterate(m, 3);
+  BOOST_CHECK_EQUAL(m.at(2),7);
+  BOOST_CHECK_EQUAL(m.at(3),4);
+  BOOST_CHECK_EQUAL(m.at(5),6);
+  BOOST_CHECK_EQUAL(m.find(4),nullptr);
+  BOOST_CHECK_EQUAL(m.find(1),nullptr);
+  BOOST_CHECK_EQUAL(m.find(2+32),nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Put_sequence_idmap){
+  std::vector<int> v;
+  for (int i = 0; i < 100; ++i) v.push_back(i);
+  id_hash_map m;
+  int size = 0;
+  for (int i : v) {
+    m.mut(i) = i+999;
+    test_iterate(m, ++size);
+  }
+  BOOST_CHECK_EQUAL(m.size(),100);
+  for (int i : v) {
+    BOOST_CHECK_EQUAL(m.at(i),i+999);
+    BOOST_CHECK_EQUAL(m.mut(i),i+999);
+  }
+  for (int i = -40; i < 0; ++i) {
+    BOOST_CHECK_EQUAL(m.find(i),nullptr);
+  }
+  for (int i = 100; i < 140; ++i) {
+    BOOST_CHECK_EQUAL(m.find(i),nullptr);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(Put_random){
+  std::vector<int> v;
+  for (int i = 0; i < 100; ++i) v.push_back(i);
+  shuffle(v.begin(), v.end(), random(42));
+  id_hash_map m;
+  int size = 0;
+  for (int i : v) {
+    m.mut(i) = i+999;
+    test_iterate(m, ++size);
+  }
+  BOOST_CHECK_EQUAL(m.size(),100);
+  shuffle(v.begin(), v.end(), random(43));
+  for (int i : v) {
+    BOOST_CHECK_EQUAL(m.at(i),i+999);
+    BOOST_CHECK_EQUAL(m.mut(i),i+999);
+    test_iterate(m, 100);
+  }
+  for (int i = -40; i < 0; ++i) {
+    BOOST_CHECK_EQUAL(m.find(i),nullptr);
+  }
+  for (int i = 100; i < 140; ++i) {
+    BOOST_CHECK_EQUAL(m.find(i),nullptr);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(Put_sequence){
+  std::vector<int> v;
+  for (int i = 0; i < 100; ++i) v.push_back(i);
+  gen::map<heap_int,heap_int> m;
+  int size = 0;
+  for (int i : v) {
+    m.mut(i) = i+999;
+    test_iterate(m, ++size);
+  }
+  BOOST_CHECK_EQUAL(m.size(),100);
+  for (int i : v) {
+    BOOST_CHECK_EQUAL(m.at(i),i+999);
+    BOOST_CHECK_EQUAL(m.mut(i),i+999);
+  }
+  for (int i = -40; i < 0; ++i) {
+    BOOST_CHECK_EQUAL(m.find(i),nullptr);
+  }
+  for (int i = 100; i < 140; ++i) {
+    BOOST_CHECK_EQUAL(m.find(i),nullptr);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(COW_construct_same_address) {
+  std::vector<int> v;
+  for (int i = 0; i < 100; ++i) v.push_back(i);
+  shuffle(v.begin(), v.end(), random(44));
+  gen::map<heap_int,heap_int> m;
+  for (int i : v) {
+    m.mut(i) = i+999;
+  }
+  shuffle(v.begin(), v.end(), random(45));
+  {
+    const auto &mr = m;
+    gen::map<heap_int,heap_int> n(mr);
+    BOOST_CHECK_EQUAL(m.size(),100);
+    BOOST_CHECK_EQUAL(n.size(),100);
+    test_iterate(n, 100);
+    for (int i : v) {
+      const heap_int &mi = m.at(i);
+      const heap_int &ni = n.at(i);
+      BOOST_CHECK_EQUAL(&mi, &ni);
+      BOOST_CHECK_EQUAL(mi,i+999);
+    }
+    for (int i = -40; i < 0; ++i) {
+      BOOST_CHECK_EQUAL(n.find(i),nullptr);
+    }
+    for (int i = 100; i < 140; ++i) {
+      BOOST_CHECK_EQUAL(n.find(i),nullptr);
+    }
+  }
+  BOOST_CHECK_EQUAL(m.size(),100);
+  test_iterate(m, 100);
+  for (int i : v) {
+    BOOST_CHECK_EQUAL(m[i],i+999);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(COW_update_collision) {
+  std::vector<int> v;
+  for (int i = 0; i < 100; ++i) v.push_back(i);
+  shuffle(v.begin(), v.end(), random(49));
+  gen::map<heap_int,heap_int,constant_hash> m;
+  for (int i = 0; i < 100; ++i) {
+    m.mut(v[i]) = v[i]+999;
+    test_iterate(m, i+1);
+  }
+  shuffle(v.begin(), v.end(), random(50));
+  {
+    const auto &mr = m;
+    gen::map<heap_int,heap_int,constant_hash> n(mr);
+    BOOST_CHECK_EQUAL(m.size(),100);
+    BOOST_CHECK_EQUAL(n.size(),100);
+    test_iterate(n, 100);
+    for (int i = 0; i < 100; ++i) {
+      n.mut(v[i]) = v[i] + 1999;
+      test_iterate(m, 100);
+      test_iterate(n, 100);
+    }
+    for (int i = 0; i < 100; ++i) {
+      BOOST_CHECK_EQUAL(m.at(i), i+999);
+      BOOST_CHECK_EQUAL(n.at(i), i+1999);
+    }
+  }
+  BOOST_CHECK_EQUAL(m.size(),100);
+  test_iterate(m, 100);
+  for (int i = 0; i < 100; ++i) {
+    BOOST_CHECK_EQUAL(m[i],i+999);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(COW_add_new){
+  std::vector<int> v;
+  for (int i = 0; i < 100; ++i) v.push_back(i);
+  shuffle(v.begin(), v.end(), random(46));
+  gen::map<heap_int,heap_int> m;
+  for (int i = 0; i < 50; ++i) {
+    m.mut(v[i]) = v[i]+999;
+  }
+  // gen::__debug_set_tracing(true);
+  {
+    const auto &mr = m;
+    gen::map<heap_int,heap_int> n(mr);
+    BOOST_CHECK_EQUAL(m.size(),50);
+    BOOST_CHECK_EQUAL(n.size(),50);
+    for (int i = 50; i < 100; ++i) {
+      n.mut(v[i]) = v[i]+999;
+      test_iterate(n, i+1);
+      test_iterate(m, 50);
+    }
+    BOOST_CHECK_EQUAL(m.size(),50);
+    BOOST_CHECK_EQUAL(n.size(),100);
+    for (int i = -40; i < 0; ++i) {
+      BOOST_CHECK_EQUAL(m.find(i),nullptr);
+      BOOST_CHECK_EQUAL(n.find(i),nullptr);
+    }
+    for (int i = 0; i < 100; ++i) {
+      int x = v[i];
+      const heap_int &ni = n.at(x);
+      BOOST_CHECK_EQUAL(ni,x+999);
+      if (i < 50) {
+        const heap_int &mi = m.at(x);
+        BOOST_CHECK_EQUAL(&ni,&mi);
+      } else {
+        BOOST_CHECK_EQUAL(m.find(x), nullptr);
+      }
+    }
+    for (int i = 100; i < 140; ++i) {
+      BOOST_CHECK_EQUAL(m.find(i),nullptr);
+      BOOST_CHECK_EQUAL(n.find(i),nullptr);
+    }
+  }
+  BOOST_CHECK_EQUAL(m.size(),50);
+  test_iterate(m, 50);
+  for (int i = 0; i < 50; ++i) {
+    BOOST_CHECK_EQUAL(m[v[i]],v[i]+999);
+  }
+  // gen::__debug_set_tracing(false);
+}
+
+BOOST_AUTO_TEST_CASE(COW_add_collision) {
+  gen::map<heap_int,heap_int,constant_hash> m;
+  for (int i = 0; i < 50; ++i) {
+    m.mut(i) = i+999;
+    test_iterate(m, i+1);
+  }
+  {
+    const auto &mr = m;
+    gen::map<heap_int,heap_int,constant_hash> n(mr);
+    BOOST_CHECK_EQUAL(m.size(),50);
+    BOOST_CHECK_EQUAL(n.size(),50);
+    test_iterate(n, 50);
+    for (int i = 50; i < 100; ++i) {
+      n.mut(i) = i + 1999;
+      test_iterate(m, 50);
+      test_iterate(n, i+1);
+    }
+    for (int i = 0; i < 50; ++i) {
+      BOOST_CHECK_EQUAL(m.at(i), i+999);
+      BOOST_CHECK_EQUAL(n.at(i), i+999);
+    }
+    for (int i = 50; i < 100; ++i) {
+      BOOST_CHECK_EQUAL(n.at(i), i+1999);
+    }
+  }
+  BOOST_CHECK_EQUAL(m.size(),50);
+  test_iterate(m, 50);
+  for (int i = 0; i < 50; ++i) {
+    BOOST_CHECK_EQUAL(m[i],i+999);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(COW_overwrite_some){
+  std::vector<int> v, w;
+  for (int i = 0; i < 100; ++i) v.push_back(i);
+  shuffle(v.begin(), v.end(), random(48));
+  gen::map<heap_int,heap_int> m;
+  for (int i : v) {
+    m.mut(i) = i+999;
+  }
+  w = v;
+  shuffle(v.begin(), v.end(), random(49));
+  v.resize(50);
+  std::set<int> moved(v.begin(), v.end());
+  // gen::__debug_set_tracing(true);
+  {
+    const auto &mr = m;
+    gen::map<heap_int,heap_int> n(mr);
+    BOOST_CHECK_EQUAL(m.size(),100);
+    BOOST_CHECK_EQUAL(n.size(),100);
+    for (int i : v) {
+      n.mut(i) = i+1999;
+      test_iterate(m, 100);
+      test_iterate(n, 100);
+    }
+    BOOST_CHECK_EQUAL(m.size(),100);
+    BOOST_CHECK_EQUAL(n.size(),100);
+    for (int i = -40; i < 0; ++i) {
+      BOOST_CHECK_EQUAL(m.find(i),nullptr);
+      BOOST_CHECK_EQUAL(n.find(i),nullptr);
+    }
+    for (int i = 0; i < 100; ++i) {
+      const heap_int &mi = m.at(i);
+      BOOST_CHECK_EQUAL(mi,i+999);
+      const heap_int &ni = n.at(i);
+      if (moved.count(i)) {
+        BOOST_CHECK_EQUAL(ni,i+1999);
+      } else {
+        /* If there's a hash collision, this may not be satisfied */
+        BOOST_WARN_EQUAL(&ni,&mi);
+      }
+    }
+    for (int i = 100; i < 140; ++i) {
+      BOOST_CHECK_EQUAL(m.find(i),nullptr);
+      BOOST_CHECK_EQUAL(n.find(i),nullptr);
+    }
+  }
+  test_iterate(m, 100);
+  for (int i : w) {
+    BOOST_CHECK_EQUAL(m[i], i+999);
+  }
+  // gen::__debug_set_tracing(false);
+}
+
+BOOST_AUTO_TEST_CASE(memory_management){
+  gen::map<heap_int, heap_int> m;
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+#endif

--- a/src/GenVector.h
+++ b/src/GenVector.h
@@ -82,7 +82,7 @@ namespace gen {
 
     void push_back(const T& val);
     void push_back(T&& val);
-    template <typename... Args> void emplace_back(Args&&... args);
+    template <typename... Args> T &emplace_back(Args&&... args);
 
   private:
 #ifndef NDEBUG
@@ -368,8 +368,8 @@ namespace gen {
     new (push_back_internal()) T(std::move(val));
   }
   template<typename T, std::size_t limb_size> template<typename... Args>
-  void vector<T, limb_size>::emplace_back(Args&&... args) {
-    new (push_back_internal()) T(std::forward<Args>(args)...);
+  T &vector<T, limb_size>::emplace_back(Args&&... args) {
+    return *new (push_back_internal()) T(std::forward<Args>(args)...);
   }
   template<typename T, std::size_t limb_size>
   const T *vector<T,limb_size>::deref(const limb_type *const *start, size_type ix) {

--- a/src/GenVector.h
+++ b/src/GenVector.h
@@ -1,0 +1,439 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#ifndef __GEN_VECTOR_H__
+#define __GEN_VECTOR_H__
+
+#ifndef NDEBUG
+/* For reference-count */
+#  include <atomic>
+#endif
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <memory>
+#include <cstdint>
+#include <climits>
+
+namespace gen {
+
+  template <typename X>
+  static constexpr unsigned vector_default_limb_size
+  = std::max<std::size_t>(8, 128/sizeof(X));
+
+  /* gen::vector is a vector implementation which offers efficient duplication
+   * through copy-on-write structural sharing and also single-owner RAII memory
+   * management (no reference counters). It is thread-safe and performant even
+   * on large parallel computers.
+   *
+   * It offers these features by placing restrictions on its use. Whenever a
+   * (non-empty) vector is duplicated (through the copy constructor or copy
+   * assignment operator), it is required that the source vector is not modified
+   * or destroyed for the lifetime of the copy.
+   *
+   * When compiling with !defined(NDEBUG), the vector will check that these
+   * rules are followed (at a cost to performance).
+   */
+  template<typename T, std::size_t limb_size = vector_default_limb_size<T>>
+  class vector {
+  public:
+    typedef std::size_t size_type;
+
+    /* Empty */
+    vector();
+    /* Copy-on-write duplicate another vector. It must not be modified after this. */
+    explicit vector(const vector &);
+    /* Steal another vector. It will be empty after this. It is allowed to steal
+     * a vector that has COW references, but then the new vector may not be
+     * modified. */
+    vector(vector &&);
+    ~vector();
+    /* Copy-on-write duplicate another vector. It must not be modified after this. */
+    vector &operator=(const vector &other);
+    /* Steal another vector. It will be empty after this. It is allowed to steal
+     * a vector that has COW references, but then *this may not be modified
+     * further. */
+    vector &operator=(vector &&other);
+
+    const T &operator[](size_type index) const;
+    const T &at(size_type index) const;
+    T &mut(size_type index);
+    const T &back() const { return (*this)[_size-1]; }
+
+    size_type size() const noexcept { return _size; }
+    bool empty() const noexcept { return !_size; }
+
+    void push_back(const T& val);
+    void push_back(T&& val);
+    template <typename... Args> void emplace_back(Args&&... args);
+
+  private:
+#ifndef NDEBUG
+    typedef std::atomic_uint_fast32_t _debug_refcount_type;
+    _debug_refcount_type *_debug_parent = nullptr;
+    std::unique_ptr<std::atomic_uint_fast32_t> _debug_refcount =
+        std::make_unique<_debug_refcount_type>(0);
+    void assert_writable() const;
+#else
+    inline constexpr void assert_writable() const {};
+#endif
+    typedef T limb_type[limb_size];
+    static_assert(sizeof(T) * limb_size == sizeof(limb_type), "Packing assumption");
+    typedef uint_fast8_t bitmap_uint;
+    static_assert(alignof(limb_type) >= alignof(bitmap_uint), "Packing assumption");
+    static constexpr std::size_t bits_per_uint = sizeof(bitmap_uint) * CHAR_BIT;
+    size_type limb_count() const;
+    static inline size_type next_capacity(size_type old_capacity) {
+      return std::max(old_capacity+2, old_capacity + (old_capacity+1)/2);
+    }
+    static inline size_type bitmap_size(size_type capacity) {
+      return (capacity + bits_per_uint - 1) / bits_per_uint;
+    }
+
+    static inline const T *deref(const limb_type *const *start, size_type index);
+    inline bool root_is_cow_or_empty() const { return !last; }
+    inline bool limb_is_cow(size_type limb_index) const;
+    inline void uncow_if_needed(size_type limb_index);
+    inline void uncow_root_if_needed();
+    inline void uncow_root_if_needed_assume_nonempty();
+    /* Does not copy bitmap, only elements */
+    limb_type **alloc_root_copy_from
+    (size_type capacity, size_type bitmap_size,
+     const limb_type *const *source, size_type old_capacity);
+    void uncow(size_type limb_index);
+    void uncow_root();
+    void copy_root(const limb_type **old_start, const limb_type **old_capacity);
+    void grow();
+    /* Adds a new element at the end without initializing it, returning its address. */
+    T *push_back_internal();
+
+    size_type _size;
+    limb_type **start, **last;
+
+    /* Overly permissive, how do I fix? */
+    template<typename U, std::size_t S, typename Fn>
+    friend void for_each(const vector<U,S> &v, Fn&& f);
+    template<typename U, std::size_t S, typename P>
+    friend bool all_of(const vector<U,S> &v, P&& f);
+
+  public:
+    class const_iterator {
+      const limb_type *const *start;
+      size_type index;
+      const_iterator(const limb_type *const *start, size_type index)
+        : start(start), index(index) {}
+      friend class vector;
+    public:
+      typedef const T value_type, *pointer, &reference;
+      typedef size_type difference_type;
+      typedef std::bidirectional_iterator_tag iterator_category;
+      const_iterator &operator++() { ++index; return *this; }
+      const_iterator &operator--() { --index; return *this; }
+      const T &operator*() { return *vector::deref(start, index); }
+      bool operator!=(const const_iterator &other) { return !((*this) == other); }
+      bool operator==(const const_iterator &other) { return index == other.index; }
+    };
+    const_iterator begin() const { return {start, 0}; }
+    const_iterator end() const { return {start, _size}; }
+  };
+
+  template<typename T, std::size_t limb_size, typename Fn>
+  void for_each(const vector<T,limb_size> &v, Fn&& f);
+
+  template<typename T, std::size_t limb_size, typename Fn>
+  bool all_of(const vector<T,limb_size> &v, Fn&& f);
+
+}
+
+/* Start implementation */
+
+#include <cassert>
+#ifndef NDEBUG
+#  define IFDEBUG(...) __VA_ARGS__
+#else
+#  define IFDEBUG(...)
+#endif
+
+namespace gen {
+  template<typename T, std::size_t limb_size>
+  vector<T,limb_size>::vector()
+    : IFDEBUG(_debug_parent(nullptr),)
+      _size(0), start(nullptr), last(nullptr) {}
+  template<typename T, std::size_t limb_size>
+  vector<T,limb_size>::vector(const vector &other) {
+    _size = other._size;
+    start = other.start;
+    /* Encodes that start is a cow pointer */
+    last = nullptr;
+#ifndef NDEBUG
+    if (start) {
+      _debug_parent = other._debug_refcount.get();
+      (*other._debug_refcount)++;
+    } else {
+      /* When copying an empty vector, we become a non-cow empty vector */
+      _debug_parent = nullptr;
+    }
+#endif
+  }
+  template<typename T, std::size_t limb_size>
+  vector<T,limb_size>::vector(vector &&other) {
+#ifndef NDEBUG
+    _debug_parent = std::exchange(other._debug_parent, nullptr);
+    std::swap(_debug_refcount, other._debug_refcount);
+#endif
+    _size = std::exchange(other._size, 0);
+    start = std::exchange(other.start, nullptr);
+    last = std::exchange(other.last, nullptr);
+  }
+  template<typename T, std::size_t limb_size>
+  auto vector<T,limb_size>::operator=(const vector &other) -> vector & {
+    this->~vector();
+    new(this) vector(other);
+    return *this;
+  }
+  template<typename T, std::size_t limb_size>
+  auto vector<T,limb_size>::operator=(vector &&other) -> vector & {
+    this->~vector();
+    new(this) vector(std::move(other));
+    return *this;
+  }
+  template<typename T, std::size_t limb_size>
+  vector<T,limb_size>::~vector() {
+    assert_writable();
+#ifndef NDEBUG
+    if (_debug_parent) (*_debug_parent)--;
+#endif
+    if (last) {
+      const size_type full_limb_count = size() / limb_size;
+      for (size_type i = 0; i < full_limb_count; ++i) {
+        if (!limb_is_cow(i)) {
+          for (size_type j = 0; j < limb_size; ++j) {
+            (*start[i])[j].~T();
+          }
+          operator delete(start[i]);
+        }
+      }
+      const size_type elements_in_last_limb = size() % limb_size;
+      if (elements_in_last_limb != 0 && !limb_is_cow(full_limb_count)) {
+        for (size_type i = 0; i < elements_in_last_limb; ++i) {
+          (*start[full_limb_count])[i].~T();
+        }
+        operator delete(start[full_limb_count]);
+      }
+      operator delete(start);
+    }
+  }
+#ifndef NDEBUG
+  template<typename T, std::size_t limb_size>
+  void vector<T,limb_size>::assert_writable() const {
+    assert((*_debug_refcount) == 0 && "Writable");
+  }
+#endif
+  template<typename T, std::size_t limb_size>
+  bool vector<T,limb_size>::limb_is_cow(size_type limb_index) const {
+    const bitmap_uint *bitmap = reinterpret_cast<const bitmap_uint*>(last);
+    return (bitmap[limb_index / bits_per_uint] >> (limb_index % bits_per_uint)) & 1;
+  }
+  template<typename T, std::size_t limb_size>
+  auto vector<T,limb_size>::limb_count() const -> size_type {
+    return (_size + limb_size - 1) / limb_size;
+  }
+  template<typename T, std::size_t limb_size>
+  void vector<T,limb_size>::uncow_if_needed(size_type limb_index) {
+    assert(last);
+    if (limb_is_cow(limb_index)) uncow(limb_index);
+  }
+  template<typename T, std::size_t limb_size>
+  void vector<T,limb_size>::uncow(size_type limb_index) {
+    assert(limb_is_cow(limb_index));
+    const size_type limb_valid_elements
+        = std::min(size() - limb_index*limb_size, limb_size);
+    assert(limb_valid_elements > 0);
+    const limb_type *old_limb = start[limb_index];
+    std::unique_ptr<limb_type> new_limb
+        (static_cast<limb_type*>(operator new (sizeof(limb_type))));
+    for (size_type i = 0; i < limb_valid_elements; ++i) {
+      new (std::addressof((*new_limb)[i])) T((*old_limb)[i]);
+    }
+    start[limb_index] = new_limb.release();
+    /* Clear COW bit */
+    bitmap_uint *bitmap = reinterpret_cast<bitmap_uint*>(last);
+    bitmap[limb_index / bits_per_uint] &= ~(1 << (limb_index % bits_per_uint));
+  }
+  template<typename T, std::size_t limb_size>
+  void vector<T,limb_size>::uncow_root_if_needed() {
+    if (!last && start) uncow_root();
+  }
+  template<typename T, std::size_t limb_size>
+  void vector<T,limb_size>::uncow_root_if_needed_assume_nonempty() {
+    assert(start);
+    if (root_is_cow_or_empty()) uncow_root();
+  }
+  template<typename T, std::size_t limb_size>
+  auto vector<T,limb_size>::alloc_root_copy_from
+   (size_type capacity, size_type bitmap_size,
+    const limb_type *const *source, size_type old_capacity) -> limb_type** {
+    const std::size_t alloc_size = capacity * sizeof(limb_type*)
+      + bitmap_size * sizeof(bitmap_uint);
+    limb_type **new_start = static_cast<limb_type **>(operator new(alloc_size));
+    std::copy(start, start+old_capacity,
+              std::raw_storage_iterator<limb_type**, limb_type*>(new_start));
+    return new_start;
+  }
+  template<typename T, std::size_t limb_size>
+  void vector<T,limb_size>::uncow_root() {
+    assert(root_is_cow_or_empty() && start);
+    const size_type old_capacity = limb_count();
+    const size_type new_capacity = next_capacity(old_capacity);
+    const size_type bitmap_uints = bitmap_size(new_capacity);
+    limb_type **new_start = alloc_root_copy_from(new_capacity, bitmap_uints,
+                                                 start, old_capacity);
+    limb_type **new_last  = new_start + new_capacity;
+    bitmap_uint *new_bitmap = reinterpret_cast<bitmap_uint*>(new_last);
+    /* Set first old_capacity bits, clear rest */
+    for (size_type i = 0; i < old_capacity/bits_per_uint; ++i) {
+      new_bitmap[i] = ~0;
+    }
+    new_bitmap[old_capacity/bits_per_uint] = (1 << (old_capacity%bits_per_uint))-1;
+    for (size_type i = old_capacity/bits_per_uint+1; i < bitmap_uints; ++i) {
+      new_bitmap[i] = 0;
+    }
+    start = new_start;
+    last = new_last;
+  }
+  template<typename T, std::size_t limb_size>
+  void vector<T,limb_size>::grow() {
+    assert(!root_is_cow_or_empty() || empty());
+    assert(size() % limb_size == 0);
+    if (limb_count() == size_type(last-start)) {
+      /* The root is too small, grow it! */
+      const size_type old_capacity = last - start;
+      const size_type new_capacity = next_capacity(old_capacity);
+      const size_type bitmap_uints = bitmap_size(new_capacity);
+      limb_type **new_start = alloc_root_copy_from(new_capacity, bitmap_uints,
+                                                   start, old_capacity);
+      limb_type **new_last  = new_start + new_capacity;
+      const bitmap_uint *bitmap = reinterpret_cast<const bitmap_uint*>(last);
+      bitmap_uint *new_bitmap = reinterpret_cast<bitmap_uint*>(new_last);
+      const size_type old_bitmap_uints = bitmap_size(old_capacity);
+      /* Copy bitmap from old root, clear new bits */
+      std::copy(bitmap, bitmap+old_bitmap_uints,
+                std::raw_storage_iterator<bitmap_uint*, bitmap_uint>(new_bitmap));
+      for (size_type i = old_bitmap_uints; i < bitmap_uints; ++i) {
+        new_bitmap[i] = 0;
+      }
+      /* Delete old root */
+      operator delete(reinterpret_cast<void*>(start));
+      start = new_start;
+      last = new_last;
+    }
+    assert(limb_count() < size_type(last-start));
+    start[limb_count()] = static_cast<limb_type*>(operator new (sizeof(limb_type)));
+  }
+
+  template<typename T, std::size_t limb_size>
+  T *vector<T,limb_size>::push_back_internal() {
+    assert_writable();
+    size_type limb = _size / limb_size;
+    size_type limb_ix = _size % limb_size;
+    uncow_root_if_needed();
+    if (limb_ix != 0) uncow_if_needed(limb);
+    else grow();
+    ++_size;
+    return (*start[limb]) + limb_ix ;
+  }
+  template<typename T, std::size_t limb_size>
+  void vector<T,limb_size>::push_back(const T &val) {
+    new (push_back_internal()) T(val);
+  }
+  template<typename T, std::size_t limb_size>
+  void vector<T,limb_size>::push_back(T &&val) {
+    new (push_back_internal()) T(std::move(val));
+  }
+  template<typename T, std::size_t limb_size> template<typename... Args>
+  void vector<T, limb_size>::emplace_back(Args&&... args) {
+    new (push_back_internal()) T(std::forward<Args>(args)...);
+  }
+  template<typename T, std::size_t limb_size>
+  const T *vector<T,limb_size>::deref(const limb_type *const *start, size_type ix) {
+    size_type limb = ix / limb_size;
+    size_type limb_ix = ix % limb_size;
+    return (*start[limb]) + limb_ix;
+  }
+  template<typename T, std::size_t limb_size>
+  const T &vector<T,limb_size>::operator[](size_type ix) const {
+    assert(ix < _size);
+    return *deref(start, ix);
+  }
+  template<typename T, std::size_t limb_size>
+  T &vector<T,limb_size>::mut(size_type ix) {
+    assert(ix < _size);
+    assert_writable();
+    size_type limb = ix / limb_size;
+    size_type limb_ix = ix % limb_size;
+    uncow_root_if_needed_assume_nonempty();
+    uncow_if_needed(limb);
+    return (*start[limb])[limb_ix];
+  }
+  template<typename T, std::size_t limb_size>
+  const T &vector<T,limb_size>::at(size_type ix) const {
+    if (ix >= _size) throw std::out_of_range("ix");
+    return *deref(start, ix);
+  }
+
+  template<typename T, std::size_t limb_size, typename Fn>
+  void for_each(const vector<T,limb_size> &v, Fn&& f) {
+    typedef typename vector<T,limb_size>::size_type size_type;
+    typedef typename vector<T,limb_size>::limb_type limb_type;
+    size_type size = v.size();
+    const limb_type *const *limb = v.start;
+    const limb_type *const *const end = limb + size / limb_size;
+    for (; limb != end; ++limb) {
+      for (size_type limb_ix = 0; limb_ix != limb_size; ++limb_ix) {
+        f((**limb)[limb_ix]);
+      }
+    }
+    for (size_type limb_ix = 0; limb_ix < size % limb_size; ++limb_ix) {
+      f((**limb)[limb_ix]);
+    }
+  }
+  template<typename T, std::size_t limb_size, typename UP>
+  bool all_of(const vector<T,limb_size> &v, UP&& p) {
+    typedef typename vector<T,limb_size>::size_type size_type;
+    typedef typename vector<T,limb_size>::limb_type limb_type;
+    size_type size = v.size();
+    const limb_type *const *limb = v.start;
+    const limb_type *const *const end = limb + size / limb_size;
+    for (; limb != end; ++limb) {
+      for (size_type limb_ix = 0; limb_ix != limb_size; ++limb_ix) {
+        if (!p((**limb)[limb_ix])) return false;
+      }
+    }
+    for (size_type limb_ix = 0; limb_ix < size % limb_size; ++limb_ix) {
+      if (!p((**limb)[limb_ix])) return false;
+    }
+    return true;
+  }
+
+} // namespace gen
+
+#undef IFDEBUG
+
+#endif

--- a/src/GenVector_test.cpp
+++ b/src/GenVector_test.cpp
@@ -1,0 +1,210 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#ifdef HAVE_BOOST_UNIT_TEST_FRAMEWORK
+#include <boost/test/unit_test.hpp>
+
+#include "GenVector.h"
+
+BOOST_AUTO_TEST_SUITE(GenVector_test)
+
+BOOST_AUTO_TEST_CASE(Init_default){
+    BOOST_CHECK_EQUAL(gen::vector<int>().size(),0);
+}
+
+BOOST_AUTO_TEST_CASE(Push_one){
+    gen::vector<int> v;
+    v.push_back(42);
+    BOOST_CHECK_EQUAL(v.size(),1);
+    BOOST_CHECK_EQUAL(v[0],42);
+    BOOST_CHECK_EQUAL(v.mut(0),42);
+    v.mut(0) = 44;
+    BOOST_CHECK_EQUAL(v.mut(0),44);
+}
+
+BOOST_AUTO_TEST_CASE(Push_move){
+    struct move_only {
+        move_only() = default;
+        move_only(const move_only &) { BOOST_TEST_ERROR("Copy disallowed"); }
+        move_only(move_only &&) = default;
+        move_only &operator=(const move_only &) {
+            BOOST_TEST_ERROR("Copy disallowed");
+            return *this;
+        }
+        move_only &operator=(move_only &&) = default;
+    };
+    gen::vector<move_only> v;
+    v.push_back(move_only());
+}
+
+BOOST_AUTO_TEST_CASE(Push_several){
+    for (int i = 2; i < 6; ++i) {
+        gen::vector<int, 2> v;
+        for (int j = 0; j < i; ++j) {
+            v.push_back(42+j);
+            BOOST_CHECK_EQUAL(v.size(),j+1);
+        }
+        for (int j = 0; j < i; ++j) {
+            BOOST_CHECK_EQUAL(v[j],42+j);
+        }
+    }
+}
+
+#define CONSTRUCT_INITER(T,N,V) T N(V)
+#define ASSIGN_INITER(T,N,V) T N; N = (V)
+#define CASE_COW__same_address(Name, Initer)            \
+    BOOST_AUTO_TEST_CASE(COW_##Name##_same_address) {   \
+        for (int i = 2; i < 6; ++i) {                   \
+            gen::vector<int, 2> v;                      \
+            for (int j = 0; j < i; ++j) {               \
+                v.push_back(42 + j);                    \
+            }                                           \
+            typedef gen::vector<int, 2> gvi2;           \
+            Initer(gvi2, w, v);                         \
+            BOOST_CHECK_EQUAL(v.size(), w.size());      \
+            for (int j = 0; j < i; ++j) {               \
+                BOOST_CHECK_EQUAL(&v[j], &w[j]);        \
+            }                                           \
+        }                                               \
+  }
+CASE_COW__same_address(construct, CONSTRUCT_INITER)
+CASE_COW__same_address(assign, ASSIGN_INITER)
+
+BOOST_AUTO_TEST_CASE(COW_push) {
+    for (int i = 0; i < 5; ++i) {
+        gen::vector<int, 2> v;
+        for (int k = 0; k < i; ++k) {
+            v.push_back(42 + k);
+        }
+        for (int j = i; j < 6; ++j) {
+            gen::vector<int, 2> w(v);
+            for (int k = i; k < j; ++k) {
+                w.push_back(42 + k);
+                BOOST_CHECK_EQUAL(w.size(),k+1);
+            }
+            BOOST_CHECK_EQUAL(v.size(),i);
+            for (int k = 0; k < i; ++k)
+                BOOST_CHECK_EQUAL(v[k],42+k);
+            for (int k = 0; k < j; ++k)
+                BOOST_CHECK_EQUAL(w[k],42+k);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(COW_mut) {
+    for (int i = 1; i < 5; ++i) {
+        gen::vector<int, 2> v;
+        for (int k = 0; k < i; ++k) {
+            v.push_back(42 + k);
+        }
+        for (int j = 0; j < i; ++j) {
+            for (int k = 0; j < i; ++j) {
+                gen::vector<int, 2> w(v);
+                w.mut(j) = 42+i;
+                if (k != j) w.mut(k) = 43+i;
+                BOOST_CHECK_EQUAL(v.size(),i);
+                BOOST_CHECK_EQUAL(w.size(),i);
+                for (int l = 0; l < i; ++l)
+                    BOOST_CHECK_EQUAL(v[l],42+l);
+                for (int l = 0; l < j; ++l) {
+                    int expected = (l==j)?42+i:((l==k)?43+i:42+l);
+                    BOOST_CHECK_EQUAL(w[l],expected);
+                }
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(COW_push_mut) {
+    for (int i = 1; i < 5; ++i) {
+        gen::vector<int, 2> v;
+        for (int k = 0; k < i; ++k) {
+            v.push_back(42 + k);
+        }
+        for (int j = 0; j < i+1; ++j) {
+            gen::vector<int, 2> w(v);
+            w.push_back(42+i);
+            w.mut(j) = 43+i;
+            BOOST_CHECK_EQUAL(v.size(),i);
+            BOOST_CHECK_EQUAL(w.size(),i+1);
+            for (int l = 0; l < i; ++l)
+                BOOST_CHECK_EQUAL(v[l],42+l);
+            for (int l = 0; l < j; ++l) {
+                int expected = (l==j)?43+i:42+l;
+                BOOST_CHECK_EQUAL(w[l],expected);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(COW_mut_push) {
+    for (int i = 1; i < 5; ++i) {
+        gen::vector<int, 2> v;
+        for (int k = 0; k < i; ++k) {
+            v.push_back(42 + k);
+        }
+        for (int j = 0; j < i; ++j) {
+            gen::vector<int, 2> w(v);
+            w.mut(j) = 43+i;
+            w.push_back(42+i);
+            BOOST_CHECK_EQUAL(v.size(),i);
+            BOOST_CHECK_EQUAL(w.size(),i+1);
+            for (int l = 0; l < i; ++l)
+                BOOST_CHECK_EQUAL(v[l],42+l);
+            for (int l = 0; l < j; ++l) {
+                int expected = (l==j)?43+i:42+l;
+                BOOST_CHECK_EQUAL(w[l],expected);
+            }
+        }
+    }
+}
+
+#define CASE_move__push(Name, Initer)                           \
+    BOOST_AUTO_TEST_CASE(move_ ## Name ## _push) {              \
+        for (int i = 2; i < 6; ++i) {                           \
+            gen::vector<int, 2> v;                              \
+            for (int j = 0; j < i; ++j) {                       \
+                v.push_back(42+j);                              \
+            }                                                   \
+            typedef gen::vector<int, 2> gvi2;                   \
+            Initer(gvi2, w, std::move(v));                      \
+            BOOST_CHECK_EQUAL(v.size(), 0);                     \
+            BOOST_CHECK_EQUAL(w.size(), i);                     \
+            for (int j = 0; j < i; ++j) {                       \
+                BOOST_CHECK_EQUAL(w[j],42+j);                   \
+            }                                                   \
+            /* v is divorced from w, we can push to either */   \
+            v.push_back(99);                                    \
+            w.push_back(101);                                   \
+            BOOST_CHECK_EQUAL(v.size(), 1);                     \
+            BOOST_CHECK_EQUAL(w.size(), i+1);                   \
+            for (int j = 0; j < i; ++j) {                       \
+                BOOST_CHECK_EQUAL(w[j],42+j);                   \
+            }                                                   \
+            BOOST_CHECK_EQUAL(w[i], 101);                       \
+            BOOST_CHECK_EQUAL(v[0], 99);                        \
+        }                                                       \
+    }
+CASE_move__push(assign, ASSIGN_INITER)
+CASE_move__push(construct, CONSTRUCT_INITER)
+
+BOOST_AUTO_TEST_SUITE_END()
+#endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -65,6 +65,7 @@ unittest_SOURCES = \
   DPORDriver_test.cpp DPORDriver_test.h \
   DryRun_test.cpp \
   FBVClock_test.cpp \
+  GenVector_test.cpp \
   nregex_test.cpp \
   Observers_test.cpp \
   POWER_test.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -65,6 +65,7 @@ unittest_SOURCES = \
   DPORDriver_test.cpp DPORDriver_test.h \
   DryRun_test.cpp \
   FBVClock_test.cpp \
+  GenMap_test.cpp \
   GenVector_test.cpp \
   nregex_test.cpp \
   Observers_test.cpp \

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -1571,7 +1571,7 @@ RFSCTraceBuilder::try_sat
     = map(prefix, [](const Event &e) { return e.iid; });
   /* We need to preserve g */
   if (Option<std::vector<IID<int>>> res
-      = try_generate_prefix(g, std::move(current_exec))) {
+      = try_generate_prefix(std::move(g), std::move(current_exec))) {
     if (conf.debug_print_on_reset) {
       llvm::dbgs() << ": Heuristic found prefix\n";
       llvm::dbgs() << "[";
@@ -1583,8 +1583,7 @@ RFSCTraceBuilder::try_sat
     std::vector<unsigned> order = map(*res, [this](IID<int> iid) {
         return find_process_event(iid.get_pid(), iid.get_index());
       });
-    return order_to_leaf(decision, changed_events, std::move(order),
-                         std::move(g));
+    return order_to_leaf(decision, changed_events, std::move(order));
   }
 
   std::unique_ptr<SatSolver> sat = conf.get_sat_solver();
@@ -1623,13 +1622,12 @@ RFSCTraceBuilder::try_sat
     llvm::dbgs() << "]\n";
   }
 
-  return order_to_leaf(decision, changed_events, std::move(order),
-                       std::move(g));
+  return order_to_leaf(decision, changed_events, std::move(order));
 }
 
 RFSCTraceBuilder::Leaf RFSCTraceBuilder::order_to_leaf
 (int decision, std::initializer_list<unsigned> changed,
- const std::vector<unsigned> order, SaturatedGraph g) const{
+ const std::vector<unsigned> order) const{
   std::vector<Branch> new_prefix;
   new_prefix.reserve(order.size());
   for (unsigned i : order) {

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -185,7 +185,8 @@ void RFSCTraceBuilder::cancel_replay(){
     blame = std::max(blame, prefix[i].decision);
   }
   assert(int(decisions.size()) > blame);
-  decisions.resize(blame+1, decisions[0]);
+  while (decisions.size() > blame+1)
+      decisions.pop_back();
 }
 
 void RFSCTraceBuilder::metadata(const llvm::MDNode *md){
@@ -1529,7 +1530,7 @@ const SaturatedGraph &RFSCTraceBuilder::get_cached_graph(unsigned i) {
   for (unsigned j = i-1; j != 0; --j) {
     if (decisions[j].graph_cache.size()) {
       /* Reuse subgraph */
-      g = decisions[j].graph_cache;
+      g = decisions[j].graph_cache.clone();
       break;
     }
   }
@@ -1555,7 +1556,7 @@ RFSCTraceBuilder::try_sat
   int decision = prefix[last_change].decision;
   std::vector<bool> keep = causal_past(decision);
 
-  SaturatedGraph g(get_cached_graph(decision));
+  SaturatedGraph g(get_cached_graph(decision).clone());
   for (unsigned i = 0; i < prefix.size(); ++i) {
     if (keep[i] && i != last_change && !g.has_event(prefix[i].iid)) {
       add_event_to_graph(g, i);

--- a/src/RFSCTraceBuilder.h
+++ b/src/RFSCTraceBuilder.h
@@ -113,41 +113,50 @@ protected:
   struct UnfoldingNode;
   typedef llvm::SmallVector<std::weak_ptr<UnfoldingNode>,1> UnfoldingNodeChildren;
   struct UnfoldingNode {
-  public:
     UnfoldingNode(std::shared_ptr<UnfoldingNode> parent,
                   std::shared_ptr<UnfoldingNode> read_from)
       : parent(std::move(parent)), read_from(std::move(read_from)),
         seqno(++unf_ctr) {};
+    UnfoldingNode(const UnfoldingNode &) = default;
+    UnfoldingNode(UnfoldingNode &&) = default;
+    UnfoldingNode &operator=(const UnfoldingNode&) = default;
+    UnfoldingNode &operator=(UnfoldingNode&&) = default;
+
     std::shared_ptr<UnfoldingNode> parent, read_from;
     UnfoldingNodeChildren children;
     unsigned seqno;
   };
 
   struct Branch {
-  public:
     Branch(int pid, int size, int decision, bool pinned, SymEv sym)
       : pid(pid), size(size), decision(decision), pinned(pinned),
         sym(std::move(sym)) {}
     Branch() : Branch(-1, 0, -1, false, {}) {}
+    Branch(const Branch &) = default;
+    Branch(Branch &&) = default;
+    Branch &operator=(const Branch&) = default;
+    Branch &operator=(Branch&&) = default;
+
     int pid, size, decision;
     bool pinned;
     SymEv sym;
   };
 
   struct Leaf {
-  public:
     /* Construct a bottom-leaf. */
-    Leaf() : prefix() {}
+    Leaf() {}
     /* Construct a prefix leaf. */
     Leaf(std::vector<Branch> prefix) : prefix(prefix) {}
+    Leaf(const Leaf &) = default;
+    Leaf(Leaf &&) = default;
+    Leaf &operator=(const Leaf&) = default;
+    Leaf &operator=(Leaf&&) = default;
     std::vector<Branch> prefix;
 
     bool is_bottom() const { return prefix.empty(); }
   };
 
   struct DecisionNode {
-  public:
-    DecisionNode() : siblings() {}
     std::unordered_map<std::shared_ptr<UnfoldingNode>, Leaf> siblings;
     std::unordered_set<std::shared_ptr<UnfoldingNode>> sleep;
     SaturatedGraph graph_cache;
@@ -462,7 +471,7 @@ protected:
   void record_symbolic(SymEv event);
   Leaf try_sat(std::initializer_list<unsigned>, std::map<SymAddr,std::vector<int>> &);
   Leaf order_to_leaf(int decision, std::initializer_list<unsigned> changed,
-                     const std::vector<unsigned> order, SaturatedGraph g) const;
+                     const std::vector<unsigned> order) const;
   void output_formula(SatSolver &sat,
                       std::map<SymAddr,std::vector<int>> &,
                       const std::vector<bool> &);

--- a/src/SaturatedGraph.cpp
+++ b/src/SaturatedGraph.cpp
@@ -39,8 +39,6 @@ static Timing::Context saturate_rev1_timing("saturate_reverse_one");
 static Timing::Context add_edge_timing("add_edge");
 static Timing::Context add_event_timing("add_event");
 
-SaturatedGraph::SaturatedGraph() : saturated_until(0) {}
-
 template <typename T> void
 enlarge(immer::vector<T> &vec, std::size_t size, T val = {}) {
   if (vec.size() >= size) return;

--- a/src/SaturatedGraph.cpp
+++ b/src/SaturatedGraph.cpp
@@ -39,13 +39,11 @@ static Timing::Context saturate_rev1_timing("saturate_reverse_one");
 static Timing::Context add_edge_timing("add_edge");
 static Timing::Context add_event_timing("add_event");
 
-template <typename T> void
-enlarge(immer::vector<T> &vec, std::size_t size, T val = {}) {
+template <typename T>
+void enlarge(gen::vector<T> &vec, std::size_t size) {
   if (vec.size() >= size) return;
-  auto transient = std::move(vec).transient();
-  while (transient.size() < size)
-    transient.push_back(val);
-  vec = std::move(transient).persistent();
+  while (vec.size() < size)
+    vec.emplace_back();
 }
 
 void SaturatedGraph::add_event(Pid pid, ExtID extid, EventKind kind,
@@ -54,9 +52,6 @@ void SaturatedGraph::add_event(Pid pid, ExtID extid, EventKind kind,
   Timing::Guard timing_guard(add_event_timing);
   ID id = events.size();
   extid_to_id = std::move(extid_to_id).set(extid, id);
-  const auto add_out = [id](immer::vector<ID> o) {
-      return std::move(o).push_back(id);
-    };
   bool is_load = kind == LOAD || kind == RMW;
   bool is_store = kind == STORE || kind == RMW;
   Option<ID> po_predecessor;
@@ -68,17 +63,15 @@ void SaturatedGraph::add_event(Pid pid, ExtID extid, EventKind kind,
     po_predecessor = events_by_pid[pid].back();
     IFTRACE(std::cerr << "Adding PO(" << pid << ") between " << *po_predecessor << " and " << id << "\n");
     index = events.at(*po_predecessor).iid.get_index() + 1;
-    outs = std::move(outs).update(*po_predecessor, add_out);
+    outs.mut(*po_predecessor).push_back(id);
   }
-  events_by_pid = std::move(events_by_pid).update(pid, [id](auto v) {
-      return std::move(v).push_back(id);
-    });
+  events_by_pid.mut(pid).push_back(id);
 
   auto extid_to_id = [this](ExtID i) { return this->extid_to_id.at(i); };
   Option<ID> read_from = ext_read_from.map(extid_to_id);
 
-  immer::vector_transient<ID> out;
-  immer::vector_transient<ID> in;
+  gen::vector<ID> out;
+  gen::vector<ID> in;
   for (const ExtID &ei : orig_in) {
     ID i = extid_to_id(ei);
     IFTRACE(std::cerr << "Adding edge between " << i << " and " << id << "\n");
@@ -86,10 +79,7 @@ void SaturatedGraph::add_event(Pid pid, ExtID extid, EventKind kind,
   }
   if (read_from) {
     IFTRACE(std::cerr << "Adding read-from between " << *read_from << " and " << id << "\n");
-    events = std::move(events).update(*read_from, [id](Event w) {
-        w.readers = std::move(w.readers).push_back(id);
-        return w;
-      });
+    events.mut(*read_from).readers.push_back(id);
   } else if (is_load) {
     /* We do loads first so that in the case of RMW we do not find
      * ourselves in writes_by_address.
@@ -99,9 +89,7 @@ void SaturatedGraph::add_event(Pid pid, ExtID extid, EventKind kind,
       /* TODO: Optimise; only add the first write of each process */
       IFTRACE(std::cerr << "Adding from-read between " << id << " and " << w << "\n");
       out.push_back(w);
-      ins = std::move(ins).update(w, [id](immer::vector<ID> v) {
-          return std::move(v).push_back(id);
-        });
+      ins.mut(w).push_back(id);
       wq_add(w);
     }
   }
@@ -115,7 +103,7 @@ void SaturatedGraph::add_event(Pid pid, ExtID extid, EventKind kind,
       for (ID r : reads_from_init[addr]) {
         IFTRACE(std::cerr << "Adding from-read between " << r << " and " << id << "\n");
         in.push_back(r);
-        outs = std::move(outs).update(r, add_out);
+        outs.mut(r).push_back(id);
       }
       writes_by_address = std::move(writes_by_address).update
         (addr, [pid,id] (immer::map<Pid,ID> m) {
@@ -123,28 +111,25 @@ void SaturatedGraph::add_event(Pid pid, ExtID extid, EventKind kind,
                });
     }
 
-    writes_by_process_and_address = std::move(writes_by_process_and_address)
-      .update(pid, [id,addr](immer::map<SymAddr,immer::vector<ID>> m) {
-          return std::move(m).update(addr, [id](immer::vector<ID> v){
-                return std::move(v).push_back(id);
-              });
-        });
+    immer::map<SymAddr,immer::vector<ID>> &m = writes_by_process_and_address.mut(pid);
+    m = std::move(m).update(addr, [id](immer::vector<ID> v){
+            return std::move(v).push_back(id);
+          });
   }
 
   for (ID after : in) {
     IFTRACE(std::cerr << "Adding out edge for " << after << " and " << id << "\n");
-    outs = std::move(outs).update(after, add_out);
+    outs.mut(after).push_back(id);
   }
 
   IID<Pid> iid(pid, index);
-  events = std::move(events).push_back
-    (Event(iid, extid, is_load, is_store, addr, read_from, {}, po_predecessor));
-
+  /* XXX: Why can't we emplace_back here? */
+  events.push_back(Event(iid, extid, is_load, is_store, addr, read_from, {}, po_predecessor));
 
   assert(ins.size() == id);
-  ins = std::move(ins).push_back(std::move(in).persistent());
+  ins.push_back(std::move(in));
   assert(outs.size() == id);
-  outs = std::move(outs).push_back(std::move(out).persistent());
+  outs.push_back(std::move(out));
 
   if (!read_from && is_load) {
     /* Read from init */
@@ -155,7 +140,7 @@ void SaturatedGraph::add_event(Pid pid, ExtID extid, EventKind kind,
   }
 
   assert(vclocks.size() == id);
-  vclocks = std::move(vclocks).push_back({});
+  vclocks.emplace_back();
   wq_add(id);
 }
 
@@ -163,17 +148,16 @@ bool SaturatedGraph::saturate() {
   Timing::Guard saturate_guard(saturate_timing);
   check_graph_consistency();
   reverse_saturate();
-  std::vector<ID> new_in;
   std::vector<std::pair<ID,ID>> new_edges;
   while (!wq_empty()) {
     Timing::Guard saturate1_guard(saturate1_timing);
     const ID id = wq_pop();
+    bool new_in = false;
     assert(id < events.size());
-    new_in.clear();
     new_edges.clear();
     {
       Event e = events[id];
-      const immer::vector<ID> &old_in = ins[id];
+      const gen::vector<ID> &old_in = ins[id];
       VC vc = recompute_vc_for_event(e, old_in);
       const VC &old_vc = vclocks[id];
       if (is_in_cycle(e, old_in, vc)) {
@@ -212,12 +196,15 @@ bool SaturatedGraph::saturate() {
 
           /* Add edges */
           if (e.is_store) {
+            gen::vector<ID> &in = ins.mut(id);
             for (unsigned r : pe.readers) {
               if (r == id) continue; /* RMW we're reading from */
               /* from-read */
               assert(events[r].is_load && events[r].addr == e.addr);
               IFTRACE(std::cerr << "Adding from-read from " << r << " to " << id << "\n");
-              new_in.push_back(r);
+              in.push_back(r);
+              outs.mut(r).push_back(id);
+              new_in = true;
             }
           }
           if (e.is_load) {
@@ -241,19 +228,9 @@ bool SaturatedGraph::saturate() {
 
       add_successors_to_wq(id, e);
       IFTRACE(std::cerr << "Updating " << id << ": " << vc << "\n");
-      vclocks = vclocks.set(id, std::move(vc));
+      vclocks.mut(id) = std::move(vc);
     }
-    ins = std::move(ins).update(id, [&new_in](immer::vector<ID> v) {
-        auto tmp = std::move(v).transient();
-        for (ID b : new_in) tmp.push_back(b);
-        return tmp.persistent();
-      });
-    for (ID b : new_in) {
-      outs = std::move(outs).update(b, [id](immer::vector<ID> v) {
-          return std::move(v).push_back(id);
-        });
-    }
-    if (!new_in.empty()) wq_add_first(id);
+    if (new_in) wq_add_first(id);
     add_edges(new_edges);
   }
   check_graph_consistency();
@@ -261,13 +238,13 @@ bool SaturatedGraph::saturate() {
 }
 
 bool SaturatedGraph::is_in_cycle
-(const Event &e, const immer::vector<ID> &in, const VC &vc) const {
+(const Event &e, const gen::vector<ID> &in, const VC &vc) const {
   const auto vc_different = [&vc,this](unsigned other) {
-                              return vclocks[other].get() != vc;
+                              return vclocks[other] != vc;
                             };
   if (e.po_predecessor && !vc_different(*e.po_predecessor)) return true;
   if (e.read_from && !vc_different(*e.read_from)) return true;
-  if (!immer::all_of(in, vc_different)) return true;
+  if (!gen::all_of(in, vc_different)) return true;
   return false;
 }
 
@@ -308,7 +285,7 @@ SaturatedGraph::VC SaturatedGraph::initial_vc_for_event(const Event &e) const {
 }
 
 SaturatedGraph::VC SaturatedGraph::
-recompute_vc_for_event(const Event &e, const immer::vector<ID> &in) const {
+recompute_vc_for_event(const Event &e, const gen::vector<ID> &in) const {
   Timing::Guard timing_guard(saturate_vc_timing);
   VC vc = initial_vc_for_event(e);;
   const auto add_to_vc = [&vc,this](ID id) {
@@ -318,15 +295,15 @@ recompute_vc_for_event(const Event &e, const immer::vector<ID> &in) const {
   if (e.po_predecessor)
     add_to_vc(*e.po_predecessor);
   if (e.read_from) add_to_vc(*e.read_from);
-  immer::for_each(in, add_to_vc);
+  gen::for_each(in, add_to_vc);
   return vc;
 }
 
 void SaturatedGraph::add_successors_to_wq(ID id, const Event &e) {
   const auto add_to_wq = [this](unsigned id) { wq_add(id); };
   if (e.is_store)
-    immer::for_each(e.readers, add_to_wq);
-  immer::for_each(outs[id], add_to_wq);
+    gen::for_each(e.readers, add_to_wq);
+  gen::for_each(outs[id], add_to_wq);
 }
 
 void SaturatedGraph::wq_add(unsigned id) {
@@ -360,22 +337,22 @@ void SaturatedGraph::check_graph_consistency() const {
     const Event &e = events.at(id);
     /* All incoming types */
     for (ID in : ins[id]) {
-      assert(!immer::all_of(outs[in], is_not_id));
+      assert(!gen::all_of(outs[in], is_not_id));
     }
     if (e.read_from) {
       const ID w = *e.read_from;
       assert(events.at(w).is_store && events.at(w).addr == e.addr);
-      assert(!immer::all_of(events.at(w).readers, is_not_id));
-      // assert(immer::all_of(e.in, [w](unsigned v) { return v != w; }));
+      assert(!gen::all_of(events.at(w).readers, is_not_id));
+      // assert(gen::all_of(e.in, [w](unsigned v) { return v != w; }));
     }
     if (e.po_predecessor) {
-      assert(!immer::all_of(outs[*e.po_predecessor], is_not_id));
-      // assert(immer::all_of(e.in, [&e](unsigned v) { return v != *e.po_predecessor; }));
+      assert(!gen::all_of(outs[*e.po_predecessor], is_not_id));
+      // assert(gen::all_of(e.in, [&e](unsigned v) { return v != *e.po_predecessor; }));
     }
     /* All outgoing types */
     for (ID out : outs[id]) {
       const Event &oute = events.at(out);
-      assert(!immer::all_of(ins[out], is_not_id)
+      assert(!gen::all_of(ins[out], is_not_id)
              || (oute.po_predecessor && *oute.po_predecessor == id));
     }
     if (e.is_store) {
@@ -384,8 +361,8 @@ void SaturatedGraph::check_graph_consistency() const {
         assert(reade.is_load);
         assert(reade.read_from);
         assert(*reade.read_from == id);
-        // !immer::all_of(reade.read_froms, is_not_id)
-        // assert(immer::all_of(e.out, [r](unsigned v) { return v != r; })
+        // !gen::all_of(reade.read_froms, is_not_id)
+        // assert(gen::all_of(e.out, [r](unsigned v) { return v != r; })
         //        || (reade.po_predecessor && *reade.po_predecessor == id));
       }
     }
@@ -415,7 +392,7 @@ void SaturatedGraph::print_graph
 
 std::vector<SaturatedGraph::ExtID> SaturatedGraph::event_ids() const {
   std::vector<ExtID> ret;
-  immer::for_each(events, [&ret](const Event &e) { ret.push_back(e.ext_id); });
+  gen::for_each(events, [&ret](const Event &e) { ret.push_back(e.ext_id); });
   return ret;
 }
 
@@ -438,9 +415,9 @@ std::vector<SaturatedGraph::ExtID> SaturatedGraph::event_in(ExtID eid) const {
   std::vector<ExtID> ret;
   ID id = extid_to_id.at(eid);
   const Event &e = events[id];
-  const immer::vector<ID> &in = ins[id];
+  const gen::vector<ID> &in = ins[id];
   ret.reserve(in.size() + 2);
-  immer::for_each
+  gen::for_each
     (in, [&ret,this](ID e) { ret.push_back(events[e].ext_id); });
   if (e.po_predecessor) ret.push_back(events[*e.po_predecessor].ext_id);
   if (e.read_from)
@@ -454,12 +431,8 @@ void SaturatedGraph::add_edge(ExtID from, ExtID to) {
 
 void SaturatedGraph::add_edge_internal(ID from, ID to) {
   Timing::Guard timing_guard(add_edge_timing);
-  outs = std::move(outs).update(from, [to](immer::vector<ID> v) {
-                                        return std::move(v).push_back(to);
-                                      });
-  ins = std::move(ins).update(to, [from](immer::vector<ID> v) {
-                                    return std::move(v).push_back(from);
-                                  });
+  outs.mut(from).push_back(to);
+  ins.mut(to).push_back(from);
   wq_add(to);
 }
 
@@ -540,7 +513,7 @@ auto SaturatedGraph::reverse_care_set() const -> struct care {
 }
 
 auto SaturatedGraph::po_successor(ID id, const Event &e) const -> Option<ID> {
-  const immer::vector<ID> &events = events_by_pid[e.iid.get_pid()];
+  const gen::vector<ID> &events = events_by_pid[e.iid.get_pid()];
   if (events.back() == id) return nullptr;
   auto suc = std::upper_bound(events.begin(), events.end(), id);
   assert(suc != events.end());
@@ -550,8 +523,8 @@ auto SaturatedGraph::po_successor(ID id, const Event &e) const -> Option<ID> {
 template <typename Fn> void SaturatedGraph::
 foreach_succ(ID id, const Event &e, Fn f) const {
   if (Option<ID> suc = po_successor(id, e)) f(*suc);
-  immer::for_each(e.readers, f);
-  immer::for_each(outs[id], f);
+  gen::for_each(e.readers, f);
+  gen::for_each(outs[id], f);
 }
 
 void SaturatedGraph::add_to_care(struct care &care, unsigned id) const {

--- a/src/SaturatedGraph.cpp
+++ b/src/SaturatedGraph.cpp
@@ -233,6 +233,7 @@ bool SaturatedGraph::saturate() {
     if (new_in) wq_add_first(id);
     add_edges(new_edges);
   }
+  wq_set.clear();
   check_graph_consistency();
   return true;
 }
@@ -307,15 +308,17 @@ void SaturatedGraph::add_successors_to_wq(ID id, const Event &e) {
 }
 
 void SaturatedGraph::wq_add(unsigned id) {
-  if (wq_set.count(id)) return;
-  wq_queue = wq_queue.push_back(id);
-  wq_set = wq_set.insert(id);
+  if (wq_set.size() > id && wq_set[id]) return;
+  if (wq_set.size() <= id) wq_set.resize(id+1);
+  wq_set[id] = true;
+  wq_queue.push_back(id);
 }
 
 void SaturatedGraph::wq_add_first(unsigned id) {
-  if (wq_set.count(id)) return;
-  wq_queue = wq_queue.push_front(id);
-  wq_set = wq_set.insert(id);
+  if (wq_set.size() > id && wq_set[id]) return;
+  if (wq_set.size() <= id) wq_set.resize(id+1);
+  wq_set[id] = true;
+  wq_queue.push_front(id);
 }
 
 bool SaturatedGraph::wq_empty() const {
@@ -324,9 +327,9 @@ bool SaturatedGraph::wq_empty() const {
 
 unsigned SaturatedGraph::wq_pop() {
   assert(!wq_empty());
-  unsigned ret = wq_queue[0];
-  wq_queue = wq_queue.drop(1);
-  wq_set = wq_set.erase(ret);
+  unsigned ret = wq_queue.front();
+  wq_queue.pop_front();
+  wq_set[ret] = false;
   return ret;
 }
 

--- a/src/SaturatedGraph.h
+++ b/src/SaturatedGraph.h
@@ -25,17 +25,10 @@
 #include "VClock.h"
 #include "Option.h"
 #include "GenVector.h"
+#include "GenMap.h"
 
 #include <vector>
 #include <deque>
-
-/* We are never sharing immer datastructures between threads; omit
- * expensive atomic reference counting operations.
- */
-#define IMMER_NO_THREAD_SAFETY 1
-
-#include <immer/vector.hpp>
-#include <immer/map.hpp>
 
 class SaturatedGraph final {
 public:
@@ -118,15 +111,15 @@ private:
     Option<ID> po_predecessor;
   };
 
-  immer::map<ExtID,ID> extid_to_id;
+  gen::map<ExtID,ID> extid_to_id;
   gen::vector<Event> events;
   gen::vector<edge_vector> ins;
   gen::vector<edge_vector> outs;
-  immer::map<SymAddr,immer::map<Pid,ID>> writes_by_address;
-  immer::map<SymAddr,immer::vector<ID>> reads_from_init;
+  gen::map<SymAddr,gen::map<Pid,ID>> writes_by_address;
+  gen::map<SymAddr,gen::vector<ID>> reads_from_init;
   gen::vector<gen::vector<ID>> events_by_pid;
   gen::vector<VClock<int>> vclocks;
-  gen::vector<immer::map<SymAddr,immer::vector<ID>>>
+  gen::vector<gen::map<SymAddr,gen::vector<ID>>>
     writes_by_process_and_address;
   unsigned saturated_until = 0;
 

--- a/src/SaturatedGraph.h
+++ b/src/SaturatedGraph.h
@@ -40,7 +40,9 @@
 
 class SaturatedGraph final {
 public:
-  SaturatedGraph();
+  SaturatedGraph() = default;
+  SaturatedGraph(SaturatedGraph &&other) = default;
+  SaturatedGraph &operator=(SaturatedGraph &&other) = default;
 
   typedef IID<int> ExtID;
   typedef unsigned Pid;
@@ -77,7 +79,16 @@ public:
 
   void add_edge(ExtID from, ExtID to);
 
+  /* Clone this graph. This graph becomes read-only at this point, and must
+   * outlive the clone and any decendents of it.
+   */
+  SaturatedGraph clone() const {
+    return SaturatedGraph(*this);
+  };
+
 private:
+  explicit SaturatedGraph(const SaturatedGraph &other) = default;
+
   typedef unsigned ID;
   void add_edge_internal(ID from, ID to);
 
@@ -113,7 +124,7 @@ private:
   immer::vector<immer::box<VClock<int>>> vclocks;
   immer::vector<immer::map<SymAddr,immer::vector<ID>>>
     writes_by_process_and_address;
-  unsigned saturated_until;
+  unsigned saturated_until = 0;
 
   void add_edges(const std::vector<std::pair<ID,ID>> &);
   ID get_process_event(Pid pid, unsigned index) const;

--- a/src/SaturatedGraph.h
+++ b/src/SaturatedGraph.h
@@ -27,6 +27,7 @@
 #include "GenVector.h"
 
 #include <vector>
+#include <deque>
 
 /* We are never sharing immer datastructures between threads; omit
  * expensive atomic reference counting operations.
@@ -34,9 +35,7 @@
 #define IMMER_NO_THREAD_SAFETY 1
 
 #include <immer/vector.hpp>
-#include <immer/flex_vector.hpp>
 #include <immer/map.hpp>
-#include <immer/set.hpp>
 
 class SaturatedGraph final {
 public:
@@ -83,6 +82,9 @@ public:
    * outlive the clone and any decendents of it.
    */
   SaturatedGraph clone() const {
+    /* Not strictly necessary, but an assumption that informed the choice of
+     * queue data structures */
+    assert(wq_empty());
     return SaturatedGraph(*this);
   };
 
@@ -155,8 +157,8 @@ private:
   void check_graph_consistency() const {};
 #endif
 
-  immer::flex_vector<ID> wq_queue;
-  immer::set<ID> wq_set;
+  std::deque<ID> wq_queue;
+  std::vector<bool> wq_set;
   void wq_add(ID id);
   void wq_add_first(ID id);
   bool wq_empty() const;

--- a/src/SaturatedGraph.h
+++ b/src/SaturatedGraph.h
@@ -24,6 +24,7 @@
 #include "SymAddr.h"
 #include "VClock.h"
 #include "Option.h"
+#include "GenVector.h"
 
 #include <vector>
 
@@ -95,7 +96,7 @@ private:
   struct Event {
     Event() { abort(); }
     Event(IID<Pid> iid, ExtID ext_id, bool is_load, bool is_store, SymAddr addr,
-          Option<ID> read_from, immer::vector<ID> readers,
+          Option<ID> read_from, gen::vector<ID> readers,
           Option<ID> po_predecessor)
       : iid(iid), ext_id(ext_id), is_load(is_load), is_store(is_store), addr(addr),
         read_from(read_from), readers(std::move(readers)),
@@ -110,19 +111,19 @@ private:
      */
     Option<ID> read_from;
     /* The events that read from us. */
-    immer::vector<ID> readers;
+    gen::vector<ID> readers;
     Option<ID> po_predecessor;
   };
 
   immer::map<ExtID,ID> extid_to_id;
-  immer::vector<Event> events;
-  immer::vector<immer::vector<ID>> ins;
-  immer::vector<immer::vector<ID>> outs;
+  gen::vector<Event> events;
+  gen::vector<gen::vector<ID>> ins;
+  gen::vector<gen::vector<ID>> outs;
   immer::map<SymAddr,immer::map<Pid,ID>> writes_by_address;
   immer::map<SymAddr,immer::vector<ID>> reads_from_init;
-  immer::vector<immer::vector<ID>> events_by_pid;
-  immer::vector<immer::box<VClock<int>>> vclocks;
-  immer::vector<immer::map<SymAddr,immer::vector<ID>>>
+  gen::vector<gen::vector<ID>> events_by_pid;
+  gen::vector<VClock<int>> vclocks;
+  gen::vector<immer::map<SymAddr,immer::vector<ID>>>
     writes_by_process_and_address;
   unsigned saturated_until = 0;
 
@@ -131,9 +132,9 @@ private:
   Option<ID> maybe_get_process_event(Pid pid, unsigned index) const;
   VC initial_vc_for_event(IID<Pid> iid) const;
   VC initial_vc_for_event(const Event &e) const;
-  VC recompute_vc_for_event(const Event &e, const immer::vector<ID> &in) const;
+  VC recompute_vc_for_event(const Event &e, const gen::vector<ID> &in) const;
   void add_successors_to_wq(ID id, const Event &e);
-  bool is_in_cycle(const Event &e, const immer::vector<ID> &in, const VC &vc) const;
+  bool is_in_cycle(const Event &e, const gen::vector<ID> &in, const VC &vc) const;
   Option<ID> po_successor(ID id, const Event &e) const;
   VC top() const;
   struct care {


### PR DESCRIPTION
The data structures that back `SaturatedGraph` need to have a copy-on-write behaviour with some level of structural sharing to have good performance with the way they are cached and reused. During development it was convenient to use the _immer_ data structure libraries, which use reference counting for memory management.

However, the way we cache and reuse graph never has a derived graph outlive its parent, nor is a graph ever modified once it is inserted into the cache, from where it may be cloned. Using this fact, we can design data structures that do not rely on reference counting (or any other form of garbage collection) to manage memory, and yet provide these characteristics. We call them "generational" data structures.

`gen::vector` stores elements in chunks, typically 128 bytes. The root contains an array of pointers to all of the chunks, as well as a bitmap of which chunks it "owns". Attempting to update an element in a non-owned chunk, i.e. one that was inherited through cloning, makes a copy of the chunk and updates the copy. The root is also copied lazily, so that cloning a vector and doing only read accesses are constant-time operations.

`gen::map` implements a 32-ary hash-array mapped trie (HAMT), where each node keeps a "generation" number. The root owns all nodes with its generation number. Buckets are singly-linked lists.

These data structures offer a more conventional interface than immer, providing mutable accessors in addition to the immutable ones. It's not clear why immer doesn't offer this, as it simplifies using the library, especially in a performant manner.

Still, accessors that return mutable references are much more expensive than those that return immutable references. In order to make these new data structures more easy to use performantly I have chosen to not offer a non-const `operator[]` for either of these data structures, instead offering that as a separate method `mut()`, as it would otherwise be easy to call the non-const operator even when no mutation is intended.

Finally, the workqueue in `SaturatedGraph` is replaced with `std::deque` and `std::vector<bool>`, as the workqueue is always empty when graphs are cloned.