### PR TITLE
Handle unknown addresses gracefully in all operations

### DIFF
--- a/src/Execution.cpp
+++ b/src/Execution.cpp
@@ -1169,13 +1169,13 @@ void Interpreter::visitLoadInst(LoadInst &I) {
   GenericValue *Ptr = (GenericValue*)GVTOP(SRC);
   GenericValue Result;
 
-  /* XXX: Can't this one fail? */
-  SymAddrSize Ptr_sas = GetSymAddrSize(Ptr,I.getType());
+  Option<SymAddrSize> Ptr_sas = GetSymAddrSize(Ptr,I.getType());
+  if (!Ptr_sas) return;
   if (!conf.c11 || I.isVolatile() || I.getOrdering() != llvm::AtomicOrdering::NotAtomic)
-    TB.load(Ptr_sas);
+    TB.load(*Ptr_sas);
 
   if(DryRun && DryRunMem.size()){
-    DryRunLoadValueFromMemory(Result, Ptr, Ptr_sas, I.getType());
+    DryRunLoadValueFromMemory(Result, Ptr, *Ptr_sas, I.getType());
     SetValue(&I, Result, SF);
     return;
   }
@@ -1188,7 +1188,7 @@ void Interpreter::visitStoreInst(StoreInst &I) {
   ExecutionContext &SF = ECStack()->back();
   GenericValue Val = getOperandValue(I.getOperand(0), SF);
   GenericValue *Ptr = (GenericValue *)GVTOP(getOperandValue(I.getPointerOperand(), SF));
-  Option<SymAddrSize> Ptr_sas = TryGetSymAddrSizeOrSegv(Ptr,I.getOperand(0)->getType());
+  Option<SymAddrSize> Ptr_sas = GetSymAddrSize(Ptr,I.getOperand(0)->getType());
   if (!Ptr_sas) return;
 
   SymData sd = GetSymData(*Ptr_sas, I.getOperand(0)->getType(), Val);
@@ -1212,16 +1212,16 @@ void Interpreter::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I){
   Type *Ty = I.getCompareOperand()->getType();
   GenericValue Result;
 
-  /* XXX: Can't this one fail? */
-  SymAddrSize Ptr_sas = GetSymAddrSize(Ptr,Ty);
-  SymData::block_type expected = SymData::alloc_block(Ptr_sas.size);
+  Option<SymAddrSize> Ptr_sas = GetSymAddrSize(Ptr,Ty);
+  if (!Ptr_sas) return;
+  SymData::block_type expected = SymData::alloc_block(Ptr_sas->size);
   StoreValueToMemory(CmpVal,static_cast<GenericValue*>((void*)expected.get()),Ty);
 
 #if defined(LLVM_CMPXCHG_SEPARATE_SUCCESS_FAILURE_ORDERING)
   // Return a tuple (oldval,success)
   Result.AggregateVal.resize(2);
   if(DryRun && DryRunMem.size()){
-    DryRunLoadValueFromMemory(Result.AggregateVal[0], Ptr, Ptr_sas, Ty);
+    DryRunLoadValueFromMemory(Result.AggregateVal[0], Ptr, *Ptr_sas, Ty);
   }else{
     LoadValueFromMemory(Result.AggregateVal[0], Ptr, Ty);
   }
@@ -1229,13 +1229,13 @@ void Interpreter::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I){
 #else
   // Return only the old value oldval
   if(DryRun && DryRunMem.size()){
-    DryRunLoadValueFromMemory(Result, Ptr, Ptr_sas, Ty);
+    DryRunLoadValueFromMemory(Result, Ptr, *Ptr_sas, Ty);
   }else{
     LoadValueFromMemory(Result, Ptr, Ty);
   }
   GenericValue CmpRes = executeICMP_EQ(Result,CmpVal,Ty);
 #endif
-  SymData sd = GetSymData(Ptr_sas,Ty,NewVal);
+  SymData sd = GetSymData(*Ptr_sas,Ty,NewVal);
   TB.compare_exchange(sd, expected, CmpRes.IntVal.getBoolValue());
   if(CmpRes.IntVal.getBoolValue()){
 #if defined(LLVM_CMPXCHG_SEPARATE_SUCCESS_FAILURE_ORDERING)
@@ -1264,12 +1264,12 @@ void Interpreter::visitAtomicRMWInst(AtomicRMWInst &I){
   assert(I.getType()->isIntegerTy());
   assert(I.getOrdering() != llvm::AtomicOrdering::NotAtomic);
 
-  /* Can't this one fail? */
-  SymAddrSize Ptr_sas = GetSymAddrSize(Ptr,I.getType());
+  Option<SymAddrSize> Ptr_sas = GetSymAddrSize(Ptr,I.getType());
+  if (!Ptr_sas) return;
 
   /* Load old value at *Ptr */
   if(DryRun && DryRunMem.size()){
-    DryRunLoadValueFromMemory(OldVal, Ptr, Ptr_sas, I.getType());
+    DryRunLoadValueFromMemory(OldVal, Ptr, *Ptr_sas, I.getType());
   }else{
     LoadValueFromMemory(OldVal, Ptr, I.getType());
   }
@@ -1304,7 +1304,7 @@ void Interpreter::visitAtomicRMWInst(AtomicRMWInst &I){
     throw std::logic_error("Unsupported operation in RMW instruction.");
   }
 
-  SymData sd = GetSymData(Ptr_sas,I.getType(),NewVal);
+  SymData sd = GetSymData(*Ptr_sas,I.getType(),NewVal);
   TB.atomic_rmw(sd);
 
   /* Store NewVal */
@@ -2415,11 +2415,6 @@ GenericValue Interpreter::getOperandValue(Value *V, ExecutionContext &SF) {
 
 void Interpreter::callPthreadCreate(Function *F,
                                     const std::vector<GenericValue> &ArgVals) {
-  // Memory fence
-  TB.fence();
-
-  TB.spawn();
-
   // Return 0 (success)
   GenericValue Result;
   Result.IntVal = APInt(F->getReturnType()->getIntegerBitWidth(),0);
@@ -2431,7 +2426,7 @@ void Interpreter::callPthreadCreate(Function *F,
     GenericValue *Ptr = (GenericValue*)GVTOP(ArgVals[0]);
     if(Ptr){
       Type *ity = static_cast<PointerType*>(F->arg_begin()->getType())->getElementType();
-      if (!TryGetSymAddrSizeOrSegv(Ptr,ity)) return;
+      if (!GetSymAddrSize(Ptr,ity)) return;
       GenericValue TIDVal = tid_to_pthread_t(ity, new_tid);
       /* XXX: No race detection on this access! */
       StoreValueToMemory(TIDVal,Ptr,ity);
@@ -2440,11 +2435,17 @@ void Interpreter::callPthreadCreate(Function *F,
     }
   }
 
+  // Memory fence
+  TB.fence();
+
+  TB.spawn();
+
   // Add a new stack for the new thread
   int caller_thread = CurrentThread;
   CurrentThread = newThread(CPS.spawn(Threads[CurrentThread].cpid));
 
   // Build stack frame for the call
+  // XXX: No validation on argument value!
   Function *F_inner = (Function*)GVTOP(ArgVals[2]);
   std::vector<GenericValue> ArgVals_inner;
   if(F_inner->arg_size() == 1 &&
@@ -2485,7 +2486,7 @@ void Interpreter::callPthreadJoin(Function *F,
   GenericValue *rvPtr = (GenericValue*)GVTOP(ArgVals[1]);
   if(rvPtr){
     Type *ty = Type::getInt8PtrTy(F->getContext())->getPointerTo();
-    if (!TryGetSymAddrSizeOrSegv(rvPtr,ty)) return;
+    if (!GetSymAddrSize(rvPtr,ty)) return;
     /* XXX: No race detection on this access*/
     StoreValueToMemory(Threads[tid].RetVal,rvPtr,ty);
   }
@@ -2526,7 +2527,9 @@ void Interpreter::callPthreadMutexInit(Function *F,
     return;
   }
 
-  TB.mutex_init({GetSymAddr(lck),1}); // also acts as a fence
+  Option<SymAddr> addr = GetSymAddr(lck);
+  if (!addr) return;
+  TB.mutex_init({*addr,1}); // also acts as a fence
 
   if(PthreadMutexes.count(lck)){
     TB.pthreads_error("pthread_mutex_init called with already initialized mutex.");
@@ -2562,7 +2565,9 @@ void Interpreter::callPthreadMutexLock(void *lck){
     return;
   }
 
-  TB.mutex_lock({GetSymAddr(lck),1}); // also acts as a fence
+  Option<SymAddr> addr = GetSymAddr(lck);
+  if (!addr) return;
+  TB.mutex_lock({*addr,1}); // also acts as a fence
 
   if(PthreadMutexes.count(lck) == 0){
     if(conf.mutex_require_init){
@@ -2590,7 +2595,9 @@ void Interpreter::callPthreadMutexTryLock(Function *F,
     return;
   }
 
-  TB.mutex_trylock({GetSymAddr(lck),1}); // also acts as a fence
+  Option<SymAddr> addr = GetSymAddr(lck);
+  if (!addr) return;
+  TB.mutex_trylock({*addr,1}); // also acts as a fence
 
   if(PthreadMutexes.count(lck) == 0){
     if(conf.mutex_require_init){
@@ -2626,7 +2633,9 @@ void Interpreter::callPthreadMutexUnlock(Function *F,
     return;
   }
 
-  TB.mutex_unlock({GetSymAddr(lck),1}); // also acts as a fence
+  Option<SymAddr> addr = GetSymAddr(lck);
+  if (!addr) return;
+  TB.mutex_unlock({*addr,1}); // also acts as a fence
 
   if(PthreadMutexes.count(lck) == 0){
     if(conf.mutex_require_init){
@@ -2667,7 +2676,9 @@ void Interpreter::callPthreadMutexDestroy(Function *F,
     return;
   }
 
-  TB.mutex_destroy({GetSymAddr(lck),1}); // also acts as a fence
+  Option<SymAddr> addr = GetSymAddr(lck);
+  if (!addr) return;
+  TB.mutex_destroy({*addr,1}); // also acts as a fence
 
   if(PthreadMutexes.count(lck) == 0){
     if(conf.mutex_require_init){
@@ -2709,7 +2720,9 @@ void Interpreter::callPthreadCondInit(Function *F,
     return;
   }
 
-  if(!TB.cond_init({GetSymAddr(cnd),1})){ // also acts as a fence
+  Option<SymAddr> addr = GetSymAddr(cnd);
+  if (!addr) return;
+  if(!TB.cond_init({*addr,1})){ // also acts as a fence
     abort();
     return;
   }
@@ -2730,7 +2743,9 @@ void Interpreter::callPthreadCondSignal(Function *F,
     return;
   }
 
-  if(!TB.cond_signal({GetSymAddr(cnd),1})){ // also acts as a fence
+  Option<SymAddr> addr = GetSymAddr(cnd);
+  if (!addr) return;
+  if(!TB.cond_signal({*addr,1})){ // also acts as a fence
     abort();
     return;
   }
@@ -2751,7 +2766,9 @@ void Interpreter::callPthreadCondBroadcast(Function *F,
     return;
   }
 
-  if(!TB.cond_broadcast({GetSymAddr(cnd),1})){ // also acts as a fence
+  Option<SymAddr> addr = GetSymAddr(cnd);
+  if (!addr) return;
+  if(!TB.cond_broadcast({*addr,1})){ // also acts as a fence
     abort();
     return;
   }
@@ -2779,7 +2796,10 @@ void Interpreter::callPthreadCondWait(Function *F,
     return;
   }
 
-  if(!TB.cond_wait({GetSymAddr(cnd),1},{GetSymAddr(lck),1})){ // also acts as a fence
+  Option<SymAddr> cnd_sa = GetSymAddr(cnd);
+  Option<SymAddr> lck_sa = GetSymAddr(lck);
+  if (!cnd_sa || !lck_sa) return;
+  if(!TB.cond_wait({*cnd_sa,1},{*lck_sa,1})){ // also acts as a fence
     abort();
     return;
   }
@@ -2806,7 +2826,10 @@ void Interpreter::callPthreadCondWait(Function *F,
 void Interpreter::doPthreadCondAwake(void *cnd, void *lck){
   assert(lck);
 
-  TB.cond_awake({GetSymAddr(cnd),1},{GetSymAddr(lck),1}); // also acts as a fence
+  Option<SymAddr> cnd_sa = GetSymAddr(cnd);
+  Option<SymAddr> lck_sa = GetSymAddr(lck);
+  if (!cnd_sa || !lck_sa) return;
+  TB.cond_awake({*cnd_sa,1},{*lck_sa,1}); // also acts as a fence
 
   if(PthreadMutexes.count(lck) == 0){
     /* We don't need to check conf.mutex_require_init as the mutex is always
@@ -2833,7 +2856,9 @@ void Interpreter::callPthreadCondDestroy(Function *F,
     return;
   }
 
-  int rv = TB.cond_destroy({GetSymAddr(cnd),1}); // also acts as a fence
+  Option<SymAddr> addr = GetSymAddr(cnd);
+  if (!addr) return;
+  int rv = TB.cond_destroy({*addr,1}); // also acts as a fence
 
   if(rv == 0 || rv == EBUSY){
     GenericValue Result;
@@ -3182,10 +3207,12 @@ bool Interpreter::checkRefuse(Instruction &I){
   }
   {
     GenericValue *ptr;
+    Option<SymAddr> addr;
     if(isPthreadMutexLock(I,&ptr)){
-      if(PthreadMutexes.count(ptr) &&
+      if((addr = TryGetSymAddr(ptr)) &&
+         PthreadMutexes.count(ptr) &&
          PthreadMutexes[ptr].isLocked()){
-        TB.mutex_lock_fail({GetSymAddr(ptr),1});
+        TB.mutex_lock_fail({*addr,1});
         TB.refuse_schedule();
         PthreadMutexes[ptr].waiting.insert(CurrentThread);
         return true;
@@ -3230,26 +3257,18 @@ Option<SymAddr> Interpreter::TryGetSymAddr(void *Ptr) {
   return SymAddr(ub->second.block, (char*)Ptr - (char*)ub->first);
 }
 
-SymAddr Interpreter::GetSymAddr(void *Ptr) {
-  if (Option<SymAddr> ret = TryGetSymAddr(Ptr)) {
-    return *ret;
-  } else {
-    std::stringstream out;
-    out << std::hex << Ptr << std::dec;
-    llvm::dbgs() << "Memory at address " << out.str() + " was not allocated!\n";
-    std::abort();
+Option<SymAddr> Interpreter::GetSymAddr(void *Ptr) {
+  Option<SymAddr> ret = TryGetSymAddr(Ptr);
+  if (!ret) {
+    if (DryRun) {
+      TB.nondeterminism_error("Address of memory access became undefined "
+                              "in replay");
+    } else {
+      TB.segmentation_fault_error();
+    }
+    abort();
   }
-}
-
-SymAddrSize Interpreter::GetSymAddrSize(void *Ptr, Type *Ty){
-  if (Option<SymAddrSize> ret = TryGetSymAddrSize(Ptr, Ty)) {
-    return *ret;
-  } else {
-    std::stringstream out;
-    out << std::hex << Ptr << std::dec;
-    llvm::dbgs() << "Memory at address " << out.str() + " was not allocated!\n";
-    std::abort();
-  }
+  return ret;
 }
 
 void Interpreter::run() {

--- a/src/Interpreter_test.cpp
+++ b/src/Interpreter_test.cpp
@@ -1,0 +1,132 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#ifdef HAVE_BOOST_UNIT_TEST_FRAMEWORK
+
+#ifdef HAVE_VALGRIND_VALGRIND_H
+#include <valgrind/valgrind.h>
+#endif
+#include "DPORDriver.h"
+#include "DPORDriver_test.h"
+#include "StrModule.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(Interpreter_test)
+
+enum MM {
+  SC,
+  TSO,
+  PSO,
+};
+
+Configuration get_conf(MM mm) {
+  switch(mm) {
+  case SC:  return DPORDriver_test::get_sc_conf();
+  case TSO: return DPORDriver_test::get_tso_conf();
+  case PSO: return DPORDriver_test::get_pso_conf();
+  default: abort();
+  }
+}
+
+void do_test_error(const char *module, const std::initializer_list<MM> mms) {
+  for (MM mm : mms) {
+    BOOST_TEST_CHECKPOINT( "mm=" << mm );
+    Configuration conf = get_conf(mm);
+    std::unique_ptr<DPORDriver> driver(DPORDriver::parseIR(module, conf));
+    DPORDriver::Result res = driver->run();
+    BOOST_CHECK(res.trace_count == 1);
+    BOOST_CHECK(res.has_errors());
+  }
+}
+
+#define TEST_ERROR(Name, IR) TEST_ERROR2(Name, IR, "")
+#define TEST_ERROR2(Name, IR, IRAfter) TEST_ERROR3(Name, IR, IRAfter, SC)
+#define TEST_ERROR3(Name, IR, IRAfter, ...)                         \
+  BOOST_AUTO_TEST_CASE(Name){                                       \
+    do_test_error("define i32 @main(){\n" IR                        \
+                  "\n ret i32 0\n }\n" IRAfter, { __VA_ARGS__  });  \
+  }
+
+#define BADADDRT(T) T " inttoptr (i32 3735928559 to " T ")"
+#define BADADDR BADADDRT("i32*")
+
+TEST_ERROR3(Load_segv_badaddr, "load i32, " BADADDR, "", SC, TSO, PSO)
+TEST_ERROR3(Store_segv_badaddr, "store i32 42, " BADADDR, "", SC, TSO, PSO)
+TEST_ERROR(Cmpxhg_segv_badaddr, "cmpxchg " BADADDR ", i32 0, i32 42 seq_cst seq_cst")
+TEST_ERROR(Atomicrmw_segv_badaddr, "atomicrmw add " BADADDR ", i32 42 seq_cst")
+TEST_ERROR2(Pthread_create_tid_badaddr,
+            "call i32 @pthread_create(" BADADDR
+            ", i32* null, i8*(i8*)* @p1, i8* null)",
+            R"(define i8* @p1(i8*){ ret i8* null }
+               declare i32 @pthread_create(i32*, i32*, i8*(i8*)*, i8*))")
+// TEST_ERROR2(Pthread_create_proc_badaddr,
+//             "call i32 @pthread_create(i32* null, i32* null, "
+//             BADADDRT("i8*(i8*)*") ", i8* null)",
+//             R"(declare i32 @pthread_create(i32*, i32*, i8*(i8*)*, i8*))")
+TEST_ERROR2(Pthread_join_ret_badaddr,
+            R"(%tidp = alloca i8*
+               call i32 @pthread_create(i8** %tidp, i32* null, i8*(i8*)* @p1, i8* null)
+               %tid = load i8*, i8** %tidp
+               call i32 @pthread_join(i8* %tid, )" BADADDRT("i8**") ")",
+            R"(define i8* @p1(i8*){ ret i8* null }
+               declare i32 @pthread_create(i8**, i32*, i8*(i8*)*, i8*)
+               declare i32 @pthread_join(i8*, i8**))")
+TEST_ERROR2(Pthread_mutex_init_mtx_badaddr,
+            "call i32 @pthread_mutex_init(" BADADDR ", i32* null)",
+            "declare i32 @pthread_mutex_init(i32*, i32*)")
+TEST_ERROR2(Pthread_mutex_lock_badaddr,
+            "call i32 @pthread_mutex_lock(" BADADDR ")",
+            "declare i32 @pthread_mutex_lock(i32*)")
+TEST_ERROR2(Pthread_mutex_trylock_badaddr,
+            "call i32 @pthread_mutex_trylock(" BADADDR ")",
+            "declare i32 @pthread_mutex_trylock(i32*)")
+TEST_ERROR2(Pthread_mutex_unlock_badaddr,
+            "call i32 @pthread_mutex_unlock(" BADADDR ")",
+            "declare i32 @pthread_mutex_unlock(i32*)")
+TEST_ERROR2(Pthread_mutex_destroy_badaddr,
+            "call i32 @pthread_mutex_destroy(" BADADDR ")",
+            "declare i32 @pthread_mutex_destroy(i32*)")
+TEST_ERROR2(Pthread_cond_init_cnd_badaddr,
+            "call i32 @pthread_cond_init(" BADADDR ", i32* null)",
+            "declare i32 @pthread_cond_init(i32*, i32*)")
+TEST_ERROR2(Pthread_cond_wait_cnd_badaddr,
+            R"(call i32 @pthread_mutex_init(i32* @lck, i32* null)
+               call i32 @pthread_cond_wait()" BADADDR ", i32* @lck)",
+            R"(@lck = global i32 0, align 4
+               declare i32 @pthread_mutex_init(i32*, i32*)
+               declare i32 @pthread_cond_wait(i32*, i32*))")
+TEST_ERROR2(Pthread_cond_wait_mtx_badaddr,
+            R"(call i32 @pthread_cond_init(i32* @cnd, i32* null)
+               call i32 @pthread_cond_wait(i32* @cnd, )" BADADDR ")",
+            R"(@cnd = global i32 0, align 4
+               declare i32 @pthread_cond_init(i32*, i32*)
+               declare i32 @pthread_cond_wait(i32*, i32*))")
+TEST_ERROR2(Pthread_cond_broadcast_badaddr,
+            "call i32 @pthread_cond_broadcast(" BADADDR ")",
+            "declare i32 @pthread_cond_broadcast(i32*)")
+TEST_ERROR2(Pthread_cond_destroy_badaddr,
+            "call i32 @pthread_cond_destroy(" BADADDR ")",
+            "declare i32 @pthread_cond_destroy(i32*)")
+
+
+BOOST_AUTO_TEST_SUITE_END()
+
+#endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,6 +71,7 @@ unittest_SOURCES = \
   FBVClock_test.cpp \
   GenMap_test.cpp \
   GenVector_test.cpp \
+  Interpreter_test.cpp \
   nregex_test.cpp \
   Observers_test.cpp \
   POWER_test.cpp \

--- a/src/PSOInterpreter.cpp
+++ b/src/PSOInterpreter.cpp
@@ -238,13 +238,14 @@ bool PSOInterpreter::checkRefuse(llvm::Instruction &I){
     llvm::ExecutionContext &SF = ECStack()->back();
     llvm::GenericValue SRC = getOperandValue(static_cast<llvm::LoadInst&>(I).getPointerOperand(), SF);
     llvm::GenericValue *Ptr = (llvm::GenericValue*)GVTOP(SRC);
-    SymAddrSize mr = GetSymAddrSize(Ptr,static_cast<llvm::LoadInst&>(I).getType());
-    if(!pso_threads[CurrentThread].readable(mr)){
+    Option<SymAddrSize> mr = TryGetSymAddrSize(Ptr,static_cast<llvm::LoadInst&>(I).getType());
+    if (!mr) return false; /* Let it execute and segfault */
+    if(!pso_threads[CurrentThread].readable(*mr)){
       /* Block until this store buffer entry has disappeared from
        * the buffer.
        */
       pso_threads[CurrentThread].awaiting_buffer_flush = PSOThread::BFL_PARTIAL;
-      pso_threads[CurrentThread].buffer_flush_ml = mr;
+      pso_threads[CurrentThread].buffer_flush_ml = *mr;
       TB.refuse_schedule();
       return true;
     }
@@ -258,23 +259,23 @@ void PSOInterpreter::visitLoadInst(llvm::LoadInst &I){
   llvm::GenericValue *Ptr = (llvm::GenericValue*)GVTOP(SRC);
   llvm::GenericValue Result;
 
-  /* XXX: Check for segfault */
-  SymAddrSize ml = GetSymAddrSize(Ptr,I.getType());
-  TB.load(ml);
+  Option<SymAddrSize> ml = GetSymAddrSize(Ptr,I.getType());
+  if (!ml) return;
+  TB.load(*ml);
 
   if(DryRun && DryRunMem.size()){
     assert(pso_threads[CurrentThread].all_buffers_empty());
-    DryRunLoadValueFromMemory(Result, Ptr, ml, I.getType());
+    DryRunLoadValueFromMemory(Result, Ptr, *ml, I.getType());
     SetValue(&I, Result, SF);
     return;
   }
 
   /* Check store buffer for ROWE opportunity. */
-  if(pso_threads[CurrentThread].store_buffers.count(ml.addr)){
-    uint8_t *blk = new uint8_t[ml.size];
-    for(SymAddr b : ml){
-      assert(pso_threads[CurrentThread].store_buffers[b].back().ml == ml);
-      blk[b - ml.addr] = pso_threads[CurrentThread].store_buffers[b].back().val;
+  if(pso_threads[CurrentThread].store_buffers.count(ml->addr)){
+    uint8_t *blk = new uint8_t[ml->size];
+    for(SymAddr b : *ml){
+      assert(pso_threads[CurrentThread].store_buffers[b].back().ml == *ml);
+      blk[b - ml->addr] = pso_threads[CurrentThread].store_buffers[b].back().val;
     }
     LoadValueFromMemory(Result,(llvm::GenericValue*)blk,I.getType());
     SetValue(&I, Result, SF);
@@ -293,8 +294,8 @@ void PSOInterpreter::visitStoreInst(llvm::StoreInst &I){
   llvm::GenericValue *Ptr = (llvm::GenericValue *)GVTOP
     (getOperandValue(I.getPointerOperand(), SF));
 
-  /* XXX: Check for segfault */
-  SymData mb = GetSymData(Ptr, I.getOperand(0)->getType(), Val);
+  Option<SymData> mb = GetSymData(Ptr, I.getOperand(0)->getType(), Val);
+  if (!mb) return;
 
   PSOThread &thr = pso_threads[CurrentThread];
 
@@ -302,29 +303,29 @@ void PSOInterpreter::visitStoreInst(llvm::StoreInst &I){
      0 <= AtomicFunctionCall){
     /* Atomic store */
     assert(thr.all_buffers_empty());
-    TB.atomic_store(mb);
+    TB.atomic_store(*mb);
     if(DryRun){
-      DryRunMem.push_back(mb);
+      DryRunMem.push_back(*mb);
       return;
     }
     StoreValueToMemory(Val, Ptr, I.getOperand(0)->getType());
   }else{
     /* Store to buffer */
-    const SymAddrSize &ml = mb.get_ref();
+    const SymAddrSize &ml = mb->get_ref();
     if(thr.byte_to_aux.count(ml.addr) == 0){
       thr.byte_to_aux[ml.addr] = int(thr.aux_to_byte.size());
       thr.aux_to_byte.push_back(ml.addr);
       thr.aux_to_addr.push_back((uint8_t*)Ptr);
     }
 
-    TB.store(mb);
+    TB.store(*mb);
     if(DryRun){
-      DryRunMem.push_back(mb);
+      DryRunMem.push_back(*mb);
       return;
     }
     for(SymAddr b : ml){
       unsigned i = b - ml.addr;
-      thr.store_buffers[b].push_back(PendingStoreByte(ml,((uint8_t*)mb.get_block())[i]));
+      thr.store_buffers[b].push_back(PendingStoreByte(ml,((uint8_t*)mb->get_block())[i]));
     }
   }
 }

--- a/src/TSOInterpreter.cpp
+++ b/src/TSOInterpreter.cpp
@@ -203,10 +203,11 @@ bool TSOInterpreter::checkRefuse(llvm::Instruction &I){
     llvm::ExecutionContext &SF = ECStack()->back();
     llvm::GenericValue SRC = getOperandValue(static_cast<llvm::LoadInst&>(I).getPointerOperand(), SF);
     llvm::GenericValue *Ptr = (llvm::GenericValue*)GVTOP(SRC);
-    SymAddrSize mr = GetSymAddrSize(Ptr,static_cast<llvm::LoadInst&>(I).getType());
+    Option<SymAddrSize> mr = TryGetSymAddrSize(Ptr,static_cast<llvm::LoadInst&>(I).getType());
+    if (!mr) return false; /* Let it execute and segfault */
     for(int i = int(tso_threads[CurrentThread].store_buffer.size())-1; 0 <= i; --i){
-      if(mr.overlaps(tso_threads[CurrentThread].store_buffer[i].second.get_ref())){
-        if(mr != tso_threads[CurrentThread].store_buffer[i].second.get_ref()){
+      if(mr->overlaps(tso_threads[CurrentThread].store_buffer[i].second.get_ref())){
+        if(*mr != tso_threads[CurrentThread].store_buffer[i].second.get_ref()){
           /* Block until this store buffer entry has disappeared from
            * the buffer.
            */
@@ -228,21 +229,22 @@ void TSOInterpreter::visitLoadInst(llvm::LoadInst &I){
   llvm::GenericValue *Ptr = (llvm::GenericValue*)GVTOP(SRC);
   llvm::GenericValue Result;
 
-  SymAddrSize Ptr_sas = GetSymAddrSize(Ptr,I.getType());
-  TB.load(Ptr_sas);
+  Option<SymAddrSize> Ptr_sas = GetSymAddrSize(Ptr,I.getType());
+  if (!Ptr_sas) return;
+  TB.load(*Ptr_sas);
 
   if(DryRun && DryRunMem.size()){
     assert(tso_threads[CurrentThread].store_buffer.empty());
-    DryRunLoadValueFromMemory(Result, Ptr, Ptr_sas, I.getType());
+    DryRunLoadValueFromMemory(Result, Ptr, *Ptr_sas, I.getType());
     SetValue(&I, Result, SF);
     return;
   }
 
   /* Check store buffer for ROWE opportunity. */
   for(int i = int(tso_threads[CurrentThread].store_buffer.size())-1; 0 <= i; --i){
-    if(Ptr_sas.addr == tso_threads[CurrentThread].store_buffer[i].second.get_ref().addr){
+    if(Ptr_sas->addr == tso_threads[CurrentThread].store_buffer[i].second.get_ref().addr){
       /* Read-Own-Write-Early */
-      assert(GetSymAddrSize(Ptr,I.getType()).size == tso_threads[CurrentThread].store_buffer[i].second.get_ref().size);
+      assert(Ptr_sas->size == tso_threads[CurrentThread].store_buffer[i].second.get_ref().size);
       LoadValueFromMemory(Result,(llvm::GenericValue*)tso_threads[CurrentThread].store_buffer[i].second.get_block(),I.getType());
       SetValue(&I, Result, SF);
       return;
@@ -258,26 +260,27 @@ void TSOInterpreter::visitStoreInst(llvm::StoreInst &I){
   llvm::ExecutionContext &SF = ECStack()->back();
   llvm::GenericValue Val = getOperandValue(I.getOperand(0), SF);
   llvm::GenericValue *Ptr = (llvm::GenericValue *)GVTOP(getOperandValue(I.getPointerOperand(), SF));
-  SymData sd = GetSymData(Ptr, I.getOperand(0)->getType(), Val);
+  Option<SymData> sd = GetSymData(Ptr, I.getOperand(0)->getType(), Val);
+  if (!sd) return;
 
   if(I.getOrdering() == LLVM_ATOMIC_ORDERING_SCOPE::SequentiallyConsistent ||
      0 <= AtomicFunctionCall){
     /* Atomic store */
     assert(tso_threads[CurrentThread].store_buffer.empty());
-    TB.atomic_store(sd);
+    TB.atomic_store(*sd);
     if(DryRun){
-      DryRunMem.push_back(std::move(sd));
+      DryRunMem.push_back(std::move(*sd));
       return;
     }
     StoreValueToMemory(Val, Ptr, I.getOperand(0)->getType());
   }else{
     /* Store to buffer */
-    TB.store(sd);
+    TB.store(*sd);
     if(DryRun){
-      DryRunMem.push_back(std::move(sd));
+      DryRunMem.push_back(std::move(*sd));
       return;
     }
-    tso_threads[CurrentThread].store_buffer.emplace_back(Ptr, std::move(sd));
+    tso_threads[CurrentThread].store_buffer.emplace_back(Ptr, std::move(*sd));
   }
 }
 


### PR DESCRIPTION
Previously, passing bad memory addresses to many operations resulted in nidhugg aborting with a message `Memory at address 0xabcdef was not allocated!` rather than a proper error report. This should resolve that problem.

This applies to the frontends for the SC, TSO, and PSO memory models.

Todo:
- [x] Tests