### PR TITLE
Partial Loop Purity Elimination

### DIFF
--- a/src/CastElimPass.cpp
+++ b/src/CastElimPass.cpp
@@ -1,0 +1,73 @@
+/* Copyright (C) 2021 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#include <llvm/ADT/SmallPtrSet.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/Analysis/ValueTracking.h>
+#include <llvm/Support/Debug.h>
+
+#include "CastElimPass.h"
+#include "llvm/Support/Casting.h"
+
+void CastElimPass::getAnalysisUsage(llvm::AnalysisUsage &AU) const{
+  AU.setPreservesCFG();
+}
+
+namespace {
+  llvm::Value *findSubstitute(llvm::CastInst &CI) {
+    using namespace llvm;
+    Value *src = CI.getOperand(0);
+    if (auto *csrc = dyn_cast<CastInst>(src)) { /* A->B->C cast */
+      if (csrc->getSrcTy() == CI.getDestTy() /* A->B->A cast */
+          && CI.getOpcode() == CastInst::Trunc
+          && (csrc->getOpcode() == CastInst::SExt
+              || csrc->getOpcode() == CastInst::ZExt)
+          ) {
+        return csrc->getOperand(0);
+      }
+    }
+    return nullptr;
+  }
+}
+
+bool CastElimPass::runOnFunction(llvm::Function &F) {
+  size_t eliminated = 0;
+
+  auto &BBL = F.getBasicBlockList();
+  for (auto BBI = BBL.begin(); BBI != BBL.end(); ++BBI) {
+    for (auto it = BBI->begin(), end = std::prev(BBI->end()); it != end; ++it) {
+      if (auto *CI = llvm::dyn_cast<llvm::CastInst>(it)) {
+        if (llvm::Value *S = findSubstitute(*CI)) {
+          CI->replaceAllUsesWith(S);
+          ++eliminated;
+        }
+      }
+    }
+  }
+
+  // if (eliminated != 0)
+  //   llvm::dbgs() << "Eliminated " << std::to_string(eliminated)
+  //                << " casts from " << F.getName() << "\n";
+  return eliminated != 0;
+}
+
+char CastElimPass::ID = 0;
+static llvm::RegisterPass<CastElimPass> X("cast-elim","Eliminate some unnecessary casts.");

