### PR TITLE
Fix warning in PSOTraceBuilder

### DIFF
--- a/src/PSOTraceBuilder.h
+++ b/src/PSOTraceBuilder.h
@@ -47,7 +47,8 @@ public:
   virtual NODISCARD bool store(const SymData &ml) override;
   virtual NODISCARD bool atomic_store(const SymData &ml) override;
   virtual NODISCARD bool compare_exchange
-  (const SymData &sd, const SymData::block_type expected, bool success);
+  (const SymData &sd, const SymData::block_type expected, bool success)
+      override;
   virtual NODISCARD bool load(const SymAddrSize &ml) override;
   virtual NODISCARD bool full_memory_conflict() override;
   virtual NODISCARD bool fence() override;


### PR DESCRIPTION
Add missing override keyword to `PSOTraceBuilder`. This was causing a warning when compiling with clang.