### PR TITLE
Execution: Fix assertion failure on older llvms

### DIFF
--- a/src/AnyCallInst.h
+++ b/src/AnyCallInst.h
@@ -27,6 +27,8 @@
 #include <llvm/IR/CallSite.h>
 #endif
 
+#include <cassert>
+
 /* Because older llvms do not have the llvm::CallBase base class, but instead
  * have a helper type llvm::CallSite that wraps any instruction type that is a
  * call, we need a consistent way of handling them. We introduce our own wrapper
@@ -40,7 +42,7 @@ class AnyCallInst {
 
  public:
   AnyCallInst() : CB(nullptr) {}
-  AnyCallInst(llvm::CallBase *CB) : CB(CB) {}
+  AnyCallInst(llvm::CallBase *CB) : CB(CB) { assert(CB); }
   AnyCallInst(llvm::CallBase &CB) : CB(&CB) {}
 
   operator bool() const { return (bool)CB; }

--- a/src/Execution.cpp
+++ b/src/Execution.cpp
@@ -3217,8 +3217,10 @@ bool Interpreter::isUnknownIntrinsic(Instruction &I){
 static AnyCallInst isCallOrInvoke(Instruction &I) {
   if (CallInst *CI = dyn_cast<CallInst>(&I)) {
     return {CI};
+  } else if(InvokeInst *II = dyn_cast<InvokeInst>(&I)) {
+    return {II};
   } else {
-    return {dyn_cast<InvokeInst>(&I)};
+    return AnyCallInst();
   }
 }
 


### PR DESCRIPTION
llvm::CallSite may not be constructed from a null pointer, but our
AnyCallInst accepted it fine when using newer llvms, so this bug was
missed. Add an assertion to AnyCallInst so that we do not make the same
mistake again.

Fixes: 3e22b3606

Solves the issue we were seeing in PR #100 