--- a/src/CastElimPass.h
+++ b/src/CastElimPass.h
@@ -1,0 +1,44 @@
+/* Copyright (C) 2021 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#ifndef __CAST_ELIM_PASS_H__
+#define __CAST_ELIM_PASS_H__
+
+#include <llvm/Pass.h>
+#include <llvm/Analysis/LoopPass.h>
+
+/* The CastElim pass eliminates some unnecessary casts that can
+ * complicate later analyses. */
+class CastElimPass final : public llvm::FunctionPass{
+public:
+  static char ID;
+  CastElimPass() : llvm::FunctionPass(ID) {};
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+  bool runOnFunction(llvm::Function &F) override;
+#ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF
+  llvm::StringRef getPassName() const override { return "CastElimPass"; } ;
+#else
+  const char *getPassName() const override { return "CastElimPass"; };
+#endif
+private:
+};
+
+#endif

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -119,13 +119,20 @@ static llvm::cl::alias cl_robustness("robustness",llvm::cl::Hidden,
 
 static llvm::cl::OptionCategory cl_transformation_cat("Module Transformation Passes");
 
-static llvm::cl::opt<bool> cl_transform_no_spin_assume("no-spin-assume",llvm::cl::NotHidden,llvm::cl::cat(cl_transformation_cat),
-                                                       llvm::cl::desc("Disable the spin assume pass in module\n"
-                                                                      "transformation."));
+static llvm::cl::opt<bool> cl_transform_no_spin_assume("no-spin-assume",llvm::cl::NotHidden,llvm::cl::cat(cl_transformation_cat));
+
+static llvm::cl::opt<bool> cl_transform_spin_assume("spin-assume",llvm::cl::NotHidden,llvm::cl::cat(cl_transformation_cat),
+                                                    llvm::cl::desc("Enable the spin assume pass in module\n"
+                                                                   "transformation."));
 
 static llvm::cl::opt<bool> cl_transform_no_dead_code_elim
 ("no-dead-code-elim",llvm::cl::NotHidden,llvm::cl::cat(cl_transformation_cat),
  llvm::cl::desc("Disable the dead code elimination pass in module\n"
+                "transformation."));
+
+static llvm::cl::opt<bool> cl_transform_no_partial_loop_purity
+("no-partial-loop-purity",llvm::cl::NotHidden,llvm::cl::cat(cl_transformation_cat),
+ llvm::cl::desc("Disable the partial loop purity bounding pass in module\n"
                 "transformation."));
 
 static llvm::cl::opt<int>
@@ -190,7 +197,8 @@ const std::set<std::string> &Configuration::commandline_opts(){
     "smtlib",
     "source","optimal","observers","rf",
     "check-robustness",
-    "no-spin-assume",
+    "spin-assume",
+    "no-partial-loop-purity",
     "unroll",
     "print-progress",
     "print-progress-estimate",
@@ -215,8 +223,9 @@ void Configuration::assign_by_commandline(){
   c11 = cl_c11;
   dpor_algorithm = cl_dpor_algorithm;
   check_robustness = cl_check_robustness;
-  transform_spin_assume = !cl_transform_no_spin_assume;
+  transform_spin_assume = cl_transform_spin_assume;
   transform_dead_code_elim = !cl_transform_no_dead_code_elim;
+  transform_partial_loop_purity = !cl_transform_no_partial_loop_purity;
   transform_loop_unroll = cl_transform_loop_unroll;
   if (cl_verifier_nondet_int.getNumOccurrences())
     svcomp_nondet_int = (int)cl_verifier_nondet_int;
@@ -278,13 +287,17 @@ void Configuration::check_commandline(){
         << "WARNING: Program arguments (argv for test case) ignored in presence of --transform.\n";
     }
   }else{
-    if(cl_transform_no_spin_assume.getNumOccurrences()){
+    if(cl_transform_spin_assume.getNumOccurrences()){
       Debug::warn("Configuration::check_commandline:no:transform:transform-no-spin-assume")
-        << "WARNING: --no-spin-assume ignored in absence of --transform.\n";
+        << "WARNING: --spin-assume ignored in absence of --transform.\n";
     }
     if(cl_transform_loop_unroll.getNumOccurrences()){
       Debug::warn("Configuration::check_commandline:no:transform:transform_loop_unroll")
         << "WARNING: --unroll ignored in absence of --transform.\n";
+    }
+    if(cl_transform_no_partial_loop_purity.getNumOccurrences()){
+      Debug::warn("Configuration::check_commandline:no:transform:transform-no-partial-loop-purity")
+        << "WARNING: --no-partial-loop-purity ignored in absence of --transform.\n";
     }
   }
   /* Check commandline switch compatibility with memory model. */

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -130,6 +130,11 @@ static llvm::cl::opt<bool> cl_transform_no_dead_code_elim
  llvm::cl::desc("Disable the dead code elimination pass in module\n"
                 "transformation."));
 
+static llvm::cl::opt<bool> cl_transform_no_cast_elim
+("no-cast-elim",llvm::cl::NotHidden,llvm::cl::cat(cl_transformation_cat),
+ llvm::cl::desc("Disable the cast elimination pass in module\n"
+                "transformation."));
+
 static llvm::cl::opt<bool> cl_transform_no_partial_loop_purity
 ("no-partial-loop-purity",llvm::cl::NotHidden,llvm::cl::cat(cl_transformation_cat),
  llvm::cl::desc("Disable the partial loop purity bounding pass in module\n"
@@ -225,6 +230,7 @@ void Configuration::assign_by_commandline(){
   check_robustness = cl_check_robustness;
   transform_spin_assume = cl_transform_spin_assume;
   transform_dead_code_elim = !cl_transform_no_dead_code_elim;
+  transform_cast_elim = !cl_transform_no_cast_elim;
   transform_partial_loop_purity = !cl_transform_no_partial_loop_purity;
   transform_loop_unroll = cl_transform_loop_unroll;
   if (cl_verifier_nondet_int.getNumOccurrences())
@@ -294,6 +300,10 @@ void Configuration::check_commandline(){
     if(cl_transform_loop_unroll.getNumOccurrences()){
       Debug::warn("Configuration::check_commandline:no:transform:transform_loop_unroll")
         << "WARNING: --unroll ignored in absence of --transform.\n";
+    }
+    if(cl_transform_no_cast_elim.getNumOccurrences()){
+      Debug::warn("Configuration::check_commandline:no:transform:transform-no-cast-elim")
+        << "WARNING: --no-cast-elim ignored in absence of --transform.\n";
     }
     if(cl_transform_no_partial_loop_purity.getNumOccurrences()){
       Debug::warn("Configuration::check_commandline:no:transform:transform-no-partial-loop-purity")

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -187,6 +187,8 @@ public:
   bool transform_spin_assume;
   /* In module transformation, enable the DeadCodeElim pass. */
   bool transform_dead_code_elim = true;
+  /* In module transformation, enable the CastElim pass. */
+  bool transform_cast_elim = true;
   /* In module transformation, enable the PartialLoopPurity pass. */
   bool transform_partial_loop_purity = true;
   /* If transform_loop_unroll is non-negative, in module

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -92,7 +92,7 @@ public:
     debug_collect_all_traces = false;
     debug_print_on_reset = false;
     debug_print_on_error = false;
-    transform_spin_assume = true;
+    transform_spin_assume = false;
     transform_loop_unroll = -1;
     svcomp_nondet_int = nullptr;
     print_progress = false;
@@ -187,6 +187,8 @@ public:
   bool transform_spin_assume;
   /* In module transformation, enable the DeadCodeElim pass. */
   bool transform_dead_code_elim = true;
+  /* In module transformation, enable the PartialLoopPurity pass. */
+  bool transform_partial_loop_purity = true;
   /* If transform_loop_unroll is non-negative, in module
    * transformation, enable loop unrolling with depth
    * transform_loop_unroll.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,6 +4,7 @@ noinst_LIBRARIES = libnidhugg.a
 libnidhugg_a_SOURCES = \
   AddLibPass.cpp AddLibPass.h \
   BVClock.cpp BVClock.h \
+  CastElimPass.cpp CastElimPass.h \
   CheckModule.cpp CheckModule.h \
   Configuration.cpp Configuration.h \
   CPid.cpp CPid.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,6 +23,7 @@ libnidhugg_a_SOURCES = \
   MRef.cpp MRef.h \
   nregex.cpp nregex.h \
   Option.h \
+  PartialLoopPurityPass.h PartialLoopPurityPass.cpp \
   POWERExecution.cpp \
   POWERInterpreter.cpp POWERInterpreter.h \
   POWERARMTraceBuilder.cpp POWERARMTraceBuilder.tcc POWERARMTraceBuilder.h POWERARMTraceBuilder_decl.h \

--- a/src/PartialLoopPurityPass.cpp
+++ b/src/PartialLoopPurityPass.cpp
@@ -1,0 +1,1223 @@
+/* Copyright (C) 2021 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#include "CheckModule.h"
+#include "PartialLoopPurityPass.h"
+#include "SpinAssumePass.h"
+#include "Debug.h"
+#include "vecset.h"
+
+#include <llvm/Pass.h>
+#include <llvm/Analysis/LoopPass.h>
+#if defined(HAVE_LLVM_IR_DOMINATORS_H)
+#include <llvm/IR/Dominators.h>
+#elif defined(HAVE_LLVM_ANALYSIS_DOMINATORS_H)
+#include <llvm/Analysis/Dominators.h>
+#endif
+#if defined(HAVE_LLVM_IR_FUNCTION_H)
+#include <llvm/IR/Function.h>
+#elif defined(HAVE_LLVM_FUNCTION_H)
+#include <llvm/Function.h>
+#endif
+#if defined(HAVE_LLVM_IR_INSTRUCTIONS_H)
+#include <llvm/IR/Instructions.h>
+#elif defined(HAVE_LLVM_INSTRUCTIONS_H)
+#include <llvm/Instructions.h>
+#endif
+#if defined(HAVE_LLVM_IR_LLVMCONTEXT_H)
+#include <llvm/IR/LLVMContext.h>
+#elif defined(HAVE_LLVM_LLVMCONTEXT_H)
+#include <llvm/LLVMContext.h>
+#endif
+#if defined(HAVE_LLVM_IR_MODULE_H)
+#include <llvm/IR/Module.h>
+#elif defined(HAVE_LLVM_MODULE_H)
+#include <llvm/Module.h>
+#endif
+#if defined(HAVE_LLVM_SUPPORT_CALLSITE_H)
+#include <llvm/Support/CallSite.h>
+#elif defined(HAVE_LLVM_IR_CALLSITE_H)
+#include <llvm/IR/CallSite.h>
+#endif
+#include <llvm/Transforms/Utils/BasicBlockUtils.h>
+#include <llvm/Transforms/Utils/Cloning.h>
+#include <llvm/Analysis/ValueTracking.h>
+#include <llvm/Analysis/CallGraph.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/Support/Debug.h>
+
+#include <unordered_map>
+#include <sstream>
+
+#ifdef LLVM_HAS_TERMINATORINST
+typedef llvm::TerminatorInst TerminatorInst;
+#else
+typedef llvm::Instruction TerminatorInst;
+#endif
+
+namespace {
+  /* Not reentrant */
+  static const llvm::DominatorTree *DominatorTree;
+  static const std::unordered_map<llvm::Function *, bool> *may_inline;
+  static bool inlining_needed = false;
+
+  std::uint_fast8_t icmpop_to_bits(llvm::CmpInst::Predicate pred) {
+    using llvm::CmpInst;
+    assert(pred >= CmpInst::FIRST_ICMP_PREDICATE
+           && pred <= CmpInst::LAST_ICMP_PREDICATE);
+    switch(pred) {
+    case CmpInst::ICMP_SGT: return 0b00010;
+    case CmpInst::ICMP_UGT: return 0b00001;
+    case CmpInst::ICMP_SGE: return 0b00110;
+    case CmpInst::ICMP_UGE: return 0b00101;
+    case CmpInst::ICMP_EQ:  return 0b00100;
+    case CmpInst::ICMP_NE:  return 0b11011;
+    case CmpInst::ICMP_SLE: return 0b01100;
+    case CmpInst::ICMP_ULE: return 0b10100;
+    case CmpInst::ICMP_SLT: return 0b01000;
+    case CmpInst::ICMP_ULT: return 0b10000;
+    default: abort();
+    }
+  }
+
+  llvm::CmpInst::Predicate bits_to_icmpop(std::uint_fast8_t bits) {
+    using llvm::CmpInst;
+    if ((bits & 0b01110) == 0b01110) return CmpInst::FCMP_TRUE; // Not expected to happen
+    if ((bits & 0b10101) == 0b10101) return CmpInst::FCMP_TRUE; // Not expected to happen
+    if ((bits & 0b01100) == 0b01100) return CmpInst::ICMP_SLE;
+    if ((bits & 0b00110) == 0b00110) return CmpInst::ICMP_SGE;
+    if ((bits & 0b10100) == 0b10100) return CmpInst::ICMP_ULE;
+    if ((bits & 0b00101) == 0b00101) return CmpInst::ICMP_UGE;
+    if ((bits & 0b01000) == 0b01000) return CmpInst::ICMP_SLT;
+    if ((bits & 0b00010) == 0b00010) return CmpInst::ICMP_SGT;
+    if ((bits & 0b10000) == 0b10000) return CmpInst::ICMP_ULT;
+    if ((bits & 0b00001) == 0b00001) return CmpInst::ICMP_UGT;
+    if ((bits & 0b01010) == 0b01010) return CmpInst::ICMP_NE;
+    if ((bits & 0b10001) == 0b10001) return CmpInst::ICMP_NE;
+    if ((bits & 0b00100) == 0b00100) return CmpInst::ICMP_EQ;
+    return CmpInst::FCMP_FALSE;
+  }
+
+  llvm::CmpInst::Predicate icmpop_invert_strictness(llvm::CmpInst::Predicate pred) {
+    return bits_to_icmpop(0b00100 ^ icmpop_to_bits(pred));
+  }
+
+  bool check_predicate_satisfaction(const llvm::APInt &lhs,
+                                    llvm::CmpInst::Predicate pred,
+                                    const llvm::APInt &rhs) {
+    using llvm::CmpInst;
+    assert(pred >= CmpInst::FIRST_ICMP_PREDICATE
+           && pred <= CmpInst::LAST_ICMP_PREDICATE);
+    switch(pred) {
+    case CmpInst::ICMP_SGT: return lhs.sgt(rhs);
+    case CmpInst::ICMP_UGT: return lhs.ugt(rhs);
+    case CmpInst::ICMP_SGE: return lhs.sge(rhs);
+    case CmpInst::ICMP_UGE: return lhs.uge(rhs);
+    case CmpInst::ICMP_EQ:  return lhs.eq (rhs);
+    case CmpInst::ICMP_NE:  return lhs.ne (rhs);
+    case CmpInst::ICMP_SLE: return lhs.sle(rhs);
+    case CmpInst::ICMP_ULE: return lhs.ule(rhs);
+    case CmpInst::ICMP_SLT: return lhs.slt(rhs);
+    case CmpInst::ICMP_ULT: return lhs.ult(rhs);
+    default: abort();
+    }
+  }
+
+  struct BinaryPredLoc {
+    struct BinaryPredicate {
+      llvm::Value *lhs = nullptr, *rhs = nullptr;
+      /* FCMP_TRUE and FCMP_FALSE are used as special values indicating
+       * unconditional purity
+       */
+      llvm::CmpInst::Predicate op = llvm::CmpInst::FCMP_TRUE;
+
+      BinaryPredicate() {}
+      BinaryPredicate(bool static_value) {
+        op = static_value ? llvm::CmpInst::FCMP_TRUE : llvm::CmpInst::FCMP_FALSE;
+      }
+      BinaryPredicate(llvm::CmpInst::Predicate op, llvm::Value *lhs,
+                      llvm::Value *rhs)
+        : lhs(lhs), rhs(rhs), op(op) {
+        assert(!(is_true() || is_false()) || (lhs == nullptr && rhs == nullptr));
+      }
+
+      /* A BinaryPredicate must be normalised after direct modification of its members. */
+      void normalise() {
+        if (op == llvm::CmpInst::FCMP_TRUE || op == llvm::CmpInst::FCMP_FALSE) {
+          lhs = rhs = nullptr;
+        } else {
+          assert(lhs && rhs);
+        }
+      }
+
+      bool is_true() const {
+        assert(!(op == llvm::CmpInst::FCMP_TRUE && (lhs || rhs)));
+        return op == llvm::CmpInst::FCMP_TRUE;
+      }
+      bool is_false() const {
+        assert(!(op == llvm::CmpInst::FCMP_FALSE && (lhs || rhs)));
+        return op == llvm::CmpInst::FCMP_FALSE;
+      }
+
+      BinaryPredicate negate() const {
+        return {llvm::CmpInst::getInversePredicate(op), lhs, rhs};
+      }
+
+      BinaryPredicate swap() const {
+        return {llvm::CmpInst::getSwappedPredicate(op), rhs, lhs};
+      }
+
+      // IDEA: Use operator| for join (and operator& for meet, if needed),
+      // unless it's confusing
+      BinaryPredicate operator&(const BinaryPredicate &other) const {
+        if (other.is_true() || *this == other) return *this;
+        if (is_true()) return other;
+
+        using llvm::CmpInst;
+        BinaryPredicate res = *this;
+        BinaryPredicate o(other);
+        if (res.rhs == o.lhs || res.rhs == o.rhs) res = swap();
+        if (res.lhs == o.lhs || res.lhs == o.rhs) {
+          if (res.lhs != o.lhs) o = o.swap();
+          if (res.rhs == o.rhs) {
+            if (llvm::CmpInst::isFPPredicate(res.op)
+                && llvm::CmpInst::isFPPredicate(o.op)) {
+              res.op = CmpInst::Predicate(res.op & o.op);
+            } else if (llvm::CmpInst::isIntPredicate(res.op)
+                       && llvm::CmpInst::isIntPredicate(o.op)) {
+              res.op = bits_to_icmpop(icmpop_to_bits(res.op) & icmpop_to_bits(o.op));
+            } else {
+              return false; // Mixing fp and int predicates
+            }
+            res.normalise();
+            return res;
+          }
+          if (llvm::isa<llvm::ConstantInt>(res.rhs) && llvm::isa<llvm::ConstantInt>(o.rhs)) {
+            assert((llvm::cast<llvm::ConstantInt>(res.rhs)->getValue()
+                    != llvm::cast<llvm::ConstantInt>(o.rhs)->getValue()));
+            if (res.op == CmpInst::ICMP_EQ || o.op == CmpInst::ICMP_EQ) {
+              if (res.op != CmpInst::ICMP_EQ) std::swap(o, res);
+              const llvm::APInt &RR = llvm::cast<llvm::ConstantInt>(res.rhs)->getValue();
+              const llvm::APInt &OR = llvm::cast<llvm::ConstantInt>(o.rhs)->getValue();
+              if (check_predicate_satisfaction(RR, o.op, OR)) {
+                return res;
+              } else {
+                return false;
+              }
+            }
+            if (res.op == CmpInst::ICMP_NE || o.op == CmpInst::ICMP_NE) {
+              if (o.op != CmpInst::ICMP_NE) std::swap(o, res);
+              const llvm::APInt &RR = llvm::cast<llvm::ConstantInt>(res.rhs)->getValue();
+              const llvm::APInt &OR = llvm::cast<llvm::ConstantInt>(o.rhs)->getValue();
+              if (check_predicate_satisfaction(OR, res.op, RR)) {
+                return false; /* Possible to refine: we'd have to
+                               * exclude OR from res somehow */
+              } else {
+                return res;
+              }
+            }
+            {
+              const llvm::APInt &RR = llvm::cast<llvm::ConstantInt>(res.rhs)->getValue();
+              const llvm::APInt &OR = llvm::cast<llvm::ConstantInt>(o.rhs)->getValue();
+              assert(res.op != CmpInst::ICMP_EQ && res.op != CmpInst::ICMP_NE);
+              if (CmpInst::isIntPredicate(res.op)
+                  && (o.op == res.op || o.op == icmpop_invert_strictness(res.op))) {
+                  if ((check_predicate_satisfaction(RR, res.op, OR))) return o;
+                  else return res;
+              }
+            }
+          }
+        }
+
+        return false;
+      }
+      BinaryPredicate &operator&=(const BinaryPredicate &other) {
+        return *this = (*this & other);
+      }
+
+      bool operator!=(const BinaryPredicate &other) const { return !(*this == other); }
+      bool operator==(const BinaryPredicate &other) const {
+        assert(!(is_true() || is_false()) || (lhs == nullptr && rhs == nullptr));
+        return lhs == other.lhs && rhs == other.rhs && op == other.op;
+      }
+      bool operator<(const BinaryPredicate &other) const {
+        if (other.is_true() && !is_true()) return true;
+        if (is_false() && !other.is_false()) return true;
+        return false;
+      }
+      bool operator<=(const BinaryPredicate &other) const {
+        return *this == other || *this < other;
+      }
+    } pred;
+
+    /* Earliest location that can support an insertion. nullptr means
+     * that any location is fine. */
+    llvm::Instruction *insertion_point = nullptr;
+
+    BinaryPredLoc() {}
+    BinaryPredLoc(bool static_pred, llvm::Instruction *insertion_point = nullptr)
+      : pred(static_pred), insertion_point(static_pred ? insertion_point : nullptr) {}
+    BinaryPredLoc(BinaryPredicate pred, llvm::Instruction *insertion_point = nullptr)
+      : pred(std::move(pred)), insertion_point(pred.is_false() ? nullptr : insertion_point) {}
+    BinaryPredLoc(llvm::CmpInst::Predicate op, llvm::Value *lhs,
+                    llvm::Value *rhs) : pred(op, lhs, rhs) {}
+    // BinaryPredLoc(BinaryPredicate pred, llvm::Instruction *insertion_point)
+    //   : pred(std::move(pred)), insertion_point(insertion_point) {}
+
+    /* A BinaryPredLoc must be normalised after direct modification of its members. */
+    void normalise() {
+      pred.normalise();
+      if (pred.is_false()) insertion_point = nullptr;
+    }
+
+    bool is_true() const { return pred.is_true() && !insertion_point; }
+    bool is_false() const {
+      assert(!(pred.is_false() && insertion_point));
+      return pred.is_false();
+    }
+    BinaryPredLoc negate() const {
+      BinaryPredLoc res = *this;
+      res.pred = pred.negate();
+      return res;
+    }
+
+    // IDEA: Use operator| for join (and operator& for meet, if needed),
+    // unless it's confusing
+    BinaryPredLoc operator&(const BinaryPredLoc &other) const {
+      BinaryPredLoc res;
+      if (!insertion_point) res.insertion_point = other.insertion_point;
+      else if (!other.insertion_point) res.insertion_point = insertion_point;
+      else if (insertion_point == other.insertion_point) res.insertion_point = insertion_point;
+      else if (DominatorTree->dominates(insertion_point, other.insertion_point)) {
+        res.insertion_point = other.insertion_point;
+      } else if (DominatorTree->dominates(other.insertion_point, insertion_point)) {
+        res.insertion_point = insertion_point;
+      } else {
+        /* TODO: We have to find the least common denominator */
+        llvm::dbgs() << "Meeting insertion points general case not implemented:\n";
+        llvm::dbgs() << "    " << *insertion_point << "\n"
+                     << " and" << *other.insertion_point << "\n";
+        // assert(false);
+        return false; // Underapproximating for now
+      }
+
+      res.pred = pred & other.pred;
+      if (res.pred.is_false()) res.insertion_point = nullptr; // consistency
+      return res;
+    }
+    BinaryPredLoc &operator&=(const BinaryPredLoc &other) {
+      return *this = (*this & other);
+    }
+
+  private:
+    llvm::Instruction *join_insertion_points(llvm::Instruction *other) const {
+      llvm::Instruction *me = this->insertion_point;
+      if (!me || !other) return nullptr;
+      if (DominatorTree->dominates(other, me)) {
+        assert(other != me);
+        return other;
+      }
+      return me;
+    }
+  protected:
+    friend struct PurityCondition;
+    BinaryPredLoc operator|(const BinaryPredLoc &other) const {
+      if (other.is_false()) return *this;
+      if (is_false()) return other;
+      if (pred.lhs == other.pred.lhs && pred.rhs == other.pred.rhs) {
+        /* Maybe this can be made more precise. F.ex. <= | >= is also
+         * true. There might be such a check in LLVM already. */
+        if (llvm::CmpInst::getInversePredicate(pred.op) == other.pred.op) {
+          return BinaryPredLoc(true, join_insertion_points(other.insertion_point));
+        } else if (pred == other.pred) {
+          BinaryPredLoc res = *this;
+          res.insertion_point = join_insertion_points(other.insertion_point);
+          return res;
+        }
+      }
+      /* XXX: We have to underapproximate :( */
+      if (*this < other) return other;
+      else return *this;
+    }
+    BinaryPredLoc &operator|=(const BinaryPredLoc &other) {
+      return *this = (*this | other);
+    }
+
+  public:
+    bool operator!=(const BinaryPredLoc &other) const { return !(*this == other); }
+    bool operator==(const BinaryPredLoc &other) const {
+      return pred == other.pred && insertion_point == other.insertion_point;
+    }
+    bool operator<(const BinaryPredLoc &other) const {
+      if (is_false()) return !other.is_false();
+      else if (!other.insertion_point && insertion_point /* < */) return pred <= other.pred;
+      else if (!insertion_point && other.insertion_point /* > */) return false;
+      else if (insertion_point == other.insertion_point /* == */) return pred < other.pred;
+      else if (insertion_point && other.insertion_point) {
+        if (DominatorTree->dominates(other.insertion_point, insertion_point) /* < */) {
+          return pred <= other.pred;
+        }
+        return false; /* Incomparable */
+      }
+
+      llvm_unreachable("All cases of insertion_point comparision covered above");
+    }
+
+  };
+
+  struct PurityCondition {
+    PurityCondition(BinaryPredLoc cond = true) {
+      if (!cond.is_false()) condset.insert_gt(cond);
+    }
+    PurityCondition(bool b){
+      if (b) condset.insert_gt(b);
+    }
+
+    bool is_true() const { return condset.size() == 1 && condset[0].is_true(); }
+    bool is_false() const { return condset.empty(); }
+    auto begin() const { return condset.begin(); }
+    auto end() const { return condset.end(); }
+    bool operator!=(const PurityCondition &other) { return !(*this == other); }
+    bool operator==(const PurityCondition &other) {
+      return condset == other.condset;
+    }
+    bool operator<(const PurityCondition &other) const {
+      bool found_smaller = condset.size() < other.condset.size();
+      for (const BinaryPredLoc &c : condset) {
+        bool found_leq = false;
+        for (const BinaryPredLoc &r : other.condset) {
+          if (r < c) return false;
+          if (c < r) {
+            found_smaller = found_leq = true;
+            break;
+          }
+          if (c == r) {
+            found_leq = true;
+            break;
+          }
+        }
+        if (!found_leq) return false;
+      }
+      return found_smaller;
+    }
+
+    PurityCondition operator|(const PurityCondition &other) const {
+      PurityCondition res = *this;
+      res.addConds(other.condset);
+      return res;
+    }
+
+    PurityCondition operator&(const PurityCondition &other) const {
+      /* Oh god */
+
+      /* Step one, pick out common conditions */
+      auto lhs = condset;
+      auto rhs = other.condset;
+      PurityCondition res(false);
+      assert(!res.is_true() && res.is_false());
+      for (unsigned l = 0; l < unsigned(lhs.size());) {
+        if (rhs.erase(lhs[l]) // || erase_greater(rhs, lhs[l])
+            ) {
+          res.addCond(lhs[l]);
+          lhs.erase_at(l);
+        } else {
+          ++l;
+        }
+      }
+      // for (unsigned r = 0; r < unsigned(rhs.size());) {
+      //   if (erase_greater(lhs, rhs[r])) {
+      //     res.addCond(rhs[r]);
+      //     rhs.erase_at(r);
+      //   } else {
+      //     ++r;
+      //   }
+      // }
+
+      /* If either is now false, we can short-circuit */
+      if (lhs.empty() || rhs.empty()) return res;
+
+      if (lhs.size() == 1) {
+        for (const BinaryPredLoc &r : rhs)
+          res.addCond(r & lhs[0]);
+      } else {
+        /* TODO: Improve step 2 */
+        BinaryPredLoc rhsdisj = false;
+        for (const BinaryPredLoc &r : rhs) rhsdisj |= r;
+        for (const BinaryPredLoc &l : lhs)
+          res.addCond(l & rhsdisj);
+      }
+
+      return res;
+    }
+
+    PurityCondition &operator&=(const PurityCondition &other) {
+      return *this = (*this & other);
+    }
+
+
+    PurityCondition map(std::function<BinaryPredLoc(const BinaryPredLoc &)> f) const {
+      auto vec = condset.get_vector();
+      for (BinaryPredLoc &term : vec)
+        term = f(term);
+
+      PurityCondition res(false);
+      for (BinaryPredLoc &term : vec)
+        res.addCond(std::move(term));
+      return res;
+    };
+
+  private:
+    struct LexicalCompare {
+      auto tupleit(const BinaryPredLoc &p) const {
+        return std::make_tuple(p.insertion_point, p.pred.lhs, p.pred.op, p.pred.rhs);
+      }
+      bool operator()(const BinaryPredLoc &a, const BinaryPredLoc &b) const {
+        return tupleit(a) < tupleit(b);
+      };
+    };
+
+    void addCond(const BinaryPredLoc &cond) {
+      if (cond.is_false()) return; /* Keep it normalised */
+      std::vector<BinaryPredLoc> newset;
+      for (const BinaryPredLoc &c : condset) {
+        if (cond < c) return;
+        if (!(c < cond)) newset.push_back(c);
+      }
+      condset = std::move(newset);
+      condset.insert(cond);
+    };
+    void addConds(const VecSet<BinaryPredLoc, LexicalCompare> &conds) {
+      for(const BinaryPredLoc &cond : conds)
+        addCond(cond); /* Can be more efficient */
+    };
+
+    static bool erase_greater(VecSet<BinaryPredLoc, LexicalCompare> &set,
+                             const BinaryPredLoc &c) {
+      bool erased = false;
+      for (unsigned i = 0; i < unsigned(set.size());) {
+        if (c < set[i]) {
+          set.erase_at(i);
+          erased = true;
+        } else ++i;
+      }
+      return erased;
+    }
+
+    VecSet<BinaryPredLoc, LexicalCompare> condset;
+  };
+  typedef std::unordered_map<const llvm::BasicBlock*,PurityCondition> PurityConditions;
+
+  const char *getPredicateName(llvm::CmpInst::Predicate pred) {
+    using llvm::ICmpInst; using llvm::FCmpInst;
+    switch (pred) {
+    default:                   return "unknown";
+    case FCmpInst::FCMP_FALSE: return "false";
+    case FCmpInst::FCMP_OEQ:   return "oeq";
+    case FCmpInst::FCMP_OGT:   return "ogt";
+    case FCmpInst::FCMP_OGE:   return "oge";
+    case FCmpInst::FCMP_OLT:   return "olt";
+    case FCmpInst::FCMP_OLE:   return "ole";
+    case FCmpInst::FCMP_ONE:   return "one";
+    case FCmpInst::FCMP_ORD:   return "ord";
+    case FCmpInst::FCMP_UNO:   return "uno";
+    case FCmpInst::FCMP_UEQ:   return "ueq";
+    case FCmpInst::FCMP_UGT:   return "ugt";
+    case FCmpInst::FCMP_UGE:   return "uge";
+    case FCmpInst::FCMP_ULT:   return "ult";
+    case FCmpInst::FCMP_ULE:   return "ule";
+    case FCmpInst::FCMP_UNE:   return "une";
+    case FCmpInst::FCMP_TRUE:  return "true";
+    case ICmpInst::ICMP_EQ:    return "eq";
+    case ICmpInst::ICMP_NE:    return "ne";
+    case ICmpInst::ICMP_SGT:   return "sgt";
+    case ICmpInst::ICMP_SGE:   return "sge";
+    case ICmpInst::ICMP_SLT:   return "slt";
+    case ICmpInst::ICMP_SLE:   return "sle";
+    case ICmpInst::ICMP_UGT:   return "ugt";
+    case ICmpInst::ICMP_UGE:   return "uge";
+    case ICmpInst::ICMP_ULT:   return "ult";
+    case ICmpInst::ICMP_ULE:   return "ule";
+    }
+  }
+
+  llvm::Instruction::OtherOps getPredicateOpcode(llvm::CmpInst::Predicate pred) {
+    using llvm::ICmpInst; using llvm::FCmpInst;
+    switch (pred) {
+    case ICmpInst::ICMP_EQ:  case ICmpInst::ICMP_NE:
+    case ICmpInst::ICMP_SGT: case ICmpInst::ICMP_SGE:
+    case ICmpInst::ICMP_SLT: case ICmpInst::ICMP_SLE:
+    case ICmpInst::ICMP_UGT: case ICmpInst::ICMP_UGE:
+    case ICmpInst::ICMP_ULT: case ICmpInst::ICMP_ULE:
+      return llvm::Instruction::OtherOps::ICmp;
+    case FCmpInst::FCMP_FALSE: case FCmpInst::FCMP_TRUE:
+      assert(false && "Predicates false & true should not generate cmp insts");
+    case FCmpInst::FCMP_OEQ: case FCmpInst::FCMP_OGT:
+    case FCmpInst::FCMP_OGE: case FCmpInst::FCMP_OLT:
+    case FCmpInst::FCMP_OLE: case FCmpInst::FCMP_ONE:
+    case FCmpInst::FCMP_ORD: case FCmpInst::FCMP_UNO:
+    case FCmpInst::FCMP_UEQ: case FCmpInst::FCMP_UGT:
+    case FCmpInst::FCMP_UGE: case FCmpInst::FCMP_ULT:
+    case FCmpInst::FCMP_ULE: case FCmpInst::FCMP_UNE:
+      return llvm::Instruction::OtherOps::FCmp;
+    case ICmpInst::BAD_ICMP_PREDICATE:
+    case FCmpInst::BAD_FCMP_PREDICATE:
+      (void)0; // fallthrough
+    }
+    llvm::dbgs() << "Predicate " << pred << " unknown!\n";
+    assert(false && "unknown predicate"); abort();
+  }
+
+  llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const BinaryPredLoc &cond) {
+    if (cond.pred.is_true()) os << "true";
+    else if (cond.pred.is_false()) os << "false";
+    else {
+      cond.pred.lhs->printAsOperand(os);
+      os << " " << getPredicateName(cond.pred.op) << " ";
+      cond.pred.rhs->printAsOperand(os);
+    }
+    if (cond.insertion_point) {
+      os << " before " << *cond.insertion_point;
+    }
+    return os;
+  }
+  llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const PurityCondition &cond) {
+    if (cond.is_false()) os << "false";
+    else {
+      for (auto it = cond.begin(); it != cond.end();++it) {
+        if (it != cond.begin()) os << " || ";
+        os << *it;
+      }
+    }
+    return os;
+  }
+
+  llvm::Instruction *maybeFindUserLocationOrNull(llvm::User *U) {
+    return llvm::dyn_cast_or_null<llvm::Instruction>(U);
+  }
+
+  llvm::Instruction *maybeFindValueLocation(llvm::Value *V) {
+    return llvm::dyn_cast<llvm::Instruction>(V);
+  }
+
+  void maybeResolvePhi(llvm::Value *&V, const llvm::BasicBlock *From,
+                       const llvm::BasicBlock *To) {
+    llvm::PHINode *N = llvm::dyn_cast_or_null<llvm::PHINode>(V);
+    if (!N || N->getParent() != To) return;
+    V = N->getIncomingValueForBlock(From);
+  }
+
+  void collapseTautologies(BinaryPredLoc &cond) {
+    if (cond.pred.is_true() || cond.pred.is_false()) return;
+    if (cond.pred.rhs == cond.pred.lhs) {
+      if (llvm::CmpInst::isFalseWhenEqual(cond.pred.op)) cond.pred = false;
+      if (llvm::CmpInst::isTrueWhenEqual(cond.pred.op))  cond.pred = true;
+    }
+    if (llvm::ConstantInt *LHS = llvm::dyn_cast_or_null<llvm::ConstantInt>(cond.pred.lhs)) {
+      if (llvm::ConstantInt *RHS = llvm::dyn_cast_or_null<llvm::ConstantInt>(cond.pred.rhs)) {
+        if (check_predicate_satisfaction(LHS->getValue(), cond.pred.op, RHS->getValue())) {
+          cond.pred = true;
+        } else  {
+          cond = false;
+        }
+      }
+    }
+
+    cond.normalise();
+  }
+
+  llvm::Value *maybeGetExtractValueAggregate
+  (llvm::Value *I, unsigned OnlyIfIndex) {
+    auto *EV = llvm::dyn_cast<llvm::ExtractValueInst>(I);
+    if (!EV || EV->getNumIndices() != 1 || EV->getIndices()[0] != OnlyIfIndex)
+      return nullptr;
+    return EV->getAggregateOperand();
+  }
+
+  /* Does not check that def-use order is respected, only for global
+   * side effects */
+  bool mayReorder(const llvm::Instruction *I, const llvm::Instruction *J) {
+    /* Crude but hopefully safe */
+    if (J->mayReadOrWriteMemory()) return false;
+    return true;
+  }
+
+  bool deepPointerComparison(const llvm::Value *P1, const llvm::Value *P2) {
+    if (P1 == P2) return true;
+
+    /* Hail-mary */
+    if (auto *I1 = llvm::dyn_cast<llvm::Instruction>(P1)) {
+      if (I1->mayReadOrWriteMemory()) return false; /* Two identical loads, f.ex. */
+      auto *I2 = llvm::dyn_cast<llvm::Instruction>(P2);
+      return I2 && I1->isIdenticalTo(I2);
+    }
+    return false;
+  }
+
+  bool isPermissibleLeak(const llvm::Loop *L, const llvm::PHINode *Phi,
+                         llvm::Instruction *LoopCarried) {
+    auto *CmpXchg = llvm::dyn_cast_or_null<llvm::AtomicCmpXchgInst>
+      (maybeGetExtractValueAggregate(LoopCarried, 0));
+    if (!CmpXchg) {
+      /* Sometimes, clang generates this odd pattern where the expected
+       * value is only assigned when the cmpxchg fails */
+      if (auto *CPhi = llvm::dyn_cast<llvm::PHINode>(LoopCarried)) {
+        if (CPhi->getNumIncomingValues() != 2) return false;
+        for (unsigned predi = 0; predi < 2; ++predi) {
+          CmpXchg = llvm::dyn_cast_or_null<llvm::AtomicCmpXchgInst>
+            (maybeGetExtractValueAggregate(CPhi->getIncomingValue(predi), 0));
+          if (!CmpXchg) continue;
+          llvm::BasicBlock *Pred = CPhi->getIncomingBlock(predi);
+          llvm::BasicBlock *PPred = Pred->getSinglePredecessor();
+          if (!PPred) return false;
+          auto *Term = llvm::dyn_cast<llvm::BranchInst>(PPred->getTerminator());
+          if (!Term || !Term->isConditional()) return false;
+          if (maybeGetExtractValueAggregate(Term->getCondition(), 1) != CmpXchg)
+            return false;
+        }
+      }
+      /* Do we need else if (auto *Select = ...) ? */
+    }
+    if (!CmpXchg) return false;
+    llvm::Value *Ptr = CmpXchg->getPointerOperand();
+    /* Note, we do not check the location of the cmpxchg because no more
+     * than one value can permissibly be carried along a backedge, and
+     * so we are always allowed to do the "code motion" */
+
+    for (llvm::BasicBlock *Entering : llvm::predecessors(L->getHeader())) {
+      if (L->contains(Entering)) continue; // Not an entering block
+      llvm::Value *V = Phi->getIncomingValueForBlock(Entering);
+      llvm::LoadInst *Ld = llvm::dyn_cast<llvm::LoadInst>(V);
+      if (!Ld) return false;
+      if (!deepPointerComparison(Ld->getPointerOperand(), Ptr)) return false;
+      if (Ld->getParent() != Entering) return false;
+      for (llvm::Instruction *I = Ld; I != Entering->getTerminator();){
+        I = I->getNextNode();
+        if (!mayReorder(Ld, I)) return false;
+      }
+    }
+    return true;
+  }
+
+  PurityCondition getIn(const llvm::Loop *L, PurityConditions &conds,
+                        const llvm::BasicBlock *From,
+                        const llvm::BasicBlock *To) {
+    if (To == L->getHeader()) {
+      /* Check for data leaks along the back edge */
+      // llvm::dbgs() << "Checking " << From->getName() << "->" << To->getName()
+      //              << " for escaping phis: \n";
+      for (const llvm::Instruction *I = &*To->begin();
+           I != To->getFirstNonPHI(); I = I->getNextNode()) {
+        const llvm::PHINode *Phi = llvm::cast<llvm::PHINode>(I);
+        llvm::Value *V = Phi->getIncomingValueForBlock(From);
+        // llvm::dbgs() << "  "; Phi->printAsOperand(llvm::dbgs());
+        // llvm::dbgs() << ": "; V->printAsOperand(llvm::dbgs()); llvm::dbgs() << "\n";
+        if (llvm::Instruction *VI = maybeFindValueLocation(V)) {
+          if (L->contains(VI)) {
+            if (isPermissibleLeak(L, Phi, VI)) {
+              continue;
+            }
+            // llvm::dbgs() << "  leak: "; V->printAsOperand(llvm::dbgs());
+            // llvm::dbgs() << " through "; Phi->printAsOperand(llvm::dbgs());
+            // llvm::dbgs() << "\n";
+            return false; /* Leak */
+          }
+        }
+      }
+      return true;
+    }
+    if (!L->contains(To)) return false;
+    PurityCondition in = conds[To].map([From, To](BinaryPredLoc term) {
+      maybeResolvePhi(term.pred.rhs, From, To);
+      maybeResolvePhi(term.pred.lhs, From, To);
+      term.normalise();
+      collapseTautologies(term);
+      return term;
+    });
+    return in;
+  }
+
+  BinaryPredLoc getBranchCondition(llvm::Value *cond) {
+    assert(cond && llvm::isa<llvm::IntegerType>(cond->getType())
+           && llvm::cast<llvm::IntegerType>(cond->getType())->getBitWidth() == 1);
+    if (auto *cmp = llvm::dyn_cast<llvm::CmpInst>(cond)) {
+        return BinaryPredLoc(cmp->getPredicate(), cmp->getOperand(0),
+                             cmp->getOperand(1));
+    } else if (auto *bop = llvm::dyn_cast<llvm::BinaryOperator>(cond)) {
+      if (bop->getOpcode() == llvm::Instruction::Xor) {
+        llvm::Value *lhs = bop->getOperand(0), *rhs = bop->getOperand(1);
+        if (llvm::isa<llvm::ConstantInt>(lhs) || llvm::isa<llvm::ConstantInt>(rhs)) {
+          if (!llvm::isa<llvm::ConstantInt>(rhs)) std::swap(lhs, rhs);
+          llvm::ConstantInt *rhsi = llvm::cast<llvm::ConstantInt>(rhs);
+          if (rhsi->getValue() == 0) {
+            return getBranchCondition(lhs);
+          } else {
+            assert(rhsi->getValue() == 1);
+            return getBranchCondition(lhs).negate();
+          }
+        }
+      }
+    }
+    return BinaryPredLoc(llvm::CmpInst::ICMP_EQ, cond,
+                         llvm::ConstantInt::getTrue(cond->getContext()));
+  }
+
+  PurityCondition computeOut(const llvm::Loop *L, PurityConditions &conds,
+                             const llvm::BasicBlock *BB) {
+    if (auto *branch = llvm::dyn_cast<llvm::BranchInst>(BB->getTerminator())) {
+      if (branch->isConditional()) {
+        llvm::BasicBlock *trueSucc = branch->getSuccessor(0);
+        llvm::BasicBlock *falseSucc = branch->getSuccessor(1);
+        PurityCondition trueIn = getIn(L, conds, BB, trueSucc);
+        PurityCondition falseIn = getIn(L, conds, BB, falseSucc);
+        if (trueIn == falseIn) return trueIn;
+        // If the operands are in the loop, we can check them for
+        // purity; if not, the condition should just be false. That way,
+        // we won't waste good conditions in the overapproximations
+        BinaryPredLoc brCond = getBranchCondition(branch->getCondition());
+        collapseTautologies(brCond);
+        if (!L->contains(trueSucc)) {
+          assert(trueIn.is_false());
+          if (falseIn.is_true()) return brCond.negate();
+          return falseIn & BinaryPredLoc(true, &*falseSucc->getFirstInsertionPt());
+        }
+        if (!L->contains(falseSucc)) {
+          assert(falseIn.is_false());
+          if (trueIn.is_true()) return brCond;
+          return trueIn & BinaryPredLoc(true, &*trueSucc->getFirstInsertionPt());
+        }
+        // if (trueIn.is_true()) return falseIn | brCond;
+        // if (falseIn.is_true()) return trueIn | brCond.negate();
+        // llvm::dbgs() << "   lhs: " << (falseIn | brCond) << "\n";
+        // llvm::dbgs() << "    trueIn: " << trueIn << "\n";
+        // llvm::dbgs() << "    brCond.negate(): " << brCond.negate() << "\n";
+        // llvm::dbgs() << "   rhs: " << (trueIn | brCond.negate()) << "\n";
+        // assert(!(trueIn | brCond.negate()).is_false() || (trueIn.is_false() && brCond.is_false()));
+        return (falseIn | brCond) & (trueIn | brCond.negate());
+      }
+    }
+
+    /* Generic implementation; no concern for branch conditions */
+    PurityCondition cond;
+    for (const llvm::BasicBlock *s : llvm::successors(BB)) {
+      cond &= getIn(L, conds, BB, s);
+    }
+    return cond;
+  }
+
+  bool isSafeToLoadFromPointer(const llvm::Value *V) {
+    return llvm::isa<llvm::GlobalValue>(V)
+      || llvm::isa<llvm::AllocaInst>(V);
+  }
+
+  PurityCondition instructionPurity(llvm::Loop *L, llvm::Instruction &I) {
+    if (!I.mayReadOrWriteMemory()
+        && llvm::isSafeToSpeculativelyExecute(&I)) return true;
+    if (llvm::isa<llvm::PHINode>(I)) return true;
+    if (llvm::isa<llvm::FenceInst>(I)) return true;
+
+    if (const llvm::LoadInst *Ld = llvm::dyn_cast<llvm::LoadInst>(&I)) {
+      /* No-segfaulting */
+      if (isSafeToLoadFromPointer(Ld->getPointerOperand())) {
+        return true;
+      } else {
+        return BinaryPredLoc(true, I.getNextNode());
+      }
+    }
+    if (!I.mayWriteToMemory()) {
+      if (llvm::isSafeToSpeculativelyExecute(&I)) {
+        llvm::dbgs() << "Wow, a safe-to-speculate loading inst: " << I << "\n";
+        return true;
+      } else {
+        return BinaryPredLoc(true, I.getNextNode());
+      }
+    }
+    if (llvm::AtomicRMWInst *RMW = llvm::dyn_cast<llvm::AtomicRMWInst>(&I)) {
+      BinaryPredLoc::BinaryPredicate pred(false);
+      llvm::Value *arg = RMW->getValOperand();
+      switch (RMW->getOperation()) {
+      case llvm::AtomicRMWInst::BinOp::Add:
+      case llvm::AtomicRMWInst::BinOp::Or:
+      case llvm::AtomicRMWInst::BinOp::Sub:
+      case llvm::AtomicRMWInst::BinOp::UMax:
+      case llvm::AtomicRMWInst::BinOp::Xor:
+        /* arg == 0 */
+        pred = {llvm::CmpInst::ICMP_EQ, arg,
+          llvm::ConstantInt::get(RMW->getType(), 0)};
+        break;
+      case llvm::AtomicRMWInst::BinOp::And:
+      case llvm::AtomicRMWInst::BinOp::UMin:
+        /* arg == 0b111...1 */
+        pred = {llvm::CmpInst::ICMP_EQ, arg,
+          llvm::ConstantInt::getAllOnesValue(RMW->getType())};
+        break;
+      case llvm::AtomicRMWInst::BinOp::Xchg:
+        /* ret == arg */
+        pred = {llvm::CmpInst::ICMP_EQ, &I, arg};
+        break;
+      }
+      BinaryPredLoc ret;
+      if (isSafeToLoadFromPointer(RMW->getPointerOperand())) {
+        ret = BinaryPredLoc(pred);
+      } else {
+        ret = BinaryPredLoc(pred, I.getNextNode());
+      }
+      collapseTautologies(ret);
+      return ret;
+    }
+
+    /* Extension: We do not yet handle when the return value of the cmpxchg is used for  */
+    if (llvm::AtomicCmpXchgInst *CX = llvm::dyn_cast<llvm::AtomicCmpXchgInst>(&I)) {
+      /* Try to find a ExtractValue instruction that extracts the
+       * success bit */
+      llvm::ExtractValueInst *success = nullptr;
+      for (llvm::User *U : CX->users()) {
+        if (llvm::ExtractValueInst *EV = llvm::dyn_cast<llvm::ExtractValueInst>(U)) {
+          if (EV->getNumIndices() == 1 && EV->idx_begin()[0] == 1) {
+            success = EV;
+            break;
+          }
+        }
+      }
+      if (success) {
+        BinaryPredLoc::BinaryPredicate pred
+          (llvm::CmpInst::ICMP_EQ, success,
+           llvm::ConstantInt::getFalse(CX->getContext()));
+        if (isSafeToLoadFromPointer(CX->getPointerOperand())) {
+          return BinaryPredLoc(pred);
+        } else {
+          return BinaryPredLoc(pred, I.getNextNode());
+        }
+      }
+    }
+
+    if (llvm::CallInst *CI = llvm::dyn_cast<llvm::CallInst>(&I)) {
+      if (CI->getCalledFunction()->getName() == "__VERIFIER_assume") return true;
+      if (may_inline) {
+        auto it = may_inline->find(CI->getCalledFunction());
+        if (it != may_inline->end() && it->second) {
+          /* We need inlining to do this; optimistically assume purity. If
+           * needed, the call will be inlined and the analysis redone. */
+          inlining_needed = true;
+          return true;
+        }
+      }
+    }
+    /* Extension point: We could add more instructions here */
+
+    return false;
+  }
+
+  PurityConditions analyseLoop(llvm::Loop *L) {
+    PurityConditions conds;
+    const auto &blocks = L->getBlocks();
+    bool changed;
+    unsigned count = 0;
+    // llvm::dbgs() << "Analysing " << *L;
+    do {
+      changed = false;
+      // Assume it's in reverse postorder, or some suitable order
+      for (auto it = blocks.rbegin(); it != blocks.rend(); ++it) {
+        llvm::BasicBlock *BB = *it;
+        PurityCondition cond = computeOut(L, conds, BB);
+        // llvm::dbgs() << "  out of " << BB->getName() << ": " << cond << "\n";
+        /* Skip the terminator */
+        for (auto it = BB->rbegin(); ++it != BB->rend();) {
+          cond &= instructionPurity(L, *it);
+        }
+        if (conds[BB] != cond) {
+          // llvm::dbgs() << " " << BB->getName() << ": " << cond << "\n";
+          changed = true;
+          conds[BB] = cond;
+        }
+      }
+      if (++count > 1000) {
+        llvm::dbgs() << "Analysis of loop in "
+                     << L->getHeader()->getParent()->getName()
+                     << " did not terminate after 1000 iterations\n";
+        abort();
+      }
+    } while(changed);
+    return conds;
+  }
+
+  bool functionMayInline(llvm::Function &F) {
+    return true;
+  }
+
+  auto getInliningCandidates(llvm::Module &M) {
+    std::unordered_map<llvm::Function *, bool> local_may_inline;
+    may_inline = &local_may_inline;
+
+    llvm::CallGraph CG(M);
+    std::vector<llvm::Function *> stack;
+
+    std::function<bool(llvm::Function*)> visit
+      = [&](llvm::Function *F) -> bool {
+        if (F->empty())return false;
+        if (std::count(stack.begin(), stack.end(), F) != 0) {
+          return false; /* Circular references aren't allowed */
+        }
+        struct ppg {
+          llvm::Function *F;
+          std::vector<llvm::Function *> &S;
+          ppg(llvm::Function *F, std::vector<llvm::Function *> &S)
+            : F(F), S(S) { S.push_back(F); }
+          ~ppg() { assert(S.back() == F); S.pop_back(); }
+        } push_pop_guard(F, stack);
+        for (llvm::CallGraphNode::CallRecord &callee : *CG[F]) {
+          if (!visit(callee.second->getFunction())) {
+            return local_may_inline[F] = false;
+          }
+        }
+
+        return local_may_inline[F] = functionMayInline(*F);
+      };
+
+    for (llvm::Function &F : M.functions()) {
+      if (F.empty()) continue;
+      visit(&F);
+    }
+    may_inline = nullptr;
+    return local_may_inline;
+  }
+
+  void findCallsInLoop(llvm::SmallPtrSet<llvm::CallInst*, 4> &calls,
+                       llvm::Loop *L) {
+    for (llvm::BasicBlock *BB : L->blocks()) {
+      for (llvm::Instruction *II = &*BB->begin(); II;) {
+        llvm::Instruction *I = II;
+        II = II->getNextNode();
+        if (llvm::CallInst *CI = llvm::dyn_cast<llvm::CallInst>(I)) {
+          auto it = may_inline->find(CI->getCalledFunction());
+          if (it != may_inline->end() && it->second) {
+            calls.insert(CI);
+          }
+        }
+      }
+    }
+  }
+
+  bool recurseLoops(llvm::Loop *L, const std::function<bool(llvm::Loop*)> &f) {
+    bool changed = false;
+    for (auto it = L->begin(); it != L->end(); ++it) {
+      changed |= recurseLoops(*it, f);
+    }
+    changed |= f(L);
+    return changed;
+  }
+
+  bool foreachLoop(const llvm::LoopInfo &LI,
+                   const std::function<bool(llvm::Loop*)> &f) {
+    bool changed = false;
+    for (auto it = LI.begin(); it != LI.end(); ++it) {
+      changed |= recurseLoops(*it, f);
+    }
+    return changed;
+  }
+
+  auto analyseInliningNeeds(llvm::Function &F) {
+    llvm::SmallPtrSet<llvm::CallInst*, 4> calls;
+    llvm::LoopInfo LI(*DominatorTree);
+
+    foreachLoop(LI, [&](llvm::Loop *L) {
+      assert(!inlining_needed);
+      PurityConditions conditions = analyseLoop(L);
+      PurityCondition headerCond = conditions[L->getHeader()];
+      if (!headerCond.is_false() && inlining_needed) {
+        findCallsInLoop(calls, L);
+      }
+      inlining_needed = false;
+      return false;
+    });
+
+    return calls;
+  }
+
+  bool doInline(llvm::Function &F,
+                llvm::SmallPtrSet<llvm::CallInst*, 4> &calls) {
+    for (llvm::CallInst *CI : calls) {
+      llvm::InlineFunctionInfo ifi;
+      // llvm::dbgs() << "Inlining call to " << CI->getCalledFunction()->getName()
+      //              << " in " << F.getName() << "\n";
+#if LLVM_VERSION_MAJOR >= 11
+      llvm::InlineResult res = llvm::InlineFunction(*CI, ifi);
+      assert(res.isSuccess());
+#else
+      bool success = llvm::InlineFunction(CI, ifi);
+      assert(success);
+#endif
+      assert(ifi.InlinedCalls.size() == 0);
+    }
+    return !calls.empty();
+  }
+
+  bool dominates_or_equals(const llvm::DominatorTree &DT,
+                           llvm::Instruction *Def, llvm::Instruction *User) {
+    return Def == User || DT.dominates(Def, User);
+  }
+
+  llvm::Instruction *findInsertionPoint(llvm::Loop *L,
+                                        const llvm::DominatorTree &DT,
+                                        const BinaryPredLoc &cond) {
+    if (llvm::Instruction *IPT = cond.insertion_point) {
+      if (llvm::Instruction *LHS = maybeFindUserLocationOrNull
+          (llvm::dyn_cast_or_null<llvm::User>(cond.pred.lhs))) {
+        if (llvm::Instruction *RHS = maybeFindUserLocationOrNull
+            (llvm::dyn_cast_or_null<llvm::User>(cond.pred.rhs))) {
+          if (DT.dominates(LHS, IPT) &&
+              DT.dominates(RHS, IPT)) return IPT;
+          if (dominates_or_equals(DT, IPT, RHS->getNextNode()) &&
+              dominates_or_equals(DT, LHS, RHS)) return RHS->getNextNode();
+          if (dominates_or_equals(DT, IPT, LHS->getNextNode()) &&
+              dominates_or_equals(DT, RHS, LHS)) return LHS->getNextNode();
+          /* uh oh, hard case */
+          assert(false && "Implement me"); abort();
+        } else {
+          if (DT.dominates(LHS, IPT)) return IPT;
+          if (dominates_or_equals(DT, IPT, LHS->getNextNode())) return LHS->getNextNode();
+          /* uh oh, hard case */
+          assert(false && "Implement me"); abort();
+        }
+      } else if (llvm::Instruction *RHS = maybeFindUserLocationOrNull
+            (llvm::dyn_cast_or_null<llvm::User>(cond.pred.rhs))) {
+          if (DT.dominates(LHS, IPT)) return IPT;
+          if (dominates_or_equals(DT, IPT, LHS->getNextNode())) return LHS->getNextNode();
+          /* uh oh, hard case */
+          assert(false && "Implement me"); abort();
+      } else {
+        return IPT;
+      }
+    } else {
+      if (llvm::Instruction *LHS = maybeFindUserLocationOrNull
+          (llvm::dyn_cast_or_null<llvm::User>(cond.pred.lhs))) {
+        if (llvm::Instruction *RHS = maybeFindUserLocationOrNull
+            (llvm::dyn_cast_or_null<llvm::User>(cond.pred.rhs))) {
+          if (dominates_or_equals(DT, LHS, RHS)) return RHS->getNextNode();
+          if (dominates_or_equals(DT, RHS, LHS)) return LHS->getNextNode();
+          /* uh oh, hard case */
+          assert(false && "Implement me"); abort();
+        } else {
+          return LHS->getNextNode();
+        }
+      } else if (llvm::Instruction *RHS = maybeFindUserLocationOrNull
+                 (llvm::dyn_cast_or_null<llvm::User>(cond.pred.rhs))) {
+        return RHS->getNextNode();
+      } else {
+        return &*L->getHeader()->getFirstInsertionPt();
+      }
+    }
+    llvm_unreachable("All cases covered in findInsertionPoint");
+  }
+
+  bool runOnLoop(llvm::Loop *L) {
+    // Debug::warn(("plp.code." + L->getHeader()->getParent()->getName()).str())
+    //   << "Analysing " << L->getHeader()->getParent()->getName() << ":\n"
+    //   << *L->getHeader()->getParent();
+    assert(!may_inline);
+    assert(!inlining_needed);
+    PurityConditions conditions = analyseLoop(L);
+    PurityCondition headerCond = conditions[L->getHeader()];
+    assert(!inlining_needed);
+    if (headerCond.is_false()) {
+      // llvm::dbgs() << "Loop " << L->getHeader()->getParent()->getName() << ":"
+      //              << *L << " isn't pure\n";
+      return false;
+    } else {
+      // llvm::dbgs() << "Partially pure loop found in "
+      //              << L->getHeader()->getParent()->getName() << "():\n";
+      // L->print(llvm::dbgs(), 2);
+      // llvm::dbgs() << " Purity condition: " << headerCond << "\n";
+    }
+
+    for (const BinaryPredLoc &term : headerCond) {
+      llvm::Instruction *I = findInsertionPoint(L, *DominatorTree, term);
+      //llvm::dbgs() << " Insertion point: " << *I << "\n";
+      llvm::Value *Cond;
+      if (term.pred.is_true()) {
+        Cond = llvm::ConstantInt::getTrue(L->getHeader()->getContext());
+      } else {
+        Cond = llvm::ICmpInst::Create
+          (getPredicateOpcode(term.pred.op),
+           llvm::CmpInst::getInversePredicate(term.pred.op),
+           term.pred.lhs, term.pred.rhs, "negated.pp.cond", I);
+      }
+      llvm::Function *F_assume = L->getHeader()->getParent()->getParent()
+        ->getFunction("__VERIFIER_assume");
+      {
+        llvm::Type *arg_ty = F_assume->arg_begin()->getType();
+        assert(arg_ty->isIntegerTy());
+        if(arg_ty->getIntegerBitWidth() != 1){
+          Cond = new llvm::ZExtInst(Cond, arg_ty,"",I);
+        }
+      }
+      llvm::CallInst::Create(F_assume,{Cond},"",I);
+    }
+
+    // llvm::dbgs() << "Rewritten:\n";
+    // llvm::dbgs() << *L->getHeader()->getParent();;
+
+    return true;
+  }
+}
+
+void PartialLoopPurityPass::getAnalysisUsage(llvm::AnalysisUsage &AU) const{
+  AU.addRequired<DeclareAssumePass>();
+  AU.addPreserved<DeclareAssumePass>();
+}
+
+bool PartialLoopPurityPass::runOnModule(llvm::Module &M) {
+  bool changed = false;
+
+  auto local_may_inline = getInliningCandidates(M);
+  may_inline = &local_may_inline;
+
+  for (llvm::Function &F : M.functions()) {
+    if (F.empty()) continue; /* We do nothing on declarations */
+    while(true) {
+      llvm::DominatorTree DT(F);
+      DominatorTree = &DT;
+      auto calls = analyseInliningNeeds(F);
+      if (!doInline(F, calls)) break;
+      changed = true;
+    }
+    assert(!llvm::verifyFunction(F, &llvm::dbgs()));
+  }
+
+  may_inline = nullptr;
+
+  for (llvm::Function &F : M.functions()) {
+    if (F.empty()) continue; /* We do nothing on declarations */
+    llvm::DominatorTree DT(F);
+    DominatorTree = &DT;
+    llvm::LoopInfo LI(DT);
+    changed |= foreachLoop(LI, runOnLoop);
+    assert(!llvm::verifyFunction(F, &llvm::dbgs()));
+  }
+
+  DominatorTree = nullptr;
+  return changed;
+}
+
+char PartialLoopPurityPass::ID = 0;
+static llvm::RegisterPass<PartialLoopPurityPass> X
+("partial-loop-purity",
+ "Bound pure and partially pure loops with __VERIFIER_assumes.");

--- a/src/PartialLoopPurityPass.h
+++ b/src/PartialLoopPurityPass.h
@@ -1,0 +1,36 @@
+/* Copyright (C) 2021 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#ifndef __PARTIAL_LOOP_PURITY_PASS_H__
+#define __PARTIAL_LOOP_PURITY_PASS_H__
+
+#include <llvm/Pass.h>
+#include <llvm/Analysis/LoopPass.h>
+
+class PartialLoopPurityPass : public llvm::ModulePass{
+public:
+  static char ID;
+  PartialLoopPurityPass() : llvm::ModulePass(ID) {};
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+  bool runOnModule(llvm::Module &M) override;
+};
+
+#endif

--- a/src/Transform.cpp
+++ b/src/Transform.cpp
@@ -21,6 +21,7 @@
 #include "LoopBoundPass.h"
 #include "SpinAssumePass.h"
 #include "DeadCodeElimPass.h"
+#include "PartialLoopPurityPass.h"
 #include "StrModule.h"
 #include "Transform.h"
 
@@ -108,6 +109,9 @@ namespace Transform {
     PM.add(llvm::createPromoteMemoryToRegisterPass());
     if (conf.transform_dead_code_elim) {
       PM.add(new DeadCodeElimPass());
+    }
+    if (conf.transform_partial_loop_purity) {
+      PM.add(new PartialLoopPurityPass());
     }
     if (conf.transform_spin_assume){
       PM.add(new SpinAssumePass());

--- a/src/Transform.cpp
+++ b/src/Transform.cpp
@@ -21,6 +21,7 @@
 #include "LoopBoundPass.h"
 #include "SpinAssumePass.h"
 #include "DeadCodeElimPass.h"
+#include "CastElimPass.h"
 #include "PartialLoopPurityPass.h"
 #include "StrModule.h"
 #include "Transform.h"
@@ -107,6 +108,9 @@ namespace Transform {
      */
     PM.add(new ClearOptnonePass());
     PM.add(llvm::createPromoteMemoryToRegisterPass());
+    if (conf.transform_cast_elim) {
+      PM.add(new CastElimPass());
+    }
     if (conf.transform_dead_code_elim) {
       PM.add(new DeadCodeElimPass());
     }

--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -25,7 +25,8 @@ nidhuggcparams = [
     {'name':'--clang','help':'Specify the path to clang.','param':'PATH'},
     {'name':'--clangxx','help':'Specify the path to clang++.','param':'PATH'},
     {'name':'--nidhugg','help':'Specify the path to the nidhugg binary.','param':'PATH'},
-    {'name':'--no-spin-assume','help':'Don\'t use the spin-assume transformation on module before calling nidhugg.','param':False},
+    {'name':'--no-partial-loop-purity','help':'Don\'t reduce partially pure loops with assumes before calling nidhugg.','param':False},
+    {'name':'--spin-assume','help':'Use the spin-assume transformation on module before calling nidhugg.','param':False},
     {'name':'--no-dead-code-elim','help':'Don\'t use the dead code elimination pass on module before calling nidhugg.','param':False},
     {'name':'--unroll','help':'Use unroll transformation on module before calling nidhugg.','param':'N'},
 ]
@@ -44,7 +45,8 @@ nidhuggcparamaliases = {
     '-clang':'--clang',
     '-clangxx':'--clangxx',
     '-nidhugg':'--nidhugg',
-    '-no-spin-assume':'--no-spin-assume',
+    '-no-partial-loop-purity':'--no-partial-loop-purity',
+    '-spin-assume':'--spin-assume',
     '-no-dead-code-elim':'--no-dead-code-elim',
     '-unroll':'--unroll',
 }
@@ -266,7 +268,9 @@ def main():
                 CLANGXX=argarg
             elif argname == '--nidhugg':
                 NIDHUGG=argarg
-            elif argname == '--no-spin-assume':
+            elif argname == '--no-partial-loop-purity':
+                transformargs.append(argname)
+            elif argname == '--spin-assume':
                 transformargs.append(argname)
             elif argname == '--no-dead-code-elim':
                 transformargs.append(argname)

--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -28,6 +28,7 @@ nidhuggcparams = [
     {'name':'--no-partial-loop-purity','help':'Don\'t reduce partially pure loops with assumes before calling nidhugg.','param':False},
     {'name':'--spin-assume','help':'Use the spin-assume transformation on module before calling nidhugg.','param':False},
     {'name':'--no-dead-code-elim','help':'Don\'t use the dead code elimination pass on module before calling nidhugg.','param':False},
+    {'name':'--no-cast-elim','help':'Don\'t use the cast elimination pass on module before calling nidhugg.','param':False},
     {'name':'--unroll','help':'Use unroll transformation on module before calling nidhugg.','param':'N'},
 ]
 
@@ -48,6 +49,7 @@ nidhuggcparamaliases = {
     '-no-partial-loop-purity':'--no-partial-loop-purity',
     '-spin-assume':'--spin-assume',
     '-no-dead-code-elim':'--no-dead-code-elim',
+    '-no-cast-elim':'--no-cast-elim',
     '-unroll':'--unroll',
 }
 
@@ -273,6 +275,8 @@ def main():
             elif argname == '--spin-assume':
                 transformargs.append(argname)
             elif argname == '--no-dead-code-elim':
+                transformargs.append(argname)
+            elif argname == '--no-cast-elim':
                 transformargs.append(argname)
             elif argname == '--unroll':
                 transformargs.append('--unroll={0}'.format(argarg))

--- a/tests/litmus/test-nidhugg.py
+++ b/tests/litmus/test-nidhugg.py
@@ -62,7 +62,8 @@ def res_to_string(tst, res):
         s = s + ' ' + ('Allow' if res['allow'] else 'Forbid')
 
     if tst['expected trace count'] != res['tracecount']:
-        return (s + bcolors.FAIL + ' FAILURE: not same trace as ' + str(tst['expected trace count']) + bcolors.ENDC, False)
+        return (s + bcolors.FAIL + ' FAILURE: expected ' + str(tst['expected trace count'])
+                + ' not ' + str(res['tracecount']) + ' traces' + bcolors.ENDC, False)
 
     return (s + bcolors.OKGREEN + ' OK ' + bcolors.ENDC + ' : ' + str(res['tracecount']), True)
 

--- a/tests/smoke/C-tests/plptest_br_cond_not.c
+++ b/tests/smoke/C-tests/plptest_br_cond_not.c
@@ -1,0 +1,24 @@
+// nidhuggc: -sc -optimal --no-spin-assume --unroll=3
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+atomic_int x;
+
+void *p(void *arg) {
+  for (unsigned i = 0; i < 3; ++i)
+    x = 0;
+
+  x = 1;
+
+  return arg;
+}
+
+int main() {
+  pthread_t pt;
+  pthread_create(&pt, NULL, p, NULL);
+
+  while(!x);
+
+  return 0;
+}

--- a/tests/smoke/C-tests/plptest_burns_nobound.c
+++ b/tests/smoke/C-tests/plptest_burns_nobound.c
@@ -1,0 +1,109 @@
+// nidhuggc: -sc -optimal -unroll=3
+/* Copyright (C) 2018
+ * This benchmark is part of SWSC
+ */
+
+/* Adapted from: 
+ * Burn's critical section algorithm, implemented with fences.
+ *
+ * URL:
+ *   http://www.cs.yale.edu/homes/aspnes/pinewiki/attachments/MutualExclusion/burns-lynch-1993.pdf
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdatomic.h>
+#include <pthread.h>
+
+#define N 2
+
+// shared variables
+atomic_int flags[N];
+atomic_int x;
+
+void *t(void *arg)
+{
+    int tid = *((int *)arg);
+    int ok = 0;
+    int restart = 0;
+  
+    while(1) {
+	// down
+	atomic_store_explicit(&flags[tid], 0, memory_order_seq_cst);
+	for (int i=0; i<tid; i++) {
+	    ok = 0;
+	    while(1) {
+		if (atomic_load_explicit(&flags[i], memory_order_seq_cst)==0) {
+		    ok = 1;
+		    break;
+		}
+	    }
+	    if (ok==0) return NULL;
+	}
+	// up
+	atomic_store_explicit(&flags[tid], 1, memory_order_seq_cst);
+
+	for (int i=0; i<tid; i++) {
+	    ok = 0;
+	    while(1) {
+		if (atomic_load_explicit(&flags[i], memory_order_seq_cst)==0) {
+		    ok = 1;
+		    break;
+		}
+	    }
+	    if (ok==0) {
+		restart = 1;
+		break;
+	    };
+	}
+	if (restart==0) {
+	    ok = 1;
+	    break;
+	} else ok = 0;
+    }
+
+    if (ok==0) return NULL;
+
+
+    for (int i=tid+1; i<N; i++) {
+      	ok = 0;
+	while(1) {
+	    if (atomic_load_explicit(&flags[i], memory_order_seq_cst)==0) {
+		ok = 1;
+		break;
+	    }
+      	}
+      	if (ok==0) return NULL;
+    }
+  
+    // critical section
+    atomic_store_explicit(&x, tid, memory_order_seq_cst);
+    assert(atomic_load_explicit(&x, memory_order_seq_cst) == tid);
+  
+    atomic_store_explicit(&flags[tid], 0, memory_order_seq_cst);
+
+    return NULL;
+}
+
+int arg[N];
+int main(int argc, char **argv)
+{
+    pthread_t ts[N];
+
+    for (int i=0; i<N; i++) {
+	atomic_init(&flags[i], 0);	
+    }
+
+    atomic_init(&x, 0);
+	  
+    for (int i=0; i<N; i++) {
+	arg[i] = i;
+	pthread_create(&ts[i], NULL, t, &arg[i]);
+    }
+  
+    for (int i=0; i<N; i++) {
+	pthread_join(ts[i], NULL);
+    }
+  
+    return 0;
+}

--- a/tests/smoke/C-tests/plptest_cmpxchg_member_reuse.c
+++ b/tests/smoke/C-tests/plptest_cmpxchg_member_reuse.c
@@ -1,0 +1,28 @@
+// nidhuggc: -sc -optimal
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+struct s {
+  atomic_int x;
+} s;
+
+void *p(void *arg) {
+  s.x = 1;
+  return arg;
+}
+
+static void increment(struct s *sp) {
+  int expected = sp->x;
+  while (!atomic_compare_exchange_strong(&sp->x, &expected, expected+1));
+};
+
+int main(int argc, char *argv[]) {
+  pthread_t pt[2];
+  for (unsigned i = 0; i < 2; ++i) pthread_create(pt+i, NULL, p, NULL);
+
+  increment(&s);
+
+  for (unsigned i = 0; i < 2; ++i) pthread_join(pt[i], NULL);
+  return s.x;
+}

--- a/tests/smoke/C-tests/plptest_cmpxchg_reuse.c
+++ b/tests/smoke/C-tests/plptest_cmpxchg_reuse.c
@@ -1,0 +1,22 @@
+// nidhuggc: -sc -optimal
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+atomic_int x;
+
+void *p(void *arg) {
+  x = 1;
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t pt[2];
+  for (unsigned i = 0; i < 2; ++i) pthread_create(pt+i, NULL, p, NULL);
+
+  int expected = x;
+  while (!atomic_compare_exchange_strong(&x, &expected, expected+1));
+
+  for (unsigned i = 0; i < 2; ++i) pthread_join(pt[i], NULL);
+  return x;
+}

--- a/tests/smoke/C-tests/plptest_cmpxchg_reuse_reorder.c
+++ b/tests/smoke/C-tests/plptest_cmpxchg_reuse_reorder.c
@@ -1,0 +1,25 @@
+// nidhuggc: -sc -optimal
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+atomic_int x;
+atomic_int y = 1;
+
+void *p(void *arg) {
+  x = 1;
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t pt[2];
+  for (unsigned i = 0; i < 2; ++i) pthread_create(pt+i, NULL, p, NULL);
+
+  /* It is unsafe to reorder the loads (at least since they are SC loads) */
+  int expected = x;
+  int other = y;
+  while (!atomic_compare_exchange_strong(&x, &expected, expected+other));
+
+  for (unsigned i = 0; i < 2; ++i) pthread_join(pt[i], NULL);
+  return x;
+}

--- a/tests/smoke/C-tests/plptest_cmpxchg_weak_reuse.c
+++ b/tests/smoke/C-tests/plptest_cmpxchg_weak_reuse.c
@@ -1,0 +1,22 @@
+// nidhuggc: -sc -optimal
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+atomic_int x;
+
+void *p(void *arg) {
+  x = 1;
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t pt[2];
+  for (unsigned i = 0; i < 2; ++i) pthread_create(pt+i, NULL, p, NULL);
+
+  int expected = x;
+  while (!atomic_compare_exchange_weak(&x, &expected, expected+1));
+
+  for (unsigned i = 0; i < 2; ++i) pthread_join(pt[i], NULL);
+  return x;
+}

--- a/tests/smoke/C-tests/plptest_fully_pure.c
+++ b/tests/smoke/C-tests/plptest_fully_pure.c
@@ -1,0 +1,24 @@
+// nidhuggc: -sc -rf --no-spin-assume --unroll=3
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+atomic_int x;
+
+void *p(void *arg) {
+  x = (int)x; // just x = x, but silence warning
+
+  return arg;
+}
+
+int main() {
+  pthread_t pt;
+  pthread_create(&pt, NULL, p, NULL);
+
+  while(true) {
+    if (x < 3) continue;
+
+    x++;
+  }
+  return 0;
+}

--- a/tests/smoke/C-tests/plptest_leaky_counter.c
+++ b/tests/smoke/C-tests/plptest_leaky_counter.c
@@ -1,0 +1,27 @@
+// nidhuggc: -sc -rf --no-spin-assume --unroll=3
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+atomic_int x;
+
+void *p(void *arg) {
+  x = (int)x; // just x = x, but silence warning
+
+  return arg;
+}
+
+int main() {
+  pthread_t pt;
+  pthread_create(&pt, NULL, p, NULL);
+
+  int v, c = 0;
+  while(true) {
+    v = x;
+    if (v < 3) continue;
+
+    x++;
+    if (c++ > 3) break;
+  }
+  return v;
+}

--- a/tests/smoke/C-tests/plptest_risk_of_segfault.c
+++ b/tests/smoke/C-tests/plptest_risk_of_segfault.c
@@ -1,0 +1,25 @@
+// nidhuggc: -sc -rf --no-spin-assume --unroll=3
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+atomic_int x;
+atomic_int *xp = &x;
+
+void *p(void *arg) {
+  x = (int)x; // just x = x, but silence warning
+
+  return arg;
+}
+
+int main() {
+  pthread_t pt;
+  pthread_create(&pt, NULL, p, NULL);
+
+  while(true) {
+    if (*xp < 3) continue;
+
+    x++;
+  }
+  return 0;
+}

--- a/tests/smoke/C-tests/plptest_safestack_21.c
+++ b/tests/smoke/C-tests/plptest_safestack_21.c
@@ -1,0 +1,109 @@
+// nidhuggc: -sc -optimal -unroll=4
+/* Test based on the SafeStack benchmark from SCTBench. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+#ifndef N
+#  define N 2,1
+#endif
+
+const unsigned iters[] = {N};
+
+#define NUM_THREADS (sizeof(iters)/sizeof(*iters))
+
+#ifndef STACK_SIZE
+#  define STACK_SIZE 2 // NUM_THREADS
+#endif
+
+void __VERIFIER_assume(int truth);
+
+typedef struct SafeStackItem {
+    atomic_int Value;
+    atomic_int Next;
+} SafeStackItem;
+
+typedef struct SafeStack {
+    SafeStackItem array[STACK_SIZE];
+    atomic_int head;
+    atomic_int count;
+} SafeStack;
+
+pthread_t threads[NUM_THREADS];
+SafeStack stack;
+
+void Init(int pushCount) {
+    int i;
+    atomic_init(&stack.count, pushCount);
+    atomic_init(&stack.head, 0);
+    for (i = 0; i < pushCount - 1; i++) {
+	atomic_init(&stack.array[i].Next, i + 1);
+    }
+    atomic_init(&stack.array[pushCount - 1].Next, -1);
+}
+
+int Pop(void) {
+    while (atomic_load(&stack.count) > 1) {
+
+	int head1 = atomic_load(&stack.head);
+	int next1 = atomic_exchange(&stack.array[head1].Next, -1);
+
+	if (next1 >= 0) {
+	    int head2 = head1;
+	    if (atomic_compare_exchange_strong(&stack.head, &head2, next1)) {
+		atomic_fetch_sub(&stack.count, 1);
+		return head1;
+	    } else {
+		atomic_exchange(&stack.array[head1].Next, next1);
+	    }
+	}
+    }
+    return -1;
+}
+
+void Push(int index) {
+    int head1 = atomic_load(&stack.head);
+    do {
+	atomic_store(&stack.array[index].Next, head1);
+    } while (!(atomic_compare_exchange_strong(&stack.head, &head1, index)));
+    atomic_fetch_add(&stack.count, 1);
+}
+
+
+void* thread(void* arg) {
+    int idx = (int)(uintptr_t)arg;
+    uintptr_t i = iters[idx];
+    for (;;) {
+	if (i-- == 0) return NULL;
+	int elem;
+	do { elem = Pop(); } while (elem == -1);
+
+	// Check for double-pop. Requires N=3,3,1 (or greater) to
+	// reproduce original bug
+	stack.array[elem].Value = idx;
+	assert(stack.array[elem].Value == idx);
+
+	if (i-- == 0) return NULL;
+	Push(elem);
+    }
+    return NULL;
+}
+
+int main(void) {
+    uintptr_t i;
+    Init(STACK_SIZE);
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_create(&threads[i], NULL, thread, (void*) i);
+    }
+
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_join(threads[i], NULL);
+    }
+
+    return 0;
+}

--- a/tests/smoke/C-tests/plptest_safestack_21_easy.c
+++ b/tests/smoke/C-tests/plptest_safestack_21_easy.c
@@ -1,0 +1,110 @@
+// nidhuggc: -sc -optimal -unroll=4
+/* Test based on the SafeStack benchmark from SCTBench. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+#ifndef N
+#  define N 2,1
+#endif
+
+const unsigned iters[] = {N};
+
+#define NUM_THREADS (sizeof(iters)/sizeof(*iters))
+
+#ifndef STACK_SIZE
+#  define STACK_SIZE 2 // NUM_THREADS
+#endif
+
+void __VERIFIER_assume(int truth);
+
+typedef struct SafeStackItem {
+    atomic_int Value;
+    atomic_int Next;
+} SafeStackItem;
+
+typedef struct SafeStack {
+    SafeStackItem array[STACK_SIZE];
+    atomic_int head;
+    atomic_int count;
+} SafeStack;
+
+pthread_t threads[NUM_THREADS];
+SafeStack stack;
+
+void Init(int pushCount) {
+    int i;
+    atomic_init(&stack.count, pushCount);
+    atomic_init(&stack.head, 0);
+    for (i = 0; i < pushCount - 1; i++) {
+	atomic_init(&stack.array[i].Next, i + 1);
+    }
+    atomic_init(&stack.array[pushCount - 1].Next, -1);
+}
+
+int Pop(void) {
+    while(true) {
+	while (atomic_load(&stack.count) > 1) {
+
+	    int head1 = atomic_load(&stack.head);
+	    int next1 = atomic_exchange(&stack.array[head1].Next, -1);
+
+	    __VERIFIER_assume(next1 != -1);
+	    if (next1 >= 0) {
+		int head2 = head1;
+		if (atomic_compare_exchange_strong(&stack.head, &head2, next1)) {
+		    atomic_fetch_sub(&stack.count, 1);
+		    return head1;
+		} else {
+		    atomic_exchange(&stack.array[head1].Next, next1);
+		}
+	    }
+	}
+    }
+}
+
+void Push(int index) {
+    int head1 = atomic_load(&stack.head);
+    do {
+	atomic_store(&stack.array[index].Next, head1);
+    } while (!(atomic_compare_exchange_strong(&stack.head, &head1, index)));
+    atomic_fetch_add(&stack.count, 1);
+}
+
+
+void* thread(void* arg) {
+    int idx = (int)(uintptr_t)arg;
+    uintptr_t i = iters[idx];
+    for (;;) {
+	if (i-- == 0) return NULL;
+	int elem = Pop();
+
+	// Check for double-pop. Requires N=3,3,1 (or greater) to
+	// reproduce original bug
+	stack.array[elem].Value = idx;
+	assert(stack.array[elem].Value == idx);
+
+	if (i-- == 0) return NULL;
+	Push(elem);
+    }
+    return NULL;
+}
+
+int main(void) {
+    uintptr_t i;
+    Init(STACK_SIZE);
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_create(&threads[i], NULL, thread, (void*) i);
+    }
+
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_join(threads[i], NULL);
+    }
+
+    return 0;
+}

--- a/tests/smoke/C-tests/plptest_safestack_21_inlined.c
+++ b/tests/smoke/C-tests/plptest_safestack_21_inlined.c
@@ -1,0 +1,115 @@
+// nidhuggc: -sc -optimal -unroll=4
+/* Test based on the SafeStack benchmark from SCTBench. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+#ifndef N
+#  define N 2,1
+#endif
+
+const unsigned iters[] = {N};
+
+#define NUM_THREADS (sizeof(iters)/sizeof(*iters))
+
+#ifndef STACK_SIZE
+#  define STACK_SIZE 2 // NUM_THREADS
+#endif
+
+void __VERIFIER_assume(int truth);
+
+typedef struct SafeStackItem {
+    atomic_int Value;
+    atomic_int Next;
+} SafeStackItem;
+
+typedef struct SafeStack {
+    SafeStackItem array[STACK_SIZE];
+    atomic_int head;
+    atomic_int count;
+} SafeStack;
+
+pthread_t threads[NUM_THREADS];
+SafeStack stack;
+
+void Init(int pushCount) {
+    int i;
+    atomic_init(&stack.count, pushCount);
+    atomic_init(&stack.head, 0);
+    for (i = 0; i < pushCount - 1; i++) {
+	atomic_init(&stack.array[i].Next, i + 1);
+    }
+    atomic_init(&stack.array[pushCount - 1].Next, -1);
+}
+
+int Pop(void) {
+
+}
+
+void Push(int index) {
+    int head1 = atomic_load(&stack.head);
+    do {
+	atomic_store(&stack.array[index].Next, head1);
+    } while (!(atomic_compare_exchange_strong(&stack.head, &head1, index)));
+    atomic_fetch_add(&stack.count, 1);
+}
+
+
+void* thread(void* arg) {
+    int idx = (int)(uintptr_t)arg;
+    uintptr_t i = iters[idx];
+    for (;;) {
+	if (i-- == 0) return NULL;
+	int elem;
+	do {
+	    while (true) {
+		if (!(atomic_load(&stack.count) > 1)) {
+		    elem = -1;
+		    break;
+		}
+		int head1 = atomic_load(&stack.head);
+		int next1 = atomic_exchange(&stack.array[head1].Next, -1);
+
+		__VERIFIER_assume(next1 != -1);
+		if (next1 >= 0) {
+		    int head2 = head1;
+		    if (atomic_compare_exchange_strong(&stack.head, &head2, next1)) {
+			atomic_fetch_sub(&stack.count, 1);
+			elem = head1;
+			break;
+		    } else {
+			atomic_exchange(&stack.array[head1].Next, next1);
+		    }
+		}
+	    }
+	} while (elem == -1);
+
+	// Check for double-pop. Requires N=3,3,1 (or greater) to
+	// reproduce original bug
+	stack.array[elem].Value = idx;
+	assert(stack.array[elem].Value == idx);
+
+	if (i-- == 0) return NULL;
+	Push(elem);
+    }
+    return NULL;
+}
+
+int main(void) {
+    uintptr_t i;
+    Init(STACK_SIZE);
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_create(&threads[i], NULL, thread, (void*) i);
+    }
+
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_join(threads[i], NULL);
+    }
+
+    return 0;
+}

--- a/tests/smoke/C-tests/plptest_safestack_21_inlined_xchg.c
+++ b/tests/smoke/C-tests/plptest_safestack_21_inlined_xchg.c
@@ -1,0 +1,110 @@
+// nidhuggc: -sc -optimal -unroll=3
+/* Test based on the SafeStack benchmark from SCTBench. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+#ifndef N
+#  define N 2,1
+#endif
+
+const unsigned iters[] = {N};
+
+#define NUM_THREADS (sizeof(iters)/sizeof(*iters))
+
+#ifndef STACK_SIZE
+#  define STACK_SIZE 2 // NUM_THREADS
+#endif
+
+void __VERIFIER_assume(int truth);
+
+typedef struct SafeStackItem {
+    atomic_int Value;
+    atomic_int Next;
+} SafeStackItem;
+
+typedef struct SafeStack {
+    SafeStackItem array[STACK_SIZE];
+    atomic_int head;
+    atomic_int count;
+} SafeStack;
+
+pthread_t threads[NUM_THREADS];
+SafeStack stack;
+
+void Init(int pushCount) {
+    int i;
+    atomic_init(&stack.count, pushCount);
+    atomic_init(&stack.head, 0);
+    for (i = 0; i < pushCount - 1; i++) {
+	atomic_init(&stack.array[i].Next, i + 1);
+    }
+    atomic_init(&stack.array[pushCount - 1].Next, -1);
+}
+
+void Push(int index) {
+    int head1 = atomic_load(&stack.head);
+    do {
+	atomic_store(&stack.array[index].Next, head1);
+    } while (!(atomic_compare_exchange_strong(&stack.head, &head1, index)));
+    atomic_fetch_add(&stack.count, 1);
+}
+
+
+void* thread(void* arg) {
+    int idx = (int)(uintptr_t)arg;
+    uintptr_t i = iters[idx];
+    for (;;) {
+	if (i-- == 0) return NULL;
+	int elem;
+	do {
+	    while (true) {
+		if (!(atomic_load(&stack.count) > 1)) {
+		    elem = -1;
+		    break;
+		}
+		int head1 = atomic_load(&stack.head);
+		int next1 = atomic_exchange(&stack.array[head1].Next, -1);
+
+		if (next1 >= 0) {
+		    int head2 = head1;
+		    if (atomic_compare_exchange_strong(&stack.head, &head2, next1)) {
+			atomic_fetch_sub(&stack.count, 1);
+			elem = head1;
+			break;
+		    } else {
+			atomic_exchange(&stack.array[head1].Next, next1);
+		    }
+		}
+	    }
+	} while (elem == -1);
+
+	// Check for double-pop. Requires N=3,3,1 (or greater) to
+	// reproduce original bug
+	stack.array[elem].Value = idx;
+	assert(stack.array[elem].Value == idx);
+
+	if (i-- == 0) return NULL;
+	Push(elem);
+    }
+    return NULL;
+}
+
+int main(void) {
+    uintptr_t i;
+    Init(STACK_SIZE);
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_create(&threads[i], NULL, thread, (void*) i);
+    }
+
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_join(threads[i], NULL);
+    }
+
+    return 0;
+}

--- a/tests/smoke/C-tests/plptest_seqlock.c
+++ b/tests/smoke/C-tests/plptest_seqlock.c
@@ -1,0 +1,63 @@
+// nidhuggc: -sc -optimal
+
+#include <stdbool.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+typedef struct {
+    pthread_mutex_t m;
+    atomic_uint sequence;
+} seqlock_t;
+
+unsigned read_seqbegin(seqlock_t *l) {
+    unsigned ret;
+    do {
+	ret = l->sequence;
+    } while(ret & 1);
+    return ret;
+}
+
+bool read_seqretry(seqlock_t *l, unsigned start) {
+    return l->sequence != start;
+}
+
+void write_seqlock(seqlock_t *l) {
+    pthread_mutex_lock(&l->m);
+    l->sequence++;
+}
+
+void write_sequnlock(seqlock_t *l) {
+    l->sequence++;
+    pthread_mutex_unlock(&l->m);
+}
+
+seqlock_t lock;
+atomic_int shared;
+
+void *p(void *arg)
+{
+	unsigned int seq;
+	int data;
+
+	do {
+		seq = read_seqbegin(&lock);
+		/* Make a copy of the data of interest */
+		data = atomic_load(&shared);
+	} while (read_seqretry(&lock, seq));
+	return arg;
+}
+
+void *q(void *unused)
+{
+	write_seqlock(&lock);
+	shared = 1;
+	write_sequnlock(&lock);
+	return NULL;
+}
+
+int main() {
+  pthread_t pt, qt;
+  pthread_mutex_init(&lock.m, NULL);
+  pthread_create(&pt, NULL, p, NULL);
+  pthread_create(&qt, NULL, q, NULL);
+}

--- a/tests/smoke/C-tests/plptest_seqlock_harder.c
+++ b/tests/smoke/C-tests/plptest_seqlock_harder.c
@@ -1,0 +1,81 @@
+// nidhuggc: -sc -optimal -unroll=4
+
+#include <stdbool.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+typedef struct {
+    pthread_mutex_t m;
+    atomic_uint sequence;
+} seqlock_t;
+
+unsigned read_seqbegin3(seqlock_t *l) {
+    unsigned ret;
+    do {
+	ret = l->sequence;
+    } while(ret & 1);
+    return ret;
+}
+unsigned read_seqbegin2(seqlock_t *l) {
+  unsigned ret = read_seqbegin3(l);
+  atomic_thread_fence(memory_order_release);
+  return ret;
+}
+
+unsigned read_seqbegin1(seqlock_t *l) {
+  return read_seqbegin2(l);
+}
+
+unsigned read_seqbegin(seqlock_t *l) {
+  return read_seqbegin1(l);
+}
+
+
+int read_seqretry2(atomic_uint *l, unsigned start) {
+    return *l != start;
+}
+
+unsigned read_seqretry(seqlock_t *l, unsigned start) {
+  return read_seqretry2(&l->sequence, start);
+}
+
+void write_seqlock(seqlock_t *l) {
+    pthread_mutex_lock(&l->m);
+    l->sequence++;
+}
+
+void write_sequnlock(seqlock_t *l) {
+    l->sequence++;
+    pthread_mutex_unlock(&l->m);
+}
+
+seqlock_t lock;
+atomic_int shared;
+
+void *p(void *arg)
+{
+	unsigned int seq;
+	int data;
+
+	do {
+		seq = read_seqbegin(&lock);
+		/* Make a copy of the data of interest */
+		data = atomic_load(&shared);
+	} while (read_seqretry(&lock, seq));
+	return arg;
+}
+
+void *q(void *unused)
+{
+	write_seqlock(&lock);
+	shared = 1;
+	write_sequnlock(&lock);
+	return NULL;
+}
+
+int main() {
+  pthread_t pt, qt;
+  pthread_mutex_init(&lock.m, NULL);
+  pthread_create(&pt, NULL, p, NULL);
+  pthread_create(&qt, NULL, q, NULL);
+}

