### PR TITLE
Use recorded symbolic events to check for nondeterminism

### DIFF
--- a/src/CompilerHelp.h
+++ b/src/CompilerHelp.h
@@ -1,0 +1,24 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#if __GNUC__ > 6 || __clang_major__ > 5
+#  define NODISCARD __attribute__((warn_unused_result))
+#else
+#  define NODISCARD
+#endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,6 +79,7 @@ unittest_SOURCES = \
   PSO_test.cpp \
   PSO_test2.cpp \
   Regression_test.cpp \
+  RFSC_test.cpp \
   RMW_test.cpp \
   Robustness_test.cpp \
   SC_test.cpp \

--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -401,7 +401,7 @@ void PSOTraceBuilder::debug_print() const {
   }
 }
 
-void PSOTraceBuilder::spawn(){
+bool PSOTraceBuilder::spawn(){
   IPid parent_ipid = curnode().iid.get_pid();
   IPid child_ipid = threads.size();
   CPid child_cpid = CPS.spawn(threads[parent_ipid].cpid);
@@ -412,10 +412,11 @@ void PSOTraceBuilder::spawn(){
   proc_to_ipid.push_back(child_ipid);
   threads.push_back(Thread(proc,child_cpid,threads[parent_ipid].clock,parent_ipid));
   mark_available_ipid(child_ipid);
+  return true;
 }
 
-void PSOTraceBuilder::store(const SymData &sd){
-  if(dryrun) return;
+bool PSOTraceBuilder::store(const SymData &sd){
+  if(dryrun) return true;
   const SymAddrSize &ml = sd.get_ref();
   IPid ipid = curnode().iid.get_pid();
   for(SymAddr b : ml){
@@ -435,9 +436,10 @@ void PSOTraceBuilder::store(const SymData &sd){
     upd_ipid = threads[ipid].aux_to_ipid[it->second];
   }
   mark_available_ipid(upd_ipid);
+  return true;
 }
 
-void PSOTraceBuilder::atomic_store(const SymData &sd){
+bool PSOTraceBuilder::atomic_store(const SymData &sd){
   const SymAddrSize &ml = sd.get_ref();
   if(dryrun){
     assert(prefix_idx+1 < int(prefix.size()));
@@ -447,7 +449,7 @@ void PSOTraceBuilder::atomic_store(const SymData &sd){
     for(SymAddr b : ml){
       A.insert(b);
     }
-    return;
+    return true;
   }
   IPid ipid = curnode().iid.get_pid();
   curnode().may_conflict = true;
@@ -527,18 +529,19 @@ void PSOTraceBuilder::atomic_store(const SymData &sd){
     }
     threads[tipid].aux_clock_sum += curnode().clock;
   }
+  return true;
 }
 
-void PSOTraceBuilder::compare_exchange
+bool PSOTraceBuilder::compare_exchange
 (const SymData &sd, const SymData::block_type expected, bool success){
   if(success){
-    atomic_store(sd);
+    return atomic_store(sd);
   }else{
-    load(sd.get_ref());
+    return load(sd.get_ref());
   }
 }
 
-void PSOTraceBuilder::load(const SymAddrSize &ml){
+bool PSOTraceBuilder::load(const SymAddrSize &ml){
   if(dryrun){
     assert(prefix_idx+1 < int(prefix.size()));
     assert(dry_sleepers <= prefix[prefix_idx+1].sleep.size());
@@ -547,7 +550,7 @@ void PSOTraceBuilder::load(const SymAddrSize &ml){
     for(SymAddr b : ml){
       A.insert(b);
     }
-    return;
+    return true;
   }
   curnode().may_conflict = true;
   IPid ipid = curnode().iid.get_pid();
@@ -560,7 +563,7 @@ void PSOTraceBuilder::load(const SymAddrSize &ml){
       assert(sb.size());
       assert(sb.back().ml == ml);
       sb.back().last_rowe = prefix_idx;
-      return;
+      return true;
     }
   }
 
@@ -596,15 +599,16 @@ void PSOTraceBuilder::load(const SymAddrSize &ml){
     mem[b].last_read[threads[ipid].proc] = prefix_idx;
     wakeup(Access::R,b);
   }
+  return true;
 }
 
-void PSOTraceBuilder::full_memory_conflict(){
+bool PSOTraceBuilder::full_memory_conflict(){
   if(dryrun){
     assert(prefix_idx+1 < int(prefix.size()));
     assert(dry_sleepers <= prefix[prefix_idx+1].sleep.size());
     IPid pid = prefix[prefix_idx+1].sleep[dry_sleepers-1];
     threads[pid].sleep_full_memory_conflict = true;
-    return;
+    return true;
   }
   curnode().may_conflict = true;
 
@@ -628,36 +632,39 @@ void PSOTraceBuilder::full_memory_conflict(){
 
   /* No later access can have a conflict with any earlier access */
   mem.clear();
+  return true;
 }
 
-void PSOTraceBuilder::fence(){
-  if(dryrun) return;
+bool PSOTraceBuilder::fence(){
+  if(dryrun) return true;
   IPid ipid = curnode().iid.get_pid();
   assert(!threads[ipid].cpid.is_auxiliary());
   assert(threads[ipid].all_buffers_empty());
   curnode().clock += threads[ipid].aux_clock_sum;
   threads[ipid].clock += threads[ipid].aux_clock_sum;
+  return true;
 }
 
-void PSOTraceBuilder::join(int tgt_proc){
-  if(dryrun) return;
+bool PSOTraceBuilder::join(int tgt_proc){
+  if(dryrun) return true;
   assert(0 <= tgt_proc && tgt_proc < int(proc_to_ipid.size()));
   IPid ipid = curnode().iid.get_pid();
   IPid tgt_ipid = proc_to_ipid[tgt_proc];
   curnode().clock += threads[tgt_ipid].clock;
   curnode().clock += threads[tgt_ipid].aux_clock_sum;
   threads[ipid].clock += curnode().clock;
+  return true;
 }
 
-void PSOTraceBuilder::mutex_lock(const SymAddrSize &ml){
+bool PSOTraceBuilder::mutex_lock(const SymAddrSize &ml){
   if(dryrun){
     assert(prefix_idx+1 < int(prefix.size()));
     assert(dry_sleepers <= prefix[prefix_idx+1].sleep.size());
     IPid pid = prefix[prefix_idx+1].sleep[dry_sleepers-1];
     threads[pid].sleep_accesses_w.insert(ml.addr);
-    return;
+    return true;
   }
-  fence();
+  if (!fence()) return false;
   curnode().may_conflict = true;
   wakeup(Access::W,ml.addr);
 
@@ -679,9 +686,10 @@ void PSOTraceBuilder::mutex_lock(const SymAddrSize &ml){
 
   mutex.last_lock = mutex.last_access = prefix_idx;
   mutex.locked = true;
+  return true;
 }
 
-void PSOTraceBuilder::mutex_lock_fail(const SymAddrSize &ml){
+bool PSOTraceBuilder::mutex_lock_fail(const SymAddrSize &ml){
   assert(!dryrun);
   assert(mutexes.count(ml.addr));
   Mutex &mutex = mutexes[ml.addr];
@@ -694,17 +702,18 @@ void PSOTraceBuilder::mutex_lock_fail(const SymAddrSize &ml){
      !prefix[last_full_memory_conflict].clock.leq(curnode().clock)){
     add_branch(last_full_memory_conflict,prefix_idx);
   }
+  return true;
 }
 
-void PSOTraceBuilder::mutex_unlock(const SymAddrSize &ml){
+bool PSOTraceBuilder::mutex_unlock(const SymAddrSize &ml){
   if(dryrun){
     assert(prefix_idx+1 < int(prefix.size()));
     assert(dry_sleepers <= prefix[prefix_idx+1].sleep.size());
     IPid pid = prefix[prefix_idx+1].sleep[dry_sleepers-1];
     threads[pid].sleep_accesses_w.insert(ml.addr);
-    return;
+    return true;
   }
-  fence();
+  if (!fence()) return false;
   assert(mutexes.count(ml.addr));
   Mutex &mutex = mutexes[ml.addr];
   curnode().may_conflict = true;
@@ -715,17 +724,18 @@ void PSOTraceBuilder::mutex_unlock(const SymAddrSize &ml){
 
   mutex.last_access = prefix_idx;
   mutex.locked = false;
+  return true;
 }
 
-void PSOTraceBuilder::mutex_trylock(const SymAddrSize &ml){
+bool PSOTraceBuilder::mutex_trylock(const SymAddrSize &ml){
   if(dryrun){
     assert(prefix_idx+1 < int(prefix.size()));
     assert(dry_sleepers <= prefix[prefix_idx+1].sleep.size());
     IPid pid = prefix[prefix_idx+1].sleep[dry_sleepers-1];
     threads[pid].sleep_accesses_w.insert(ml.addr);
-    return;
+    return true;
   }
-  fence();
+  if (!fence()) return false;
   assert(mutexes.count(ml.addr));
   curnode().may_conflict = true;
   wakeup(Access::W,ml.addr);
@@ -737,33 +747,35 @@ void PSOTraceBuilder::mutex_trylock(const SymAddrSize &ml){
     mutex.last_lock = prefix_idx;
     mutex.locked = true;
   }
+  return true;
 }
 
-void PSOTraceBuilder::mutex_init(const SymAddrSize &ml){
+bool PSOTraceBuilder::mutex_init(const SymAddrSize &ml){
   if(dryrun){
     assert(prefix_idx+1 < int(prefix.size()));
     assert(dry_sleepers <= prefix[prefix_idx+1].sleep.size());
     IPid pid = prefix[prefix_idx+1].sleep[dry_sleepers-1];
     threads[pid].sleep_accesses_w.insert(ml.addr);
-    return;
+    return true;
   }
-  fence();
+  if (!fence()) return false;
   curnode().may_conflict = true;
   Mutex &mutex = mutexes[ml.addr];
   see_events({mutex.last_access, last_full_memory_conflict});
 
   mutex.last_access = prefix_idx;
+  return true;
 }
 
-void PSOTraceBuilder::mutex_destroy(const SymAddrSize &ml){
+bool PSOTraceBuilder::mutex_destroy(const SymAddrSize &ml){
   if(dryrun){
     assert(prefix_idx+1 < int(prefix.size()));
     assert(dry_sleepers <= prefix[prefix_idx+1].sleep.size());
     IPid pid = prefix[prefix_idx+1].sleep[dry_sleepers-1];
     threads[pid].sleep_accesses_w.insert(ml.addr);
-    return;
+    return true;
   }
-  fence();
+  if (!fence()) return false;
   assert(mutexes.count(ml.addr));
   Mutex &mutex = mutexes[ml.addr];
   curnode().may_conflict = true;
@@ -772,6 +784,7 @@ void PSOTraceBuilder::mutex_destroy(const SymAddrSize &ml){
   see_events({mutex.last_access,last_full_memory_conflict});
 
   mutexes.erase(ml.addr);
+  return true;
 }
 
 bool PSOTraceBuilder::cond_init(const SymAddrSize &ml){
@@ -782,7 +795,7 @@ bool PSOTraceBuilder::cond_init(const SymAddrSize &ml){
     threads[pid].sleep_accesses_w.insert(ml.addr);
     return true;
   }
-  fence();
+  if (!fence()) return false;
   if(cond_vars.count(ml.addr)){
     pthreads_error("Condition variable initiated twice.");
     return false;
@@ -801,7 +814,7 @@ bool PSOTraceBuilder::cond_signal(const SymAddrSize &ml){
     threads[pid].sleep_accesses_w.insert(ml.addr);
     return true;
   }
-  fence();
+  if (!fence()) return false;
   curnode().may_conflict = true;
   wakeup(Access::W,ml.addr);
 
@@ -813,7 +826,7 @@ bool PSOTraceBuilder::cond_signal(const SymAddrSize &ml){
   CondVar &cond_var = it->second;
   VecSet<int> seen_events = {last_full_memory_conflict};
   if(cond_var.waiters.size() > 1){
-    register_alternatives(cond_var.waiters.size());
+    if (!register_alternatives(cond_var.waiters.size())) return false;
   }
   assert(0 <= curnode().alt);
   assert(cond_var.waiters.empty() || curnode().alt < int(cond_var.waiters.size()));
@@ -851,7 +864,7 @@ bool PSOTraceBuilder::cond_broadcast(const SymAddrSize &ml){
     threads[pid].sleep_accesses_w.insert(ml.addr);
     return true;
   }
-  fence();
+  if (!fence()) return false;
   curnode().may_conflict = true;
   wakeup(Access::W,ml.addr);
 
@@ -895,7 +908,7 @@ bool PSOTraceBuilder::cond_wait(const SymAddrSize &cond_ml, const SymAddrSize &m
     }
   }
 
-  mutex_unlock(mutex_ml);
+  if (!mutex_unlock(mutex_ml)) return false;
   if(dryrun){
     assert(prefix_idx+1 < int(prefix.size()));
     assert(dry_sleepers <= prefix[prefix_idx+1].sleep.size());
@@ -903,7 +916,7 @@ bool PSOTraceBuilder::cond_wait(const SymAddrSize &cond_ml, const SymAddrSize &m
     threads[pid].sleep_accesses_r.insert(cond_ml.addr);
     return true;
   }
-  fence();
+  if (!fence()) return false;
   curnode().may_conflict = true;
   wakeup(Access::R,cond_ml.addr);
 
@@ -923,8 +936,7 @@ bool PSOTraceBuilder::cond_wait(const SymAddrSize &cond_ml, const SymAddrSize &m
 }
 
 bool PSOTraceBuilder::cond_awake(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml){
-  mutex_lock(mutex_ml);
-  return true;
+  return mutex_lock(mutex_ml);
 }
 
 int PSOTraceBuilder::cond_destroy(const SymAddrSize &ml){
@@ -935,9 +947,8 @@ int PSOTraceBuilder::cond_destroy(const SymAddrSize &ml){
     threads[pid].sleep_accesses_w.insert(ml.addr);
     return 0;
   }
-  fence();
-
-  int err = (EBUSY == 1) ? 2 : 1; // Chose an error value different from EBUSY
+  const int err = (EBUSY == 1) ? 2 : 1; // Chose an error value different from EBUSY
+  if (!fence()) return err;
 
   curnode().may_conflict = true;
   wakeup(Access::W,ml.addr);
@@ -957,13 +968,14 @@ int PSOTraceBuilder::cond_destroy(const SymAddrSize &ml){
   return rv;
 }
 
-void PSOTraceBuilder::register_alternatives(int alt_count){
+bool PSOTraceBuilder::register_alternatives(int alt_count){
   curnode().may_conflict = true;
   if(curnode().alt == 0){
     for(int i = curnode().alt+1; i < alt_count; ++i){
       curnode().branch.insert(Branch({curnode().iid.get_pid(),i}));
     }
   }
+  return true;
 }
 
 VecSet<PSOTraceBuilder::IPid> PSOTraceBuilder::sleep_set_at(int i){

--- a/src/PSOTraceBuilder.h
+++ b/src/PSOTraceBuilder.h
@@ -27,44 +27,46 @@
 class PSOTraceBuilder : public TSOPSOTraceBuilder{
 public:
   PSOTraceBuilder(const Configuration &conf = Configuration::default_conf);
-  virtual ~PSOTraceBuilder();
-  virtual bool schedule(int *proc, int *aux, int *alt, bool *dryrun);
-  virtual void refuse_schedule();
-  virtual void mark_available(int proc, int aux = -1);
-  virtual void mark_unavailable(int proc, int aux = -1);
-  virtual void cancel_replay();
-  virtual bool is_replaying() const;
-  virtual void metadata(const llvm::MDNode *md);
-  virtual bool sleepset_is_empty() const;
-  virtual bool check_for_cycles();
-  virtual Trace *get_trace() const;
-  virtual bool reset();
-  virtual IID<CPid> get_iid() const;
+  virtual ~PSOTraceBuilder() override;
+  virtual bool schedule(int *proc, int *aux, int *alt, bool *dryrun) override;
+  virtual void refuse_schedule() override;
+  virtual void mark_available(int proc, int aux = -1) override;
+  virtual void mark_unavailable(int proc, int aux = -1) override;
+  virtual void cancel_replay() override;
+  virtual bool is_replaying() const override;
+  virtual void metadata(const llvm::MDNode *md) override;
+  virtual bool sleepset_is_empty() const override;
+  virtual bool check_for_cycles() override;
+  virtual Trace *get_trace() const override;
+  virtual bool reset() override;
+  virtual IID<CPid> get_iid() const override;
 
-  virtual void debug_print() const ;
+  virtual void debug_print() const  override;
 
-  virtual void spawn();
-  virtual void store(const SymData &ml);
-  virtual void atomic_store(const SymData &ml);
-  virtual void compare_exchange
+  virtual NODISCARD bool spawn() override;
+  virtual NODISCARD bool store(const SymData &ml) override;
+  virtual NODISCARD bool atomic_store(const SymData &ml) override;
+  virtual NODISCARD bool compare_exchange
   (const SymData &sd, const SymData::block_type expected, bool success);
-  virtual void load(const SymAddrSize &ml);
-  virtual void full_memory_conflict();
-  virtual void fence();
-  virtual void join(int tgt_proc);
-  virtual void mutex_lock(const SymAddrSize &ml);
-  virtual void mutex_lock_fail(const SymAddrSize &ml);
-  virtual void mutex_trylock(const SymAddrSize &ml);
-  virtual void mutex_unlock(const SymAddrSize &ml);
-  virtual void mutex_init(const SymAddrSize &ml);
-  virtual void mutex_destroy(const SymAddrSize &ml);
-  virtual bool cond_init(const SymAddrSize &ml);
-  virtual bool cond_signal(const SymAddrSize &ml);
-  virtual bool cond_broadcast(const SymAddrSize &ml);
-  virtual bool cond_wait(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml);
-  virtual bool cond_awake(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml);
-  virtual int cond_destroy(const SymAddrSize &ml);
-  virtual void register_alternatives(int alt_count);
+  virtual NODISCARD bool load(const SymAddrSize &ml) override;
+  virtual NODISCARD bool full_memory_conflict() override;
+  virtual NODISCARD bool fence() override;
+  virtual NODISCARD bool join(int tgt_proc) override;
+  virtual NODISCARD bool mutex_lock(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_lock_fail(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_trylock(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_unlock(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_init(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_destroy(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_init(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_signal(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_broadcast(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_wait(const SymAddrSize &cond_ml,
+                         const SymAddrSize &mutex_ml) override;
+  virtual NODISCARD bool cond_awake(const SymAddrSize &cond_ml,
+                          const SymAddrSize &mutex_ml) override;
+  virtual NODISCARD int cond_destroy(const SymAddrSize &ml) override;
+  virtual NODISCARD bool register_alternatives(int alt_count) override;
   virtual long double estimate_trace_count() const override;
 protected:
   /* An identifier for a thread. An index into this->threads.

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -191,7 +191,9 @@ void RFSCTraceBuilder::cancel_replay(){
   for (int i = 0; i <= prefix_idx; ++i) {
     blame = std::max(blame, prefix[i].get_decision_depth());
   }
-  prefix[blame].decision_ptr->prune_decisions();
+  if (blame != -1) {
+    prefix[blame].decision_ptr->prune_decisions();
+  }
 }
 
 void RFSCTraceBuilder::metadata(const llvm::MDNode *md){
@@ -448,8 +450,8 @@ bool RFSCTraceBuilder::compare_exchange
 }
 
 bool RFSCTraceBuilder::full_memory_conflict(){
-  llvm::dbgs() << "FULLMEM not supported\n";
-  abort();
+  invalid_input_error("RFSC does not support black-box functions with memory effects");
+  return false;
   if (!record_symbolic(SymEv::Fullmem())) return false;
   curev().may_conflict = true;
 
@@ -553,8 +555,8 @@ bool RFSCTraceBuilder::mutex_destroy(const SymAddrSize &ml){
 }
 
 bool RFSCTraceBuilder::cond_init(const SymAddrSize &ml){
-  llvm::dbgs() << "condvars not supported\n";
-  abort();
+  invalid_input_error("RFSC does not support condition variables");
+  return false;
   if (!record_symbolic(SymEv::CInit(ml))) return false;
   if(cond_vars.count(ml.addr)){
     pthreads_error("Condition variable initiated twice.");
@@ -566,8 +568,8 @@ bool RFSCTraceBuilder::cond_init(const SymAddrSize &ml){
 }
 
 bool RFSCTraceBuilder::cond_signal(const SymAddrSize &ml){
-  llvm::dbgs() << "condvars not supported\n";
-  abort();
+  invalid_input_error("RFSC does not support condition variables");
+  return false;
   if (!record_symbolic(SymEv::CSignal(ml))) return false;
   curev().may_conflict = true;
 
@@ -604,8 +606,8 @@ bool RFSCTraceBuilder::cond_signal(const SymAddrSize &ml){
 }
 
 bool RFSCTraceBuilder::cond_broadcast(const SymAddrSize &ml){
-  llvm::dbgs() << "condvars not supported\n";
-  abort();
+  invalid_input_error("RFSC does not support condition variables");
+  return false;
   if (!record_symbolic(SymEv::CBrdcst(ml))) return false;
   curev().may_conflict = true;
 
@@ -629,8 +631,8 @@ bool RFSCTraceBuilder::cond_broadcast(const SymAddrSize &ml){
 }
 
 bool RFSCTraceBuilder::cond_wait(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml){
-  llvm::dbgs() << "condvars not supported\n";
-  abort();
+  invalid_input_error("RFSC does not support condition variables");
+  return false;
   {
     auto it = mutexes.find(mutex_ml.addr);
     if(it == mutexes.end()){
@@ -666,8 +668,8 @@ bool RFSCTraceBuilder::cond_wait(const SymAddrSize &cond_ml, const SymAddrSize &
 }
 
 bool RFSCTraceBuilder::cond_awake(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml){
-  llvm::dbgs() << "condvars not supported\n";
-  abort();
+  invalid_input_error("RFSC does not support condition variables");
+  return false;
   assert(cond_vars.count(cond_ml.addr));
   CondVar &cond_var = cond_vars[cond_ml.addr];
   add_happens_after(prefix_idx, cond_var.last_signal);
@@ -680,8 +682,8 @@ bool RFSCTraceBuilder::cond_awake(const SymAddrSize &cond_ml, const SymAddrSize 
 }
 
 int RFSCTraceBuilder::cond_destroy(const SymAddrSize &ml){
-  llvm::dbgs() << "condvars not supported\n";
-  abort();
+  invalid_input_error("RFSC does not support condition variables");
+  return false;
   const int err = (EBUSY == 1) ? 2 : 1; // Chose an error value different from EBUSY
   if (!record_symbolic(SymEv::CDelete(ml))) return err;
 
@@ -700,8 +702,8 @@ int RFSCTraceBuilder::cond_destroy(const SymAddrSize &ml){
 }
 
 bool RFSCTraceBuilder::register_alternatives(int alt_count){
-  llvm::dbgs() << "alternatives not supported\n";
-  abort();
+  invalid_input_error("RFSC does not support nondeterministic events");
+  return false;
   curev().may_conflict = true;
   if (!record_symbolic(SymEv::Nondet(alt_count))) return false;
   // if(curev().alt == 0) {

--- a/src/RFSCTraceBuilder.h
+++ b/src/RFSCTraceBuilder.h
@@ -40,47 +40,49 @@ public:
   RFSCTraceBuilder(RFSCDecisionTree &desicion_tree_,
                    RFSCUnfoldingTree &unfolding_tree_,
                    const Configuration &conf = Configuration::default_conf);
-  virtual ~RFSCTraceBuilder();
-  virtual bool schedule(int *proc, int *aux, int *alt, bool *dryrun);
-  virtual void refuse_schedule();
-  virtual void mark_available(int proc, int aux = -1);
-  virtual void mark_unavailable(int proc, int aux = -1);
-  virtual void cancel_replay();
-  virtual bool is_replaying() const;
-  virtual void metadata(const llvm::MDNode *md);
-  virtual bool sleepset_is_empty() const;
-  virtual bool check_for_cycles();
-  virtual Trace *get_trace() const;
-  virtual bool reset();
-  virtual IID<CPid> get_iid() const;
+  virtual ~RFSCTraceBuilder() override;
+  virtual bool schedule(int *proc, int *aux, int *alt, bool *dryrun) override;
+  virtual void refuse_schedule() override;
+  virtual void mark_available(int proc, int aux = -1) override;
+  virtual void mark_unavailable(int proc, int aux = -1) override;
+  virtual void cancel_replay() override;
+  virtual bool is_replaying() const override;
+  virtual void metadata(const llvm::MDNode *md) override;
+  virtual bool sleepset_is_empty() const override;
+  virtual bool check_for_cycles() override;
+  virtual Trace *get_trace() const override;
+  virtual bool reset() override;
+  virtual IID<CPid> get_iid() const override;
 
-  virtual void debug_print() const ;
-  virtual bool cond_branch(bool cnd) { return true; }
+  virtual void debug_print() const override;
+  virtual bool cond_branch(bool cnd) override { return true; }
 
-  virtual void spawn();
-  virtual void store(const SymData &ml);
-  virtual void atomic_store(const SymData &ml);
-  virtual void atomic_rmw(const SymData &ml);
-  virtual void compare_exchange
-  (const SymData &sd, const SymData::block_type expected, bool success);
-  virtual void load(const SymAddrSize &ml);
-  virtual void full_memory_conflict();
-  virtual void fence();
-  virtual void join(int tgt_proc);
-  virtual void mutex_lock(const SymAddrSize &ml);
-  virtual void mutex_lock_fail(const SymAddrSize &ml);
-  virtual void mutex_trylock(const SymAddrSize &ml);
-  virtual void mutex_unlock(const SymAddrSize &ml);
-  virtual void mutex_init(const SymAddrSize &ml);
-  virtual void mutex_destroy(const SymAddrSize &ml);
-  virtual bool cond_init(const SymAddrSize &ml);
-  virtual bool cond_signal(const SymAddrSize &ml);
-  virtual bool cond_broadcast(const SymAddrSize &ml);
-  virtual bool cond_wait(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml);
-  virtual bool cond_awake(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml);
-  virtual int cond_destroy(const SymAddrSize &ml);
-  virtual void register_alternatives(int alt_count);
-  virtual long double estimate_trace_count() const;
+  virtual NODISCARD bool spawn() override;
+  virtual NODISCARD bool store(const SymData &ml) override;
+  virtual NODISCARD bool atomic_store(const SymData &ml) override;
+  virtual NODISCARD bool atomic_rmw(const SymData &ml) override;
+  virtual NODISCARD bool compare_exchange
+  (const SymData &sd, const SymData::block_type expected, bool success) override;
+  virtual NODISCARD bool load(const SymAddrSize &ml) override;
+  virtual NODISCARD bool full_memory_conflict() override;
+  virtual NODISCARD bool fence() override;
+  virtual NODISCARD bool join(int tgt_proc) override;
+  virtual NODISCARD bool mutex_lock(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_lock_fail(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_trylock(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_unlock(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_init(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_destroy(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_init(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_signal(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_broadcast(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_wait(const SymAddrSize &cond_ml,
+                         const SymAddrSize &mutex_ml) override;
+  virtual NODISCARD bool cond_awake(const SymAddrSize &cond_ml,
+                          const SymAddrSize &mutex_ml) override;
+  virtual NODISCARD int cond_destroy(const SymAddrSize &ml) override;
+  virtual NODISCARD bool register_alternatives(int alt_count) override;
+  virtual long double estimate_trace_count() const override;
 
   /* Amount of siblings found during compute_prefixes. */
   int tasks_created;
@@ -457,7 +459,7 @@ protected:
   bool can_swap_lock_by_vclocks(int f, int u, int s) const;
   /* Records a symbolic representation of the current event.
    */
-  void record_symbolic(SymEv event);
+  bool NODISCARD record_symbolic(SymEv event);
   Leaf try_sat(std::initializer_list<unsigned>, std::map<SymAddr,std::vector<int>> &);
   Leaf order_to_leaf(int decision, std::initializer_list<unsigned> changed,
                      const std::vector<unsigned> order) const;

--- a/src/RFSC_test.cpp
+++ b/src/RFSC_test.cpp
@@ -1,0 +1,59 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#ifdef HAVE_BOOST_UNIT_TEST_FRAMEWORK
+
+#ifdef HAVE_VALGRIND_VALGRIND_H
+#include <valgrind/valgrind.h>
+#endif
+#include "DPORDriver.h"
+#include "DPORDriver_test.h"
+#include "StrModule.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(RFSC_test)
+
+BOOST_AUTO_TEST_CASE(Condvars_not_supported) {
+  Configuration conf = DPORDriver_test::get_sc_conf();
+  conf.dpor_algorithm = Configuration::READS_FROM;
+  std::string module = StrModule::portasm(R"(
+@cnd = global i32 0, align 4
+
+define i32 @main(){
+  call i32 @pthread_cond_init(i32* @cnd, i32* null)
+
+  ret i32 0
+}
+declare i32 @pthread_cond_init(i32*,i32*) nounwind
+)");
+
+  std::unique_ptr<DPORDriver> driver(DPORDriver::parseIR(module, conf));
+  DPORDriver::Result res = driver->run();
+
+  BOOST_REQUIRE(res.has_errors());
+  BOOST_REQUIRE_EQUAL(res.error_trace->get_errors().size(), 1);
+  BOOST_REQUIRE_NE(res.error_trace->get_errors()[0]->to_string().find
+                   ("not supported:") , std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+#endif

--- a/src/SC_test2.cpp
+++ b/src/SC_test2.cpp
@@ -657,6 +657,63 @@ declare void @__assert_fail()
   BOOST_CHECK(!res.has_errors());
 }
 
+BOOST_AUTO_TEST_CASE(Nondeterminism_without_branch){
+  /* Mechanism is the same as in Nonteterminsim_detection (cf for
+   * detailed description of the test)
+   * Here, instead having a branch that changes direction, we have a
+   * load that changes address
+   */
+  Configuration conf = DPORDriver_test::get_sc_conf();
+  char changing = 0;
+  std::stringstream ss;
+  ss << "inttoptr(i64 " << (unsigned long)(&changing) << " to i8*)";
+  std::string changingAddr = ss.str();
+  std::string module = StrModule::portasm(R"(
+@x = global i32 0, align 4
+@arr = constant [2 x i32] [i32 42, i32 999]
+
+define i8* @p1(i8* %arg){
+  store i32 1, i32* @x
+  ret i8* null
+}
+
+define i32 @main(){
+  %tp = alloca i8
+  call i8* @memcpy(i8* %tp, i8* )"+changingAddr+R"(, i64 1)
+  %v = load i8, i8* %tp
+  %v64 = zext i8 %v to i64
+  %p = getelementptr [2 x i32], [2 x i32]* @arr, i64 0, i64 %v64
+  %xxx = load i32, i32* %p
+  store i8 1, i8* %tp
+  call i8* @memcpy(i8* )"+changingAddr+R"(, i8* %tp, i64 1)
+  call i32 @pthread_create(i64* null, %attr_t* null, i8*(i8*)* @p1, i8* null)
+  load i32, i32* @x
+  ret i32 0
+}
+
+%attr_t = type { i64, [48 x i8] }
+declare i32 @pthread_create(i64*, %attr_t*, i8*(i8*)*, i8*) nounwind
+declare void @__assert_fail()
+declare i8* @memcpy(i8*, i8*, i64)
+)");
+
+  DPORDriver *driver = DPORDriver::parseIR(module, conf);
+  DPORDriver::Result res = driver->run();
+
+  BOOST_CHECK(changing == 1);
+  BOOST_CHECK(res.has_errors());
+  delete driver;
+
+  changing = 0;
+  conf.dpor_algorithm = Configuration::OPTIMAL;
+  driver = DPORDriver::parseIR(module,conf);
+  DPORDriver::Result opt_res = driver->run();
+  delete driver;
+
+  BOOST_CHECK(changing == 1);
+  BOOST_CHECK(opt_res.has_errors());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 #endif

--- a/src/SymEv.h
+++ b/src/SymEv.h
@@ -110,7 +110,7 @@ struct SymEv {
     return {UNOBS_STORE, std::move(addr)};
   }
 
-  void set(SymEv other);
+  bool is_compatible_with(SymEv other) const;
   std::string to_string(std::function<std::string(int)> pid_str
                         = (std::string(&)(int))std::to_string) const;
 

--- a/src/TSOTraceBuilder.h
+++ b/src/TSOTraceBuilder.h
@@ -32,44 +32,46 @@ typedef llvm::SmallVector<SymEv,1> sym_ty;
 class TSOTraceBuilder : public TSOPSOTraceBuilder{
 public:
   TSOTraceBuilder(const Configuration &conf = Configuration::default_conf);
-  virtual ~TSOTraceBuilder();
-  virtual bool schedule(int *proc, int *aux, int *alt, bool *dryrun);
-  virtual void refuse_schedule();
-  virtual void mark_available(int proc, int aux = -1);
-  virtual void mark_unavailable(int proc, int aux = -1);
-  virtual void cancel_replay();
-  virtual bool is_replaying() const;
-  virtual void metadata(const llvm::MDNode *md);
-  virtual bool sleepset_is_empty() const;
-  virtual bool check_for_cycles();
-  virtual Trace *get_trace() const;
-  virtual bool reset();
-  virtual IID<CPid> get_iid() const;
+  virtual ~TSOTraceBuilder() override;
+  virtual bool schedule(int *proc, int *aux, int *alt, bool *dryrun) override;
+  virtual void refuse_schedule() override;
+  virtual void mark_available(int proc, int aux = -1) override;
+  virtual void mark_unavailable(int proc, int aux = -1) override;
+  virtual void cancel_replay() override;
+  virtual bool is_replaying() const override;
+  virtual void metadata(const llvm::MDNode *md) override;
+  virtual bool sleepset_is_empty() const override;
+  virtual bool check_for_cycles() override;
+  virtual Trace *get_trace() const override;
+  virtual bool reset() override;
+  virtual IID<CPid> get_iid() const override;
 
-  virtual void debug_print() const ;
+  virtual void debug_print() const override;
 
-  virtual void spawn();
-  virtual void store(const SymData &ml);
-  virtual void atomic_store(const SymData &ml);
-  virtual void compare_exchange
-  (const SymData &sd, const SymData::block_type expected, bool success);
-  virtual void load(const SymAddrSize &ml);
-  virtual void full_memory_conflict();
-  virtual void fence();
-  virtual void join(int tgt_proc);
-  virtual void mutex_lock(const SymAddrSize &ml);
-  virtual void mutex_lock_fail(const SymAddrSize &ml);
-  virtual void mutex_trylock(const SymAddrSize &ml);
-  virtual void mutex_unlock(const SymAddrSize &ml);
-  virtual void mutex_init(const SymAddrSize &ml);
-  virtual void mutex_destroy(const SymAddrSize &ml);
-  virtual bool cond_init(const SymAddrSize &ml);
-  virtual bool cond_signal(const SymAddrSize &ml);
-  virtual bool cond_broadcast(const SymAddrSize &ml);
-  virtual bool cond_wait(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml);
-  virtual bool cond_awake(const SymAddrSize &cond_ml, const SymAddrSize &mutex_ml);
-  virtual int cond_destroy(const SymAddrSize &ml);
-  virtual void register_alternatives(int alt_count);
+  virtual NODISCARD bool spawn() override;
+  virtual NODISCARD bool store(const SymData &ml) override;
+  virtual NODISCARD bool atomic_store(const SymData &ml) override;
+  virtual NODISCARD bool compare_exchange
+  (const SymData &sd, const SymData::block_type expected, bool success) override;
+  virtual NODISCARD bool load(const SymAddrSize &ml) override;
+  virtual NODISCARD bool full_memory_conflict() override;
+  virtual NODISCARD bool fence() override;
+  virtual NODISCARD bool join(int tgt_proc) override;
+  virtual NODISCARD bool mutex_lock(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_lock_fail(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_trylock(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_unlock(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_init(const SymAddrSize &ml) override;
+  virtual NODISCARD bool mutex_destroy(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_init(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_signal(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_broadcast(const SymAddrSize &ml) override;
+  virtual NODISCARD bool cond_wait(const SymAddrSize &cond_ml,
+                         const SymAddrSize &mutex_ml) override;
+  virtual NODISCARD bool cond_awake(const SymAddrSize &cond_ml,
+                          const SymAddrSize &mutex_ml) override;
+  virtual int cond_destroy(const SymAddrSize &ml) override;
+  virtual NODISCARD bool register_alternatives(int alt_count) override;
   virtual long double estimate_trace_count() const override;
 protected:
   /* An identifier for a thread. An index into this->threads.
@@ -624,8 +626,14 @@ protected:
    */
   void do_race_detect();
   /* Records a symbolic representation of the current event.
+   *
+   * During replay, events are checked against the replay log. If a mismatch is
+   * detected, a nondeterminism error is reported and the function returns
+   * false.
+   *
+   * Otherwise returns true.
    */
-  void record_symbolic(SymEv event);
+  bool NODISCARD record_symbolic(SymEv event);
   /* When planning a reversal with a compare-exchange, the symbolic event
    * of the hoisted event must correctly indicate whether the
    * compare-exchange will succeed or fail, otherwise sleep and

--- a/src/TSO_test2.cpp
+++ b/src/TSO_test2.cpp
@@ -1472,6 +1472,66 @@ declare i8* @memcpy(i8*, i8*, i64)
   // BOOST_CHECK(opt_res.has_errors());
 }
 
+
+BOOST_AUTO_TEST_CASE(Nondeterminism_without_branch){
+  /* Mechanism is the same as in Nonteterminsim_detection (cf for
+   * detailed description of the test)
+   * Here, instead having a branch that changes direction, we have a
+   * load that changes address
+   */
+  Configuration conf = DPORDriver_test::get_sc_conf();
+  char changing = 0;
+  std::stringstream ss;
+  ss << "inttoptr(i64 " << (unsigned long)(&changing) << " to i8*)";
+  std::string changingAddr = ss.str();
+  std::string module = StrModule::portasm(R"(
+@x = global i32 0, align 4
+@arr = constant [2 x i32] [i32 42, i32 999]
+
+define i8* @p1(i8* %arg){
+  store i32 1, i32* @x
+  ret i8* null
+}
+
+define i32 @main(){
+  %tp = alloca i8
+  call i8* @memcpy(i8* %tp, i8* )"+changingAddr+R"(, i64 1)
+  %v = load i8, i8* %tp
+  %v64 = zext i8 %v to i64
+  %p = getelementptr [2 x i32], [2 x i32]* @arr, i64 0, i64 %v64
+  %xxx = load i32, i32* %p
+  store i8 1, i8* %tp
+  call i8* @memcpy(i8* )"+changingAddr+R"(, i8* %tp, i64 1)
+  call i32 @pthread_create(i64* null, %attr_t* null, i8*(i8*)* @p1, i8* null)
+  load i32, i32* @x
+  ret i32 0
+}
+
+%attr_t = type { i64, [48 x i8] }
+declare i32 @pthread_create(i64*, %attr_t*, i8*(i8*)*, i8*) nounwind
+declare void @__assert_fail()
+declare i8* @memcpy(i8*, i8*, i64)
+)");
+
+  DPORDriver *driver = DPORDriver::parseIR(module, conf);
+  DPORDriver::Result res = driver->run();
+
+  BOOST_CHECK(changing == 1);
+  BOOST_CHECK(res.has_errors());
+  delete driver;
+
+  /* TODO: Optimal-DPOR */
+  // changing = 0;
+  // conf.dpor_algorithm = Configuration::OPTIMAL;
+  // driver = DPORDriver::parseIR(module,conf);
+  // DPORDriver::Result opt_res = driver->run();
+  // delete driver;
+
+  // BOOST_CHECK(changing == 1);
+  // BOOST_CHECK(opt_res.has_errors());
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 #endif

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -180,6 +180,14 @@ std::string NondeterminismError::to_string() const{
   return "Nondeterminism detected at "+loc.to_string()+": "+msg;
 }
 
+Error *InvalidInputError::clone() const{
+  return new InvalidInputError(loc,msg);
+}
+
+std::string InvalidInputError::to_string() const{
+  return "Operation at "+loc.to_string()+" not supported: "+msg;
+}
+
 auto SrcLocVector::operator[](std::size_t index) const -> LocRef {
   const SrcLoc &loc = locations[index];
   return {loc.line, string_table[loc.file], string_table[loc.dir]};

--- a/src/Trace.h
+++ b/src/Trace.h
@@ -128,6 +128,19 @@ private:
   std::string msg;
 };
 
+/* An error where the program has exhibited some behaviour that is not
+ * supported by the current algorithm or mode.
+ */
+class InvalidInputError : public Error{
+public:
+  InvalidInputError(const IID<CPid> &loc, std::string msg)
+    : Error(loc), msg(msg) {};
+  virtual Error *clone() const;
+  virtual std::string to_string() const;
+private:
+  std::string msg;
+};
+
 class SrcLocVector {
 public:
   struct LocRef {

--- a/src/TraceBuilder.cpp
+++ b/src/TraceBuilder.cpp
@@ -72,3 +72,12 @@ void TraceBuilder::nondeterminism_error(std::string cond, const IID<CPid> &loc){
   }
   if(conf.debug_print_on_error) debug_print();
 }
+
+void TraceBuilder::invalid_input_error(std::string cond, const IID<CPid> &loc){
+  if(loc.is_null()){
+    errors.push_back(new InvalidInputError(get_iid(),cond));
+  }else{
+    errors.push_back(new InvalidInputError(loc,cond));
+  }
+  if(conf.debug_print_on_error) debug_print();
+}

--- a/src/TraceBuilder.h
+++ b/src/TraceBuilder.h
@@ -105,6 +105,12 @@ public:
    * rather than the current.
    */
   virtual void nondeterminism_error(std::string msg, const IID<CPid> &loc = IID<CPid>());
+  /* Notify the TraceBuilder that invalid behaviour has been detected.
+   *
+   * If loc is given, the error is associated with that location
+   * rather than the current.
+   */
+  virtual void invalid_input_error(std::string msg, const IID<CPid> &loc = IID<CPid>());
   /* Estimate the total number of traces for this program based on the
    * traces that have been seen.
    */


### PR DESCRIPTION
Previously, feeding a certain class of nondeterministic input to nidhugg
would cause it to crash with an unhelpful "Merging incompatible events
XXX and YYY". Now, it should generate a proper error report.

Todo:

- [x] Tests
- [x] Take care of rfsc unsupported ops while I'm at it