### PR TITLE
Add instructions and a dockerfile for building debug builds of nidhugg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,13 @@ _bionic-clang-env-conf:
 
 jobs:
   include:
+    # Docker debug build needs to build llvm each time and is slow, start it
+    # first
+    - services: docker
+      before_script: docker build -t nidhugg-debug -f Dockerfile.debug .
+      script:
+        - docker run --rm -ti -v `pwd`:`pwd` -w `pwd` nidhugg-debug nidhuggc -sc tests/smoke/C-tests/mutex_hard.c
+        - docker run --rm -ti nidhugg-debug nidhugg-unittest
     - <<: *focal
       env:
         - LLVM_VERSION=11.0.0-rc2

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,69 @@
+FROM ubuntu:18.04 as build
+
+RUN \
+    apt-get update && \
+    apt-get --no-install-recommends -y install \
+      clang \
+      libboost-dev \
+      libboost-test-dev \
+      libboost-system-dev \
+      libc6 \
+      libc6-dev \
+      libstdc++6 \
+      autoconf \
+      automake \
+      python3 \
+      libffi-dev \
+      libz-dev \
+      xz-utils \
+      cmake \
+      make
+
+ADD https://releases.llvm.org/6.0.1/llvm-6.0.1.src.tar.xz /
+
+RUN \
+    /bin/bash -c \
+    "cd / && \
+     tar xf llvm-6.0.1.src.tar.xz && \
+     mkdir /build && \
+     cd /build && \
+     cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ \
+           -DCMAKE_BUILD_TYPE=MinSizeRel      \
+           -DLLVM_TARGETS_TO_BUILD=""         \
+           -DLLVM_LINK_LLVM_DYLIB=ON          \
+           -DLLVM_OPTIMIZED_TABLEGEN=ON       \
+           -DLLVM_ENABLE_ASSERTIONS=ON        \
+           /llvm-6.0.1.src/ &&                \
+     make -j6 &&                              \
+     cmake -DCMAKE_INSTALL_PREFIX=/usr/local -P cmake_install.cmake && \
+     cd / && rm -r /build/ /llvm-6.0.1.src/ && \
+     strip /usr/local/lib/libLLVM-6.0.so /usr/local/bin/llvm-link"
+
+COPY . /nidhugg
+
+RUN \
+    /bin/bash -c \
+    "cd /nidhugg && \
+    autoreconf --install && \
+    ./configure --prefix=/usr/local/ --enable-asserts CXXFLAGS='-Og -g' \
+                LDFLAGS='-g -Wl,-rpath=/usr/local/lib/' && \
+    make -Csrc -j6 nidhugg unittest && \
+    make install && \
+    install src/unittest /usr/local/bin/nidhugg-unittest && \
+    strip /usr/local/bin/nidhugg-unittest"
+
+FROM ubuntu:18.04
+RUN \
+    apt-get update && \
+    apt-get --no-install-recommends -y install \
+      clang \
+      libboost-system1.65.1 \
+      libboost-test1.65.1 \
+      python3 \
+      vim-tiny && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /usr/local/lib/libLLVM-6.0.so /usr/local/lib/
+COPY --from=build /usr/local/bin/llvm-link /usr/local/bin/
+COPY --from=build /usr/local/bin/nidhugg* /usr/local/bin/
+WORKDIR /root

--- a/README
+++ b/README
@@ -163,11 +163,31 @@ Specifying LLVM Installation
 Compiling LLVM
 ==============
 
-   LLVM is recommended to be compiled with optimized build and with
-   libffi.
+   If you are a user of Nidhugg, we recommend you use a release build of
+   LLVM. You can also speed up the build by disabling all the backends.
 
    $ cd llvm-*.src
-   $ ./configure --prefix /your/llvm/install/path --enable-optimized --enable-libffi
+   $ mkdir build && cd build
+   $ cmake -DCMAKE_INSTALL_PREFIX=/your/llvm/install/path \
+           -DCMAKE_BUILD_TYPE=Release \
+           -DLLVM_TARGETS_TO_BUILD="" -DLLVM_LINK_LLVM_DYLIB=ON ..
+   $ make
+   $ make install
+
+Compiling LLVM for Debugging or Developing Nidhugg
+**************************************************
+
+   If you are developing Nidhugg or are troubleshooting a bug in
+   Nidhugg, we recommend you use a debug build of LLVM, as this will
+   allow you to build an assertions-enabled build of Nidhugg.
+
+   $ cd llvm-*.src
+   $ mkdir build && cd build
+   $ cmake -DCMAKE_INSTALL_PREFIX=/your/llvm/install/path \
+           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+           -DLLVM_ENABLE_ASSERTIONS=ON \
+           -DLLVM_TARGETS_TO_BUILD="" -DLLVM_LINK_LLVM_DYLIB=ON \
+           -DLLVM_OPTIMIZED_TABLEGEN=ON ..
    $ make
    $ make install
 


### PR DESCRIPTION
We can use this to let users more easily troubleshoot issues in nidhugg, since weird behaviours are most often preceeded by assertion failures.

Todo:
 - [x] There is an assertion that fails when building against older LLVMs, most likely caused by #93 
 - [ ] The travis build is really slow (~80min), and cannot benefit from caching of the LLVM build