--- a/tests/smoke/C-tests/plptest_spinloop.c
+++ b/tests/smoke/C-tests/plptest_spinloop.c
@@ -1,0 +1,24 @@
+// nidhuggc: -sc -rf --no-spin-assume --unroll=3
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+atomic_int x;
+
+void *p(void *arg) {
+  x = (int)x; // just x = x, but silence warning
+
+  return arg;
+}
+
+int main() {
+  pthread_t pt;
+  pthread_create(&pt, NULL, p, NULL);
+
+  int v = 0;
+  while(true) {
+    v = x;
+    if (v > 3) break;
+  }
+  return v;
+}

--- a/tests/smoke/C-tests/plptest_treiber_pop_easier.c
+++ b/tests/smoke/C-tests/plptest_treiber_pop_easier.c
@@ -1,0 +1,4 @@
+// nidhuggc: -sc -optimal -unroll=4
+
+// #undef USE_ATOMIC_POINTER_TYPE
+#include "treiber_pop.inc"

--- a/tests/smoke/C-tests/treiber_pop.inc
+++ b/tests/smoke/C-tests/treiber_pop.inc
@@ -1,0 +1,74 @@
+// -*- mode: c -*-
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <stdatomic.h>
+
+#ifndef N
+# define N 3
+#endif
+
+struct node {
+  struct node *next;
+  int value;
+};
+
+#ifdef USE_ATOMIC_POINTER_TYPE
+typedef struct node *topval;
+#  define TO_TOPVAL(ptr) (ptr)
+#  define FROM_TOPVAL(val) (val)
+#else
+ /* Using atomic pointers generates allocas that mem2reg does not
+  * remove. */
+typedef uintptr_t topval;
+#  define TO_TOPVAL(PTR) ((topval)PTR)
+#  define FROM_TOPVAL(VAL) ((struct node *)VAL)
+#endif
+
+struct stack {
+  _Atomic(topval) top;
+};
+
+void free_at_next_quiescent_state(void *ptr) { /* We assume this is correct */ }
+
+int pop(struct stack *stack) {
+  topval oldHead, newHead;
+  do {
+    oldHead = stack->top; /* sic! We intentionally re-read oldHead here */
+    if (!oldHead) return -1;
+    newHead = TO_TOPVAL(FROM_TOPVAL(oldHead)->next);
+  } while (!atomic_compare_exchange_strong(&stack->top, &oldHead, newHead));
+  int ret = FROM_TOPVAL(oldHead)->value;
+  free_at_next_quiescent_state(FROM_TOPVAL(oldHead));
+  return ret;
+}
+
+void unsafe_push(struct stack *stack, int item) {
+  struct node *newNode = malloc(sizeof(*newNode));
+  newNode->value = item;
+  newNode->next = FROM_TOPVAL(stack->top);
+  stack->top = TO_TOPVAL(newNode);
+}
+
+void init(struct stack *stack) {
+  atomic_init(&stack->top, TO_TOPVAL(NULL));
+}
+
+struct stack *stack;
+
+void *thread(void *arg) {
+  int val = pop(stack);
+  assert(val >= 0 && val < N);
+  return arg;
+}
+
+int main() {
+  stack = malloc(sizeof(*stack));
+  init(stack);
+  for (int i = 0; i < N; ++i) unsafe_push(stack, i);
+
+  pthread_t ts[N];
+  for (int i = 0; i < N; ++i) pthread_create(ts+i, NULL, thread, NULL);
+  return 0;
+}

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -63,5 +63,22 @@ unroll_double_loop Forbid : 1
 # Optimal/Observers with commuting rmws
 safestack_c21_21_opt_rmwcomm Forbid : 21
 
