### PR TITLE
Fix gcc 7.5.0 warnings

### DIFF
--- a/src/RFSCDecisionTree.cpp
+++ b/src/RFSCDecisionTree.cpp
@@ -51,7 +51,7 @@ const std::shared_ptr<DecisionNode> &RFSCDecisionTree::find_ancestor
 
 RFSCScheduler::~RFSCScheduler() = default;
 
-PriorityQueueScheduler::PriorityQueueScheduler() : RFSCScheduler() {};
+PriorityQueueScheduler::PriorityQueueScheduler() : RFSCScheduler() {}
 
 void PriorityQueueScheduler::enqueue(std::shared_ptr<DecisionNode> node) {
   outstanding_jobs.fetch_add(1, std::memory_order_relaxed);
@@ -111,7 +111,7 @@ std::shared_ptr<DecisionNode> WorkstealingPQScheduler::dequeue() {
     /* Generate array of other threads in random order */
     std::vector<int> others(work_queue.size()-1);
     std::iota(others.begin(), others.end(), 0);
-    if (thread_id != others.size()) others[thread_id] = others.size();
+    if (std::size_t(thread_id) != others.size()) others[thread_id] = others.size();
     std::random_shuffle(others.begin(), others.end());
     for(int other : others) {
       std::lock_guard<std::mutex> other_lock(work_queue[other].mutex);

--- a/src/RFSCDecisionTree.h
+++ b/src/RFSCDecisionTree.h
@@ -60,7 +60,7 @@ public:
 struct DecisionNode {
 public:
   /* Empty constructor for root. */
-  DecisionNode() : parent(nullptr), depth(-1), pruned_subtree(false),
+  DecisionNode() : depth(-1), parent(nullptr), pruned_subtree(false),
                    cache_initialised(true) {}
   /* Constructor for new nodes during compute_unfolding. */
   DecisionNode(std::shared_ptr<DecisionNode> decision)

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -47,8 +47,9 @@ static Timing::Context sat_context("sat");
 RFSCTraceBuilder::RFSCTraceBuilder(RFSCDecisionTree &desicion_tree_,
                                    RFSCUnfoldingTree &unfolding_tree_,
                                    const Configuration &conf)
-    : decision_tree(desicion_tree_), unfolding_tree(unfolding_tree_),
-      TSOPSOTraceBuilder(conf) {
+    : TSOPSOTraceBuilder(conf),
+      unfolding_tree(unfolding_tree_),
+      decision_tree(desicion_tree_) {
     threads.push_back(Thread(CPid(), -1));
     prefix_idx = -1;
     replay = false;
@@ -252,7 +253,7 @@ bool RFSCTraceBuilder::reset(){
     new_prefix.reserve(l.prefix.size());
     std::vector<int> iid_map;
     for (Branch &b : l.prefix) {
-      int index = (iid_map.size() <= b.pid) ? 1 : iid_map[b.pid];
+      int index = (int(iid_map.size()) <= b.pid) ? 1 : iid_map[b.pid];
       IID<IPid> iid(b.pid, index);
       new_prefix.emplace_back(iid);
       new_prefix.back().size = b.size;

--- a/src/RFSCTraceBuilder.h
+++ b/src/RFSCTraceBuilder.h
@@ -230,8 +230,8 @@ protected:
   public:
     Event(const IID<IPid> &iid, int alt = 0, SymEv sym = {})
       : alt(0), size(1), pinned(false),
-      iid(iid), origin_iid(iid), md(0), clock(), may_conflict(false),
-        decision_depth(-1), sym(std::move(sym)), sleep_branch_trace_count(0) {};
+        iid(iid), origin_iid(iid), md(0), clock(), may_conflict(false),
+        sym(std::move(sym)), sleep_branch_trace_count(0), decision_depth(-1) {};
     /* Some instructions may execute in several alternative ways
      * nondeterministically. (E.g. malloc may succeed or fail
      * nondeterministically if Configuration::malloy_may_fail is set.)

--- a/src/TraceUtil.cpp
+++ b/src/TraceUtil.cpp
@@ -147,7 +147,7 @@ std::string TraceUtil::get_src_line_verbatim(const SrcLocVector::LocRef &loc) {
     fullname += loc.file;
   }
   std::ifstream ifs(fullname);
-  int cur_line = 0;
+  unsigned int cur_line = 0;
   std::string ln;
   while(ifs.good() && cur_line < loc.line){
     std::getline(ifs,ln);


### PR DESCRIPTION
On an Ubuntu 18.04 machine, which uses gcc 7.5.0, building nidhugg produces a number of warnings for signed/unsigned integer comparisons and for members not initialized in the proper order. This PR cleans up the code to shut off these warnings.