### PR TITLE
LLVM 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,15 @@ _bionic-conf: &bionic
         - libboost-test-dev
         - libboost-system-dev
 
+_focal-conf: &focal
+  dist: focal
+  addons:
+    apt:
+      packages:
+        - *baseline-packages
+        - libboost-test-dev
+        - libboost-system-dev
+
 _bionic-clang-env-conf:
   env: &bionic-clang-env
     - CC=clang
@@ -35,10 +44,10 @@ _bionic-clang-env-conf:
 
 jobs:
   include:
-    # - <<: *bionic
-    #   env:
-    #     - LLVM_VERSION=11.0.0-rc1
-    #     - CONFIGURE_FLAGS=--disable-llvm-clang-version-check
+    - <<: *focal
+      env:
+        - LLVM_VERSION=11.0.0-rc2
+        - CONFIGURE_FLAGS=--disable-llvm-clang-version-check
     - <<: *bionic
       env: LLVM_VERSION=10.0.0
     - <<: *bionic

--- a/configure.ac
+++ b/configure.ac
@@ -227,7 +227,6 @@ AC_CHECK_HEADERS([ \
   llvm/Transforms/Utils/Cloning.h
 ],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])
 
-AC_CHECK_HEADERS_ALT([llvm/Support/CallSite.h llvm/IR/CallSite.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])
 AC_CHECK_HEADERS_ALT([llvm/Constants.h llvm/IR/Constants.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])
 AC_CHECK_HEADERS_ALT([llvm/DataLayout.h llvm/IR/DataLayout.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])
 AC_CHECK_HEADERS_ALT([llvm/DebugInfo.h llvm/Analysis/DebugInfo.h llvm/IR/DebugInfo.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])
@@ -1113,6 +1112,23 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
          AC_MSG_RESULT([yes])],
         [AC_MSG_RESULT([no])])
 
+## Check whether the class llvm::CallBase exists (LLVM>=7)
+AC_MSG_CHECKING([for class llvm::CallBase])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_IR_INSTRUCTIONS_H)
+#include <llvm/IR/Instructions.h>
+#elif defined(HAVE_LLVM_INSTRUCTIONS_H)
+#include <llvm/Instructions.h>
+#endif
+]],[[
+  llvm::CallInst *CI = nullptr;
+  llvm::CallBase *CB = CI;
+]])],
+        [AC_DEFINE([LLVM_HAS_CALLBASE],[1],
+         [Define if llvm::CallBase exists.])
+         AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])
+         AC_CHECK_HEADERS_ALT([llvm/Support/CallSite.h llvm/IR/CallSite.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE

--- a/configure.ac
+++ b/configure.ac
@@ -1130,6 +1130,27 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
         [AC_MSG_RESULT([no])
          AC_CHECK_HEADERS_ALT([llvm/Support/CallSite.h llvm/IR/CallSite.h],[],[AC_MSG_FAILURE([Could not find necessary headers.])],[AC_INCLUDES_DEFAULT])])
 
+## Check whether we have TypeIDs for scalable vector types (LLVM>=11)
+AC_MSG_CHECKING([for llvm vector TypeIDs])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if defined(HAVE_LLVM_IR_INSTRUCTIONS_H)
+#include <llvm/IR/Instructions.h>
+#elif defined(HAVE_LLVM_INSTRUCTIONS_H)
+#include <llvm/Instructions.h>
+#endif
+]],[[
+  llvm::Type *T = nullptr;
+  bool isVector = T->getTypeID() == llvm::Type::VectorTyID;
+]])],
+        [AC_DEFINE([LLVM_VECTOR_TYPEID_CASES],[case llvm::Type::VectorTyID:],
+         [Case labels for recognising vector types.])
+         AC_MSG_RESULT([VectorTyID])],
+        [AC_DEFINE([LLVM_VECTOR_TYPEID_CASES],
+         [case llvm::Type::FixedVectorTyID: case llvm::Type::ScalableVectorTyID:],
+         [Case labels for recognising vector types.])
+         AC_MSG_RESULT([FixedVectorTyID, ScalableVectorTyID])])
+
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_TYPE_INT16_T

