### PR TITLE
Make SMTLib consistency procedure optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,6 +175,45 @@ else
   AC_DEFINE([NO_TIMING], [1], [Define to 1 if timing should be disabled])
 fi
 
+AC_ARG_ENABLE(smtlib-consistency-check,
+              [AS_HELP_STRING([--enable-smtlib-consistency-check],
+               [Allow the use of SMTLib compatible SMT solvers as decision procedure for RF-SMC])],
+              [if test "x$enableval" != "xno" ; then
+                 enable_smtlib_consistency_check=yes
+               fi
+              ], [enable_smtlib_consistency_check="auto"])
+if test "x$enable_smtlib_consistency_check" != "xno" -a "x$ax_cv_boost_system" != "xyes"; then
+  if test "x$enable_smtlib_consistency_check" = "xyes"; then
+    AC_MSG_FAILURE([SMTLib consistency procedure requires boost-system.])
+  fi
+  AC_MSG_NOTICE([Disabling SMTLib consistency procedure for RF-SMC because boost-system is not available.])
+  AC_DEFINE([NO_SMTLIB_SOLVER], [1], [Define to 1 if timing should be disabled])
+elif test "x$enable_smtlib_consistency_check" != "xno"; then
+  AC_MSG_CHECKING([whether boost-system can compile with -fno-rtti])
+  old_CXXFLAGS="$CXXFLAGS"
+  CXXFLAGS="$CXXFLAGS -fno-rtti"
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <boost/process.hpp>
+]],[[
+  boost::process::ipstream out;
+  boost::process::opstream in;
+  boost::process::child c;
+  in << "hej";
+        ]])],
+        [AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])
+         if test "x$enable_smtlib_consistency_check" = "xyes"; then
+           AC_MSG_FAILURE([SMTLib consistency procedure requires boost-system.])
+         fi
+         AC_MSG_NOTICE([Disabling SMTLib consistency procedure for RF-SMC because boost-system is not compatible with -fno-rtti.])
+         AC_DEFINE([NO_SMTLIB_SOLVER], [1], [Define to 1 if timing should be disabled])
+        ])
+  CXXFLAGS="$old_CXXFLAGS"
+else
+  AC_MSG_NOTICE([Disabling SMTLib consistency procedure for RF-SMC.])
+  AC_DEFINE([NO_SMTLIB_SOLVER], [1], [Define to 1 if timing should be disabled])
+fi
+
 AC_CHECK_HEADERS([ \
   stdlib.h \
   sys/types.h \

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -98,7 +98,11 @@ public:
     print_progress = false;
     print_progress_estimate = false;
     exploration_scheduler = WORKSTEALING;
+#ifdef NO_SMTLIB_SOLVER
+    sat_solver = NONE;
+#else
     sat_solver = SMTLIB;
+#endif
     argv.push_back(get_default_program_name());
   };
   /* Read the switches given to the program by the user. Assign
@@ -214,7 +218,11 @@ public:
 
   /* Sat solver to use. */
   enum SatSolverEnum {
+#ifdef NO_SMTLIB_SOLVER
+        NONE,
+#else
         SMTLIB,
+#endif
   } sat_solver;
   std::unique_ptr<SatSolver> get_sat_solver() const;
   /* The arguments that will be passed to the program under test */

--- a/src/SmtlibSatSolver.cpp
+++ b/src/SmtlibSatSolver.cpp
@@ -18,6 +18,9 @@
  */
 
 #include "SmtlibSatSolver.h"
+
+#ifndef NO_SMTLIB_SOLVER
+
 #include "SExpr.h"
 
 #include <llvm/Support/CommandLine.h>
@@ -164,3 +167,5 @@ std::vector<unsigned> SmtlibSatSolver::get_model() {
 
   return res;
 }
+
+#endif // !defined(NO_SMTLIB_SOLVER)

--- a/src/SmtlibSatSolver.h
+++ b/src/SmtlibSatSolver.h
@@ -23,6 +23,8 @@
 
 #include "SatSolver.h"
 
+#ifndef NO_SMTLIB_SOLVER
+
 #ifndef HAVE_BOOST
 #  error "BOOST is required"
 #endif
@@ -48,4 +50,6 @@ private:
   boost::process::child z3;
 };
 
-#endif
+#endif // !defined(NO_SMTLIB_SOLVER)
+
+#endif // !defined(__SMTLIB_SAT_SOLVER_H__)


### PR DESCRIPTION
If a version of boost-system that does not work with `-fno-rtti` is
detected, it is automatically disabled by configure.