### PR TITLE
RFSC: Make the root Leaf distinct from bottom

### DIFF
--- a/src/RFSCDecisionTree.h
+++ b/src/RFSCDecisionTree.h
@@ -48,20 +48,26 @@ public:
 struct Leaf {
 public:
   /* Construct a bottom-leaf. */
-  Leaf() : prefix() {}
+  Leaf() : prefix() { assert(is_bottom()); }
   /* Construct a prefix leaf. */
-  Leaf(std::vector<Branch> prefix) : prefix(prefix) {}
+  Leaf(std::vector<Branch> prefix) : prefix(std::move(prefix)) {
+    /* Ensure we encode a non-bottom leaf. */
+    if (is_bottom()) {
+      this->prefix.reserve(1);
+    }
+    assert(!is_bottom());
+  }
   std::vector<Branch> prefix;
 
-  bool is_bottom() const { return prefix.empty(); }
+  bool is_bottom() const { return prefix.capacity() == 0; }
 };
 
 
 struct DecisionNode {
 public:
-  /* Empty constructor for root. */
-  DecisionNode() : depth(-1), parent(nullptr), pruned_subtree(false),
-                   cache_initialised(true) {}
+  /* Constructor for root node. */
+  DecisionNode() : depth(-1), leaf(std::vector<Branch>()), parent(nullptr),
+                   pruned_subtree(false), cache_initialised(true) {}
   /* Constructor for new nodes during compute_unfolding. */
   DecisionNode(std::shared_ptr<DecisionNode> decision)
     : depth(decision->depth+1), pruned_subtree(false),

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -232,60 +232,58 @@ bool RFSCTraceBuilder::reset(){
     /* DecisionNodes have been pruned and its trailing thread-task need to return. */
     return false;
   }
-  // This will always pass except for the first exploration.
-  if (work_item->depth != -1) {
 
-    Leaf l = std::move(work_item->leaf);
-    auto unf = std::move(work_item->unfold_node);
+  Leaf l = std::move(work_item->leaf);
+  auto unf = std::move(work_item->unfold_node);
 
-    if (conf.debug_print_on_reset)
-        llvm::dbgs() << "Backtracking to decision node " << (work_item->depth)
-                    << ", replaying " << l.prefix.size() << " events to read from "
-                    << (unf ? std::to_string(unf->seqno) : "init") << "\n";
+  assert(!l.is_bottom());
+  if (conf.debug_print_on_reset && !l.prefix.empty())
+    llvm::dbgs() << "Backtracking to decision node " << (work_item->depth)
+                 << ", replaying " << l.prefix.size() << " events to read from "
+                 << (unf ? std::to_string(unf->seqno) : "init") << "\n";
 
-    assert(!l.is_bottom());
+  assert(l.prefix.empty() == (work_item->depth == -1));
 
-    replay_point = l.prefix.size();
+  replay_point = l.prefix.size();
 
-    std::vector<Event> new_prefix;
-    new_prefix.reserve(l.prefix.size());
-    std::vector<int> iid_map;
-    for (Branch &b : l.prefix) {
-      int index = (int(iid_map.size()) <= b.pid) ? 1 : iid_map[b.pid];
-      IID<IPid> iid(b.pid, index);
-      new_prefix.emplace_back(iid);
-      new_prefix.back().size = b.size;
-      new_prefix.back().sym = std::move(b.sym);
-      new_prefix.back().pinned = b.pinned;
-      new_prefix.back().set_branch_decision(b.decision_depth, work_item);
-      iid_map_step(iid_map, new_prefix.back());
-    }
-
-  #ifndef NDEBUG
-    for (int d = 0; d < work_item->depth; ++d) {
-      assert(std::any_of(new_prefix.begin(), new_prefix.end(),
-                        [&](const Event &e) { return e.get_decision_depth() == d; }));
-    }
-  #endif
-
-    prefix = std::move(new_prefix);
-
-    CPS = CPidSystem();
-    threads.clear();
-    threads.push_back(Thread(CPid(),-1));
-    mutexes.clear();
-    cond_vars.clear();
-    mem.clear();
-    mutex_deadlocks.clear();
-    last_full_memory_conflict = -1;
-    prefix_idx = -1;
-    replay = true;
-    cancelled = false;
-    last_md = 0;
-    tasks_created = 0;
-    reset_cond_branch_log();
-
+  std::vector<Event> new_prefix;
+  new_prefix.reserve(l.prefix.size());
+  std::vector<int> iid_map;
+  for (Branch &b : l.prefix) {
+    int index = (int(iid_map.size()) <= b.pid) ? 1 : iid_map[b.pid];
+    IID<IPid> iid(b.pid, index);
+    new_prefix.emplace_back(iid);
+    new_prefix.back().size = b.size;
+    new_prefix.back().sym = std::move(b.sym);
+    new_prefix.back().pinned = b.pinned;
+    new_prefix.back().set_branch_decision(b.decision_depth, work_item);
+    iid_map_step(iid_map, new_prefix.back());
   }
+
+#ifndef NDEBUG
+  for (int d = 0; d < work_item->depth; ++d) {
+    assert(std::any_of(new_prefix.begin(), new_prefix.end(),
+                       [&](const Event &e) { return e.get_decision_depth() == d; }));
+  }
+#endif
+
+  prefix = std::move(new_prefix);
+
+  CPS = CPidSystem();
+  threads.clear();
+  threads.push_back(Thread(CPid(),-1));
+  mutexes.clear();
+  cond_vars.clear();
+  mem.clear();
+  mutex_deadlocks.clear();
+  last_full_memory_conflict = -1;
+  prefix_idx = -1;
+  replay = true;
+  cancelled = false;
+  last_md = 0;
+  tasks_created = 0;
+  reset_cond_branch_log();
+
   return true;
 }
 


### PR DESCRIPTION
During parallelisation, the fact that we missed a way of representing
the root Leaf lead to some code mess. Clean it up.