--- a/src/AnyCallInst.h
+++ b/src/AnyCallInst.h
@@ -1,0 +1,77 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __ANYCALLINST_H__
+#define __ANYCALLINST_H__
+
+#include <llvm/IR/Instructions.h>
+#if defined(HAVE_LLVM_SUPPORT_CALLSITE_H)
+#include <llvm/Support/CallSite.h>
+#elif defined(HAVE_LLVM_IR_CALLSITE_H)
+#include <llvm/IR/CallSite.h>
+#endif
+
+/* Because older llvms do not have the llvm::CallBase base class, but instead
+ * have a helper type llvm::CallSite that wraps any instruction type that is a
+ * call, we need a consistent way of handling them. We introduce our own wrapper
+ * type, AnyCallInst, with an interface as close to llvm::CallBase as possible.
+ */
+
+#ifdef LLVM_HAS_CALLBASE
+
+class AnyCallInst {
+  llvm::CallBase *CB;
+
+ public:
+  AnyCallInst() : CB(nullptr) {}
+  AnyCallInst(llvm::CallBase *CB) : CB(CB) {}
+  AnyCallInst(llvm::CallBase &CB) : CB(&CB) {}
+
+  bool operator==(std::nullptr_t) { return !CB; }
+  llvm::Instruction* operator &() { return CB; };
+  const llvm::Instruction* operator &() const { return CB; };
+  llvm::Function *getCalledFunction() const { return CB->getCalledFunction(); }
+  llvm::Value *getCalledOperand() const { return CB->getCalledOperand(); }
+  auto arg_begin() { return CB->arg_begin(); }
+  auto arg_end() { return CB->arg_end(); }
+  auto arg_size() { return CB->arg_size(); }
+};
+
+#else /* #ifdef LLVM_HAS_CALLBASE */
+
+class AnyCallInst {
+  llvm::CallSite CS;
+
+ public:
+  AnyCallInst() {}
+  AnyCallInst(llvm::CallSite CS) : CS(CS) {}
+
+  bool operator==(std::nullptr_t) { return !CS.getInstruction(); }
+  llvm::Instruction* operator &() { return CS.getInstruction(); };
+  const llvm::Instruction* operator &() const { return CS.getInstruction(); };
+  llvm::Function *getCalledFunction() const { return CS.getCalledFunction(); }
+  llvm::Value *getCalledOperand() const { return CS.getCalledValue(); }
+  auto arg_begin() { return CS.arg_begin(); }
+  auto arg_end() { return CS.arg_end(); }
+  auto arg_size() { return CS.arg_size(); }
+};
+
+#endif /* ! #ifdef LLVM_HAS_CALLBASE */
+
+#endif // __ANYCALLINST_H__

--- a/src/CheckModule.cpp
+++ b/src/CheckModule.cpp
@@ -27,6 +27,7 @@
 #endif
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/raw_ostream.h>
+#include <llvm/ADT/StringSet.h>
 
 #include <set>
 