+# Tests for the partial-loop-purity transformation pass. These should be
+# transformed
+plptest_fully_pure Forbid : 2
+plptest_risk_of_segfault Forbid : 2
+plptest_spinloop Forbid : 2
+plptest_br_cond_not Forbid : 4
+plptest_safestack_21_easy Forbid : 11
+plptest_safestack_21_inlined Forbid : 11
+plptest_safestack_21_inlined_xchg Forbid : 11
+plptest_safestack_21 Forbid : 11
+plptest_burns_nobound Forbid : 16
+plptest_seqlock Forbid : 7
+plptest_seqlock_harder Forbid : 7
+# These should not be transformed
+plptest_cmpxchg_reuse_reorder Forbid : 14
+plptest_leaky_counter Forbid : 4
+
 # Total number of traces: 1116
 # Total running time: 9.51 s

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -76,6 +76,10 @@ plptest_safestack_21 Forbid : 11
 plptest_burns_nobound Forbid : 16
 plptest_seqlock Forbid : 7
 plptest_seqlock_harder Forbid : 7
+plptest_treiber_pop_easier Forbid : 27
+plptest_cmpxchg_reuse Forbid : 12
+plptest_cmpxchg_member_reuse Forbid : 12
+plptest_cmpxchg_weak_reuse Forbid : 12
 # These should not be transformed
 plptest_cmpxchg_reuse_reorder Forbid : 14
 plptest_leaky_counter Forbid : 4


### PR DESCRIPTION
The Partial Loop Purity Elimination pass generalises and subsumes the SpinAssume pass.

Partial Loop Purity Elimination discovers paths through loops that are
"pure"; that do not have observable side effects and returns to the same
local state as before the loop iteration. Such pure loop paths are then
eliminated by inserting assume-statements.

It works by for each loop computing a set of binary predicates over LLVM
values such that if any of them hold at any point in the loop, then the
current loop iteration is pure. This set is computed through a backwards
dataflow analysis.

Loops that contain function calls are analysed by selectively inlining
calls in loops that might be pure prior to the analysis.