@@ -49,7 +50,7 @@ void CheckModule::check_functions(const llvm::Module *M){
   check_calloc(M);
   check_nondet_int(M);
   check_assume(M);
-  std::set<std::string> supported =
+  llvm::StringSet<> supported =
     {"pthread_create",
      "pthread_join",
      "pthread_self",

--- a/src/ExternalFunctions.cpp
+++ b/src/ExternalFunctions.cpp
@@ -298,7 +298,7 @@ GenericValue Interpreter::callExternalFunction(Function *F,
   RawFunc RawFn;
   if (RF == RawFunctions->end()) {
     RawFn = (RawFunc)(intptr_t)
-      sys::DynamicLibrary::SearchForAddressOfSymbol(F->getName());
+      sys::DynamicLibrary::SearchForAddressOfSymbol(std::string(F->getName()));
     if (!RawFn)
       RawFn = (RawFunc)(intptr_t)getPointerToGlobalIfAvailable(F);
     if (RawFn != 0)

--- a/src/POWERExecution.cpp
+++ b/src/POWERExecution.cpp
@@ -1145,12 +1145,11 @@ static void stripws(std::string &s){
   s = s.substr(first,len);
 }
 
-bool POWERInterpreter::isInlineAsm(llvm::CallSite &CS, std::string *asmstr){
-  if(CS.isCall()){
-    llvm::CallInst *CI = llvm::cast<llvm::CallInst>(CS.getInstruction());
+bool POWERInterpreter::isInlineAsm(AnyCallInst CS, std::string *asmstr){
+  if(llvm::CallInst *CI = llvm::dyn_cast<llvm::CallInst>(&CS)){
     if(CI){
       if(CI->isInlineAsm()){
-        llvm::InlineAsm *IA = llvm::dyn_cast<llvm::InlineAsm>(CI->getCalledValue());
+        llvm::InlineAsm *IA = llvm::dyn_cast<llvm::InlineAsm>(CS.getCalledOperand());
         assert(IA);
         *asmstr = IA->getAsmString();
         stripws(*asmstr);
@@ -1164,11 +1163,10 @@ bool POWERInterpreter::isInlineAsm(llvm::CallSite &CS, std::string *asmstr){
 bool POWERInterpreter::isInlineAsm(llvm::Instruction &I, std::string *asmstr){
   llvm::CallInst *C = llvm::dyn_cast<llvm::CallInst>(&I);
   if(!C) return false;
-  llvm::CallSite CS(C);
-  return isInlineAsm(CS,asmstr);
+  return isInlineAsm(AnyCallInst(C),asmstr);
 }
 
-void POWERInterpreter::visitInlineAsm(llvm::CallSite &CS, const std::string &asmstr){
+void POWERInterpreter::visitInlineAsm(llvm::CallInst &CI, const std::string &asmstr){
   if(asmstr == "DMB" || asmstr == "dmb" ||
      asmstr == "DSB" || asmstr == "dsb" ||
      asmstr == "ISB" || asmstr == "isb" ||
@@ -1182,11 +1180,11 @@ void POWERInterpreter::visitInlineAsm(llvm::CallSite &CS, const std::string &asm
   }
 }
 
-void POWERInterpreter::visitCallSite(llvm::CallSite CS) {
+void POWERInterpreter::visitAnyCallInst(AnyCallInst CI) {
   {
     std::string asmstr;
-    if(isInlineAsm(CS,&asmstr)){
-      visitInlineAsm(CS,asmstr);
+    if(isInlineAsm(CI,&asmstr)){
+      visitInlineAsm(llvm::cast<llvm::CallInst>(CI),asmstr);
       return;
     }
   }
@@ -1194,7 +1192,7 @@ void POWERInterpreter::visitCallSite(llvm::CallSite CS) {
   ExecutionContext &SF = Threads[CurrentThread].ECStack.back();
 
   // Check to see if this is an intrinsic function call...
-  llvm::Function *F = CS.getCalledFunction();
+  llvm::Function *F = CI.getCalledFunction();
   if (F && F->isDeclaration()){
     switch (F->getIntrinsicID()) {
     case llvm::Intrinsic::not_intrinsic:
@@ -1205,7 +1203,7 @@ void POWERInterpreter::visitCallSite(llvm::CallSite CS) {
         llvm::GenericValue ArgIndex;
         ArgIndex.UIntPairVal.first = ECStack.size() - 1;
         ArgIndex.UIntPairVal.second = 0;
-        SetValue(CS.getInstruction(), ArgIndex, SF);
+        SetValue(CI.getInstruction(), ArgIndex, SF);
       */
       return;
     }
@@ -1217,7 +1215,7 @@ void POWERInterpreter::visitCallSite(llvm::CallSite CS) {
     case llvm::Intrinsic::vacopy:   // va_copy: dest = src
       throw std::logic_error("POWERInterpreter: Varargs are not supported.");
       /*
-        SetValue(CS.getInstruction(), getOperandValue(*CS.arg_begin(), SF), SF);
+        SetValue(CI.getInstruction(), getOperandValue(*CI.arg_begin(), SF), SF);
       */
       return;
     default:
@@ -1258,12 +1256,12 @@ void POWERInterpreter::visitCallSite(llvm::CallSite CS) {
         // If it is an unknown intrinsic function, use the intrinsic lowering
         // class to transform it into hopefully tasty LLVM code.
         //
-        llvm::BasicBlock::iterator me(CS.getInstruction());
-        llvm::BasicBlock *Parent = CS.getInstruction()->getParent();
+        llvm::BasicBlock::iterator me(&CI);
+        llvm::BasicBlock *Parent = (&CI)->getParent();
         bool atBegin(Parent->begin() == me);
         if (!atBegin)
           --me;
-        IL->LowerIntrinsicCall(llvm::cast<llvm::CallInst>(CS.getInstruction()));
+        IL->LowerIntrinsicCall(llvm::cast<llvm::CallInst>(&CI));
 
         // Restore the CurInst pointer to the first instruction newly inserted, if
         // any.
@@ -1288,15 +1286,15 @@ void POWERInterpreter::visitCallSite(llvm::CallSite CS) {
     }
   }
 
-  assert(CS.getInstruction());
-  assert(CS.getInstruction() == &CurInstr->I);
+  assert(!(CI == nullptr));
+  assert(&CI == &CurInstr->I);
 
   std::vector<llvm::Value*> ArgVals;
-  const unsigned NumArgs = CS.arg_size();
+  const unsigned NumArgs = CI.arg_size();
   ArgVals.reserve(NumArgs);
   for(unsigned i = 0; i < NumArgs; ++i){
-    assert(CS.getArgument(i) == CS.getInstruction()->getOperand(i));
-    ArgVals.push_back(CS.getInstruction()->getOperand(i));
+    assert(CI.arg_begin()[i] == (&CI)->getOperand(i));
+    ArgVals.push_back((&CI)->getOperand(i));
   }
 
   // To handle indirect calls, we must get the pointer value from the argument
@@ -1323,11 +1321,11 @@ int POWERInterpreter::getCalleeOpIdx(const llvm::Instruction &I){
 llvm::Function *POWERInterpreter::getCallee(){
 #ifndef NDEBUG
   if(llvm::CallInst *CI = llvm::dyn_cast<llvm::CallInst>(&CurInstr->I)){
-    assert(CI->getCalledValue() == CI->getOperand(CI->getNumOperands()-1));
+    assert(AnyCallInst(CI).getCalledOperand() == CI->getOperand(CI->getNumOperands()-1));
   }else{
     assert(llvm::dyn_cast<llvm::InvokeInst>(&CurInstr->I));
     llvm::InvokeInst &II = llvm::cast<llvm::InvokeInst>(CurInstr->I);
-    assert(II.getCalledValue() == II.getOperand(II.getNumOperands()-3));
+    assert(AnyCallInst(&II).getCalledOperand() == II.getOperand(II.getNumOperands()-3));
   }
 #endif
   return (llvm::Function*)GVTOP(getOperandValue(getCalleeOpIdx(CurInstr->I)));

--- a/src/POWERInterpreter.cpp
+++ b/src/POWERInterpreter.cpp
@@ -105,9 +105,12 @@ POWERInterpreter::POWERInterpreter(llvm::Module *M, POWERARMTraceBuilder &TB, co
 
   static llvm::Value *V0 = llvm::ConstantInt::get(llvm::Type::getInt32Ty(M->getContext()),0);
   static llvm::Value *P0_32 = llvm::ConstantPointerNull::get(llvm::Type::getInt32PtrTy(M->getContext()));
-  dummy_store = new llvm::StoreInst(V0,P0_32);
+  dummy_store = new llvm::StoreInst(V0,P0_32,/*IsVolatile=*/false,/*Align=*/{},
+                                    /*InsertBefore=*/(llvm::Instruction*)nullptr);
   static llvm::Value *P0_8 = llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(M->getContext()));
-  dummy_load8 = new llvm::LoadInst(P0_8);
+  static llvm::Type *I8 = llvm::Type::getInt8Ty(M->getContext());
+  dummy_load8 = new llvm::LoadInst(I8, P0_8,"",/*IsVolatile=*/false,/*Align=*/{},
+                                   /*InsertBefore=*/(llvm::Instruction*)nullptr);
 }
 
 POWERInterpreter::~POWERInterpreter() {

--- a/src/PSOInterpreter.cpp
+++ b/src/PSOInterpreter.cpp
@@ -158,7 +158,7 @@ int PSOInterpreter::newThread(const CPid &cpid){
 
 bool PSOInterpreter::isFence(llvm::Instruction &I){
   if(llvm::isa<llvm::CallInst>(I)){
-    llvm::CallSite CS(static_cast<llvm::CallInst*>(&I));
+    AnyCallInst CS(static_cast<llvm::CallInst*>(&I));
     llvm::Function *F = CS.getCalledFunction();
     if(F && F->isDeclaration() &&
        F->getIntrinsicID() == llvm::Intrinsic::not_intrinsic &&
@@ -345,7 +345,7 @@ void PSOInterpreter::visitAtomicRMWInst(llvm::AtomicRMWInst &I){
   Interpreter::visitAtomicRMWInst(I);
 }
 
-void PSOInterpreter::visitInlineAsm(llvm::CallSite &CS, const std::string &asmstr){
+void PSOInterpreter::visitInlineAsm(llvm::CallInst &CI, const std::string &asmstr){
   if(asmstr == "mfence"){
     TB.fence();
   }else if(asmstr == ""){ // Do nothing

--- a/src/PSOInterpreter.h
+++ b/src/PSOInterpreter.h
@@ -44,7 +44,7 @@ public:
   virtual void visitFenceInst(llvm::FenceInst &I);
   virtual void visitAtomicCmpXchgInst(llvm::AtomicCmpXchgInst &I);
   virtual void visitAtomicRMWInst(llvm::AtomicRMWInst &I);
-  virtual void visitInlineAsm(llvm::CallSite &CS, const std::string &asmstr);
+  virtual void visitInlineAsm(llvm::CallInst &CI, const std::string &asmstr);
 protected:
   /* The auxiliary threads under PSO are numbered 0, 1, ... . Each
    * auxiliary thread correspond to the store buffer for memory

--- a/src/SpinAssumePass.cpp
+++ b/src/SpinAssumePass.cpp
@@ -98,8 +98,7 @@ bool DeclareAssumePass::runOnModule(llvm::Module &M){
 bool SpinAssumePass::is_assume(llvm::Instruction &I) const {
   llvm::CallInst *C = llvm::dyn_cast<llvm::CallInst>(&I);
   if(!C) return false;
-  llvm::CallSite CS(C);
-  llvm::Function *F = CS.getCalledFunction();
+  llvm::Function *F = C->getCalledFunction();
   return F && F->getName().str() == "__VERIFIER_assume";
 }
 

--- a/src/TSOInterpreter.h
+++ b/src/TSOInterpreter.h
@@ -44,7 +44,7 @@ public:
   virtual void visitFenceInst(llvm::FenceInst &I);
   virtual void visitAtomicCmpXchgInst(llvm::AtomicCmpXchgInst &I);
   virtual void visitAtomicRMWInst(llvm::AtomicRMWInst &I);
-  virtual void visitInlineAsm(llvm::CallSite &CS, const std::string &asmstr);
+  virtual void visitInlineAsm(llvm::CallInst &CI, const std::string &asmstr);
 protected:
   virtual void runAux(int proc, int aux);
   virtual int newThread(const CPid &cpid);

--- a/src/TraceUtil.cpp
+++ b/src/TraceUtil.cpp
@@ -63,8 +63,8 @@ bool TraceUtil::get_location(const llvm::MDNode *m,
 #else
   *lineno = loc.getLine();
 #endif
-  *fname = loc.getFilename();
-  *dname = loc.getDirectory();
+  *fname = std::string(loc.getFilename());
+  *dname = std::string(loc.getDirectory());
 #if defined(LLVM_MDNODE_OPERAND_IS_VALUE) /* Otherwise, disable fallback and hope that the C compiler produces well-formed metadata. */
   if(*fname == "" && *dname == ""){
     /* Failed to get file name and directory name.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]){
     /* Hide all options defined by the LLVM library, except the ones
      * approved by Configuration.
      */
-    std::set<std::string> visible_options =
+    std::set<std::string, std::less<void>> visible_options =
       {"version"};
     visible_options.insert(Configuration::commandline_opts().begin(),
                            Configuration::commandline_opts().end());

--- a/travis/install_deps.sh
+++ b/travis/install_deps.sh
@@ -11,8 +11,11 @@ if [ -n "$LLVM_VERSION" ]; then
         3.[89]*|[4-6].*)
             LLVM_UBUNTU_VER=16.04
             ;;
-        ?*)
+        [7-9].*|10.*)
             LLVM_UBUNTU_VER=18.04
+            ;;
+        ?*)
+            LLVM_UBUNTU_VER=20.04
             ;;
     esac
     case $LLVM_VERSION in


### PR DESCRIPTION
This time, there's a lot of API breakage. Dropped implicit conversions
from StringRef to std::string, changed typeids for vector types,
mandatory alignment arguments to store and load constructors, accessor
renaming.