### PR TITLE
Optimal-DPOR-Await

### DIFF
--- a/src/AssumeAwaitPass.cpp
+++ b/src/AssumeAwaitPass.cpp
@@ -1,0 +1,437 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#include <llvm/Pass.h>
+#include <llvm/Analysis/LoopPass.h>
+#if defined(HAVE_LLVM_IR_DOMINATORS_H)
+#include <llvm/IR/Dominators.h>
+#elif defined(HAVE_LLVM_ANALYSIS_DOMINATORS_H)
+#include <llvm/Analysis/Dominators.h>
+#endif
+#if defined(HAVE_LLVM_IR_FUNCTION_H)
+#include <llvm/IR/Function.h>
+#elif defined(HAVE_LLVM_FUNCTION_H)
+#include <llvm/Function.h>
+#endif
+#if defined(HAVE_LLVM_IR_INSTRUCTIONS_H)
+#include <llvm/IR/Instructions.h>
+#elif defined(HAVE_LLVM_INSTRUCTIONS_H)
+#include <llvm/Instructions.h>
+#endif
+#if defined(HAVE_LLVM_IR_LLVMCONTEXT_H)
+#include <llvm/IR/LLVMContext.h>
+#elif defined(HAVE_LLVM_LLVMCONTEXT_H)
+#include <llvm/LLVMContext.h>
+#endif
+#if defined(HAVE_LLVM_IR_MODULE_H)
+#include <llvm/IR/Module.h>
+#elif defined(HAVE_LLVM_MODULE_H)
+#include <llvm/Module.h>
+#endif
+#include <llvm/Transforms/Utils/BasicBlockUtils.h>
+#include <llvm/IR/InstIterator.h>
+#include <llvm/IR/Operator.h>
+#include <llvm/Config/llvm-config.h>
+#include <llvm/Support/Debug.h>
+#include <llvm/Support/CommandLine.h>
+
+// #include "CheckModule.h"
+#include "AssumeAwaitPass.h"
+#include "SpinAssumePass.h"
+#include "AwaitCond.h"
+#include "Debug.h"
+
+#ifdef LLVM_HAS_ATTRIBUTELIST
+typedef llvm::AttributeList AttributeList;
+#else
+typedef llvm::AttributeSet AttributeList;
+#endif
+
+#ifdef LLVM_HAS_TERMINATORINST
+typedef llvm::TerminatorInst TerminatorInst;
+#else
+typedef llvm::Instruction TerminatorInst;
+#endif
+
+void AssumeAwaitPass::getAnalysisUsage(llvm::AnalysisUsage &AU) const{
+  AU.setPreservesCFG();
+  AU.addRequired<llvm::LLVM_DOMINATOR_TREE_PASS>();
+}
+
+unsigned AssumeAwaitPass::sizes[AssumeAwaitPass::no_sizes] = {8,16,32,64};
+
+namespace {
+  llvm::cl::opt<bool> cl_no_assume_xchgawait("no-assume-xchgawait");
+
+  llvm::Value* getOrInsertFunction(llvm::Module &M, llvm::StringRef Name,
+                                   llvm::FunctionType *T, AttributeList AttributeList) {
+    return M.getOrInsertFunction(std::move(Name),T,std::move(AttributeList))
+#if LLVM_VERSION_MAJOR >= 9
+      /* XXX: I will not work with some development versions of 9, I
+       * should be replaced/complemented with a configure check.
+       */
+      .getCallee()
+#endif
+      ;
+  }
+
+  bool is_assume(llvm::CallInst *C) {
+    llvm::Function *F = C->getCalledFunction();
+    return F && F->getName().str() == "__VERIFIER_assume";
+  }
+
+  bool is_true(llvm::Value *v) {
+    auto *I = llvm::dyn_cast<llvm::Constant>(v);
+    return I && I->isAllOnesValue();
+  }
+
+  bool is_false(llvm::Value *v) {
+    auto *I = llvm::dyn_cast<llvm::Constant>(v);
+    return I && I->isZeroValue();
+  }
+
+  llvm::Value *simplify_condition(llvm::Value *v, bool *negate) {
+    if (auto *ret = llvm::dyn_cast<llvm::ICmpInst>(v)) {
+      /* ret could be the condition we're looking for, but it could also
+       * be a comparison of a truth value with a constant. Check for
+       * this case before settling for ret */
+      if (ret->getPredicate() == llvm::CmpInst::ICMP_EQ
+          || ret->getPredicate() == llvm::CmpInst::ICMP_NE) {
+        for (unsigned otheri = 0; otheri < 2; ++otheri) {
+          llvm::Value *other = ret->getOperand(otheri);
+          llvm::Value *constant = ret->getOperand(1-otheri);
+          if (is_false(constant)) *negate ^= true;
+          else if (!is_true(constant)) continue;
+          if (ret->getPredicate() == llvm::CmpInst::ICMP_NE)
+            *negate ^= true;
+          return simplify_condition(other, negate);
+        }
+      }
+      return ret;
+    }
+    if (auto *op = llvm::dyn_cast<llvm::ZExtOperator>(v))
+      return simplify_condition(op->getOperand(0), negate);
+    if (auto *op = llvm::dyn_cast<llvm::Instruction>(v)) {
+      if (op->getOpcode() == llvm::Instruction::ZExt
+          || op->getOpcode() == llvm::Instruction::SExt) {
+        return simplify_condition(op->getOperand(0), negate);
+      } else if(op->getOpcode() == llvm::Instruction::Xor) {
+        if (is_true(op->getOperand(0)) || is_true(op->getOperand(1))) {
+          *negate ^= true;
+          unsigned opi = is_true(op->getOperand(0)) ? 1 : 0;
+          return simplify_condition(op->getOperand(opi), negate);
+        }
+      }
+    }
+    return v;
+  }
+
+  llvm::ICmpInst *get_condition(llvm::Value *v, bool *negate) {
+    if (auto *ret = llvm::dyn_cast<llvm::ICmpInst>(v)) {
+      /* ret could be the condition we're looking for, but it could also
+       * be a comparison of a truth value with a constant. Check for
+       * this case before settling for ret */
+      if (ret->getPredicate() == llvm::CmpInst::ICMP_EQ) {
+        for (unsigned otheri = 0; otheri < 2; ++otheri) {
+          bool negate2 = false; // Don't affect *negate until we're sure
+          llvm::Value *other = ret->getOperand(otheri);
+          llvm::Value *constant = ret->getOperand(1-otheri);
+          if (is_false(constant)) negate2 ^= true;
+          else if (!is_true(constant)) continue;
+          if (auto *ret2 = get_condition(other, &negate2)) {
+            *negate ^= negate2;
+            return ret2;
+          }
+        }
+      }
+      return ret;
+    }
+    if (auto *op = llvm::dyn_cast<llvm::ZExtOperator>(v))
+      return get_condition(op->getOperand(0), negate);
+    if (auto *op = llvm::dyn_cast<llvm::Instruction>(v)) {
+      if (op->getOpcode() == llvm::Instruction::ZExt
+          || op->getOpcode() == llvm::Instruction::SExt) {
+        return get_condition(op->getOperand(0), negate);
+      } else if(op->getOpcode() == llvm::Instruction::Xor) {
+        if (is_true(op->getOperand(0)) || is_true(op->getOperand(1))) {
+          *negate ^= true;
+          return get_condition(op->getOperand(is_true(op->getOperand(0)) ? 1 : 0), negate);
+        }
+      }
+    }
+    return nullptr;
+  }
+
+  AwaitCond::Op get_op(llvm::CmpInst::Predicate p) {
+    switch(p) {
+    case llvm::CmpInst::ICMP_EQ:  return AwaitCond::EQ;
+    case llvm::CmpInst::ICMP_NE:  return AwaitCond::NE;
+    case llvm::CmpInst::ICMP_UGT: return AwaitCond::UGT;
+    case llvm::CmpInst::ICMP_UGE: return AwaitCond::UGE;
+    case llvm::CmpInst::ICMP_ULT: return AwaitCond::ULT;
+    case llvm::CmpInst::ICMP_ULE: return AwaitCond::ULE;
+    case llvm::CmpInst::ICMP_SGT: return AwaitCond::SGT;
+    case llvm::CmpInst::ICMP_SGE: return AwaitCond::SGE;
+    case llvm::CmpInst::ICMP_SLT: return AwaitCond::SLT;
+    case llvm::CmpInst::ICMP_SLE: return AwaitCond::SLE;
+    default: return AwaitCond::None;
+    }
+  }
+
+  std::uint8_t get_mode(llvm::Instruction *Load) {
+    llvm::AtomicOrdering order;
+    if (llvm::LoadInst *L = llvm::dyn_cast<llvm::LoadInst>(Load)) {
+      order = L->getOrdering();
+    } else if (auto *RMW = llvm::dyn_cast<llvm::AtomicRMWInst>(Load)) {
+      order = RMW->getOrdering();
+    } else {
+      order = llvm::cast<llvm::AtomicCmpXchgInst>(Load)->getSuccessOrdering();
+    }
+    switch (order) {
+      /* TODO: lift these modes to an enum somewhere */
+    case llvm::AtomicOrdering::NotAtomic:
+    case llvm::AtomicOrdering::Unordered:
+    case llvm::AtomicOrdering::Monotonic:
+      return 0; /* Races are bugs */
+    case llvm::AtomicOrdering::Acquire:
+    case llvm::AtomicOrdering::AcquireRelease:
+      return 1; /* Release/Aquire */
+    case llvm::AtomicOrdering::SequentiallyConsistent:
+      return 2;
+    default:
+      llvm_unreachable("No other access modes allowed for Loads");
+    }
+  }
+
+  llvm::Instruction *is_permissible_load(llvm::Value *V, llvm::BasicBlock *BB) {
+    llvm::Instruction *I = llvm::dyn_cast<llvm::Instruction>(V);
+    if (!I || I->getParent() != BB) return nullptr;
+    if (auto *Load = llvm::dyn_cast<llvm::LoadInst>(I)) {
+      return Load;
+    }
+    if (auto *AtomicRmw = llvm::dyn_cast<llvm::AtomicRMWInst>(I)) {
+      if (AtomicRmw->getOperation() == llvm::AtomicRMWInst::Xchg
+          && !cl_no_assume_xchgawait) {
+        return AtomicRmw;
+      }
+    }
+    return nullptr;
+  }
+
+  bool is_permissible_arg(llvm::DominatorTree &DT, llvm::Value *V, llvm::Instruction *Load) {
+    if (llvm::isa<llvm::Constant>(V)) return true;
+    if (llvm::isa<llvm::Argument>(V)) return true;
+    if (llvm::Instruction *VI = llvm::dyn_cast<llvm::Instruction>(V))
+      return DT.dominates(VI, Load);
+    /* TODO: What about operators applied to permissible_arg(s)? */
+    return false;
+  }
+
+  bool is_safe_intermediary(llvm::Instruction *I) {
+    return !I->mayHaveSideEffects();
+  }
+
+  bool is_safe_to_rewrite(llvm::Instruction *Load, llvm::CallInst *Call) {
+    if (Load->getParent() != Call->getParent()) {
+#ifndef NDEBUG
+      Debug::warn("assume-await-no-traversal")
+        << "WARNING: assume-await: We don't yet implement BB traversal";
+#endif
+      return false;
+    }
+    llvm::BasicBlock::iterator li(Load), ci(Call);
+    while (--ci != li) {
+      if (!is_safe_intermediary(&*ci)) return false;
+    }
+    return true;
+  }
+}
+
+bool AssumeAwaitPass::doInitialization(llvm::Module &M){
+  bool modified_M = false;
+  // CheckModule::check_await(&M);
+
+  for (unsigned i = 0; i < no_sizes; ++i) {
+    std::string lname = "__VERIFIER_load_await_i" + std::to_string(sizes[i]);
+    std::string xname = "__VERIFIER_xchg_await_i" + std::to_string(sizes[i]);
+    F_load_await[i] = M.getFunction(lname);
+    F_xchg_await[i] = M.getFunction(xname);
+    if(!F_load_await[i] || !F_xchg_await[i]){
+      llvm::FunctionType *loadAwaitTy, *xchgAwaitTy;
+      {
+        llvm::Type *i8Ty = llvm::Type::getInt8Ty(M.getContext());
+        llvm::Type *ixTy = llvm::IntegerType::get(M.getContext(),sizes[i]);
+        llvm::Type *ixPTy = llvm::PointerType::getUnqual(ixTy);
+        loadAwaitTy = llvm::FunctionType::get(ixTy,{ixPTy, i8Ty, ixTy, i8Ty},false);
+        xchgAwaitTy = llvm::FunctionType::get(ixTy,{ixPTy, ixTy, i8Ty, ixTy, i8Ty},false);
+      }
+      AttributeList assumeAttrs =
+        AttributeList::get(M.getContext(),AttributeList::FunctionIndex,
+                           std::vector<llvm::Attribute::AttrKind>({llvm::Attribute::NoUnwind}));
+      F_load_await[i] = getOrInsertFunction(M,lname,loadAwaitTy,assumeAttrs);
+      F_xchg_await[i] = getOrInsertFunction(M,xname,xchgAwaitTy,assumeAttrs);
+      modified_M = true;
+    }
+  }
+  return modified_M;
+}
+
+bool AssumeAwaitPass::runOnFunction(llvm::Function &F) {
+  bool changed = false;
+
+  for (llvm::BasicBlock &BB : F) {
+    for (auto it = BB.begin(), end = BB.end(); it != end;) {
+      if (tryRewriteAssume(&F, &BB, &*it)) {
+        changed = true;
+        if (it->use_empty()) it = it->eraseFromParent();
+        else ++it;
+      } else {
+        ++it;
+      }
+    }
+  }
+
+  return changed;
+}
+
+static llvm::FunctionType *getFunctionType(llvm::Type *fptr) {
+  if (llvm::FunctionType *fty = llvm::dyn_cast<llvm::FunctionType>(fptr)) {
+    return fty;
+  } else if (llvm::PointerType *pty = llvm::dyn_cast<llvm::PointerType>(fptr)) {
+    return getFunctionType(pty->getElementType());
+  } else {
+    llvm::dbgs() << fptr << "\n";
+    ::abort();
+  }
+}
+
+bool AssumeAwaitPass::tryRewriteAssume(llvm::Function *F, llvm::BasicBlock *BB, llvm::Instruction *I) const {
+  llvm::CallInst *Call = llvm::dyn_cast<llvm::CallInst>(I);
+  if (!Call || !is_assume(Call)) return false;
+  if (tryRewriteAssumeCmpXchg(F, BB, Call)) return true;
+  bool negate = false;
+  llvm::ICmpInst *Cond = get_condition(Call->getArgOperand(0), &negate);
+  if (!Cond) return false;
+  for (unsigned load_index = 0; load_index < 2; ++load_index) {
+    llvm::Instruction *Load = is_permissible_load(Cond->getOperand(load_index),BB);
+    if (!Load) continue;
+    llvm::Value *ArgVal = Cond->getOperand(1-load_index);
+    llvm::CmpInst::Predicate pred = Cond->getPredicate();
+    if (load_index == 1) pred = llvm::CmpInst::getSwappedPredicate(pred);
+    if (negate) pred = llvm::CmpInst::getInversePredicate(pred);
+    llvm::DominatorTree &DT = getAnalysis<llvm::LLVM_DOMINATOR_TREE_PASS>().getDomTree();
+    if (!is_permissible_arg(DT, ArgVal, Load)) continue;
+    if (!is_safe_to_rewrite(Load, Call)) continue;
+    AwaitCond::Op op = get_op(pred);
+    if (op == AwaitCond::None) continue;
+    llvm::Value *AwaitFunction = getAwaitFunction(Load);
+    if (!AwaitFunction) continue;
+
+    /* Do the rewrite */
+    llvm::FunctionType *AwaitFunctionType = getFunctionType(AwaitFunction->getType());
+    llvm::IntegerType *i8Ty = llvm::Type::getInt8Ty(F->getParent()->getContext());
+    llvm::ConstantInt *COp = llvm::ConstantInt::get(i8Ty, op);
+    llvm::ConstantInt *CMode = llvm::ConstantInt::get(i8Ty, get_mode(Load));
+    llvm::Value *Address = Load->getOperand(0);
+    llvm::BasicBlock::iterator LI(Load);
+    llvm::SmallVector<llvm::Value*, 5> args;
+    if (llvm::isa<llvm::LoadInst>(Load)) {
+      args = {Address, COp, ArgVal, CMode};
+    } else {
+      llvm::AtomicRMWInst *RMW = llvm::cast<llvm::AtomicRMWInst>(Load);
+      args = {Address, RMW->getValOperand(), COp, ArgVal, CMode};
+    }
+    llvm::ReplaceInstWithInst(Load->getParent()->getInstList(), LI,
+                              llvm::CallInst::Create(AwaitFunctionType, AwaitFunction, args));
+    return true;
+  }
+  return false;
+}
+
+bool AssumeAwaitPass::tryRewriteAssumeCmpXchg
+(llvm::Function *F, llvm::BasicBlock *BB, llvm::CallInst *Call) const {
+  bool negate = false;
+  llvm::Value *CondVal = simplify_condition(Call->getArgOperand(0), &negate);
+  llvm::ExtractValueInst *EV = llvm::dyn_cast<llvm::ExtractValueInst>(CondVal);
+  if (!EV || EV->getNumIndices() != 1 || EV->getIndices()[0] != 1) return false;
+  if (negate) return false;
+  llvm::AtomicCmpXchgInst *CmpXchg
+    = llvm::dyn_cast<llvm::AtomicCmpXchgInst>(EV->getAggregateOperand());
+  if (!CmpXchg) return false;
+  if (!is_safe_to_rewrite(CmpXchg, Call)) return false;
+
+  llvm::Value *AwaitFunction = getAwaitFunction(CmpXchg);
+  if (!AwaitFunction) return false;
+  llvm::FunctionType *AwaitFunctionType = getFunctionType(AwaitFunction->getType());
+
+  /* Do the rewrite */
+  /* Step one; replace uses */
+  auto *True = llvm::ConstantInt::getTrue(F->getContext());
+  llvm::Value *Expected = CmpXchg->getCompareOperand();
+  llvm::Value *RetReplacement;
+  if (llvm::Constant *ExpectedC = llvm::dyn_cast<llvm::Constant>(Expected)) {
+    RetReplacement = llvm::ConstantStruct::getAnon({ExpectedC, True});
+  } else {
+    llvm::UndefValue *CS = llvm::UndefValue::get
+      (llvm::StructType::get(Expected->getType(), True->getType()));
+    RetReplacement = llvm::InsertValueInst::Create
+      (CS, Expected, {0}, "", CmpXchg);
+    RetReplacement = llvm::InsertValueInst::Create
+      (RetReplacement, True, {1}, "", CmpXchg);
+  }
+  CmpXchg->replaceAllUsesWith(RetReplacement);
+  /* Step two, replace cmpxchg */
+  llvm::IntegerType *i8Ty = llvm::Type::getInt8Ty(F->getContext());
+  llvm::Value *Address = CmpXchg->getPointerOperand();
+  llvm::CallInst::Create
+    (AwaitFunctionType, AwaitFunction, {Address, CmpXchg->getNewValOperand(),
+      llvm::ConstantInt::get(i8Ty, AwaitCond::EQ), Expected,
+      llvm::ConstantInt::get(i8Ty, get_mode(CmpXchg))},
+      "", CmpXchg);
+  CmpXchg->eraseFromParent();
+  return true;
+}
+
+llvm::Value *AssumeAwaitPass::getAwaitFunction(llvm::Instruction *Load) const {
+  llvm::Type *t = Load->getType();
+  if (llvm::isa<llvm::AtomicCmpXchgInst>(Load)) {
+    t = llvm::cast<llvm::StructType>(t)->getStructElementType(0);
+  }
+  if (!t->isIntegerTy()) return nullptr;
+  unsigned index;
+  switch(t->getIntegerBitWidth()) {
+  case 8:  index = 0; break;
+  case 16: index = 1; break;
+  case 32: index = 2; break;
+  case 64: index = 3; break;
+  default: return nullptr;
+  }
+  if (llvm::isa<llvm::LoadInst>(Load)) {
+    return F_load_await[index];
+  } else {
+    assert(llvm::isa<llvm::AtomicRMWInst>(Load)
+           || llvm::isa<llvm::AtomicCmpXchgInst>(Load));
+    return F_xchg_await[index];
+  }
+}
+
+char AssumeAwaitPass::ID = 0;
+static llvm::RegisterPass<AssumeAwaitPass> X("assume-await","Replace simple __VERIFIER_assumes with __VERIFIER_await.");

--- a/src/AssumeAwaitPass.h
+++ b/src/AssumeAwaitPass.h
@@ -1,0 +1,53 @@
+/* Copyright (C) 2020 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#ifndef __ASSUME_AWAIT_PASS_H__
+#define __ASSUME_AWAIT_PASS_H__
+
+#include <llvm/Pass.h>
+#include <llvm/Analysis/LoopPass.h>
+
+/* The AssumeAwaitPass identifies calls to __VERIFIER_assume with simple
+ * conditions and replaces them with
+ */
+class AssumeAwaitPass final : public llvm::FunctionPass{
+public:
+  static char ID;
+  AssumeAwaitPass() : llvm::FunctionPass(ID) {};
+  bool doInitialization(llvm::Module &M) override;
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+  bool runOnFunction(llvm::Function &F) override;
+#ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF
+  llvm::StringRef getPassName() const override { return "AssumeAwaitPass"; } ;
+#else
+  const char *getPassName() const override { return "AssumeAwaitPass"; };
+#endif
+private:
+  static const unsigned no_sizes = 4;
+  static unsigned sizes[no_sizes];
+  llvm::Value *F_load_await[no_sizes];
+  llvm::Value *F_xchg_await[no_sizes];
+  bool tryRewriteAssume(llvm::Function *F, llvm::BasicBlock *BB, llvm::Instruction *I) const;
+  bool tryRewriteAssumeCmpXchg(llvm::Function *F, llvm::BasicBlock *BB, llvm::CallInst *I) const;
+  llvm::Value *getAwaitFunction(llvm::Instruction *Load) const;
+};
+
+#endif

--- a/src/AwaitCond.h
+++ b/src/AwaitCond.h
@@ -1,0 +1,62 @@
+/* Copyright (C) 2019 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#ifndef __AWAIT_COND_H__
+#define __AWAIT_COND_H__
+
+#include "SymAddr.h"
+
+struct AwaitCond {
+  SymData::block_type operand;
+  /* An Op is a bitfield, with the following meanings for bits 3..0, msb
+   * first:
+   *   Signed  - If the comparison is of signed values
+   *   Less    - If the comparison is true when lhs is less than rhs
+   *   Equal   - If the comparison is true when lhs is equal to rhs
+   *   Greater - If the comparison is true when lhs is greater than rhs
+   */
+  enum Op : uint8_t {
+    None,
+    UGT = 0b0001,
+    EQ  = 0b0010,
+    UGE = 0b0011,
+    ULT = 0b0100,
+    NE  = 0b0101,
+    ULE = 0b0110,
+    SGT = 0b1001,
+    SGE = 0b1011,
+    SLT = 0b1100,
+    SLE = 0b1110,
+  } op = None;
+
+  AwaitCond() {}
+  AwaitCond(Op op, SymData::block_type operand)
+    : operand(std::move(operand)), op(op) { assert(op != None); }
+
+  static const char *name(Op op);
+
+  bool satisfied_by(const SymData &data) const {
+    return satisfied_by(data.get_block(), data.get_ref().size);
+  }
+  bool satisfied_by(const void *data, std::size_t size) const;
+};
+
+#endif

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -275,48 +275,7 @@ void Configuration::assign_by_commandline(){
 
 void Configuration::check_commandline(){
   /* Check commandline switch compatibility with --transform. */
-  if(cl_transform.getNumOccurrences()){
-    if(cl_extfun_no_race.getNumOccurrences()){
-      Debug::warn("Configuration::check_commandline:transform:extfun_no_race")
-        << "WARNING: --extfun-no-race ignored in presence of --transform.\n";
-    }
-    if(cl_malloc_may_fail.getNumOccurrences()){
-      Debug::warn("Configuration::check_commandline:transform:malloc_may_fail")
-        << "WARNING: --malloc_may_fail ignored in presence of --transform.\n";
-    }
-    if(cl_disable_mutex_init_requirement.getNumOccurrences()){
-      Debug::warn("Configuration::check_commandline:transform:disable_mutex_init_requirement")
-        << "WARNING: --disable-mutex-init-requirement ignored in presence of --transform.\n";
-    }
-    if(cl_max_search_depth.getNumOccurrences()){
-      Debug::warn("Configuration::check_commandline:transform:max-search-depth")
-        << "WARNING: --max-search-depth ignored in presence of --transform.\n";
-    }
-    if(cl_memory_model.getNumOccurrences()){
-      Debug::warn("Configuration::check_commandline:transform:memory_model")
-        << "WARNING: Given memory model ignored in presence of --transform.\n";
-    }
-    if(cl_dpor_algorithm.getNumOccurrences()){
-      Debug::warn("Configuration::check_commandline:transform:dpor_algorithm")
-        << "WARNING: Given DPOR algorithm ignored in presence of --transform.\n";
-    }
-    if(cl_print_progress.getNumOccurrences()){
-      Debug::warn("Configuration::check_commandline:transform:print-progress")
-        << "WARNING: --print-progress ignored in presence of --transform.\n";
-    }
-    if(cl_print_progress_estimate.getNumOccurrences()){
-      Debug::warn("Configuration::check_commandline:transform:print-progress-estimate")
-        << "WARNING: --print-progress-estimate ignored in presence of --transform.\n";
-    }
-    if(cl_check_robustness.getNumOccurrences()){
-      Debug::warn("Configuration::check_commandline:transform:check_robustness")
-        << "WARNING: --robustness ignored in presence of --transform.\n";
-    }
-    if(cl_program_arguments.size()){
-      Debug::warn("Configuration::check_commandline:transform:program_arguments")
-        << "WARNING: Program arguments (argv for test case) ignored in presence of --transform.\n";
-    }
-  }else{
+  if(!cl_transform.getNumOccurrences()){
     if(cl_transform_spin_assume.getNumOccurrences()){
       Debug::warn("Configuration::check_commandline:no:transform:transform-no-spin-assume")
         << "WARNING: --spin-assume ignored in absence of --transform.\n";

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -252,7 +252,11 @@ void Configuration::assign_by_commandline(){
   transform_cast_elim = !cl_transform_no_cast_elim;
   transform_partial_loop_purity = !cl_transform_no_partial_loop_purity;
   if (cl_transform_assume_await == Tristate::DEFAULT) {
-    transform_assume_await = false;
+    /* Source-DPOR and TSO probably work too, and maybe also Observers,
+     * but Optimal-DPOR is the only one we've formally proven correct,
+     * for now */
+    transform_assume_await = (memory_model == SC
+                              && dpor_algorithm == Configuration::OPTIMAL);
   } else {
     transform_assume_await = cl_transform_assume_await == Tristate::TRUE;
   }

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -93,6 +93,7 @@ public:
     debug_print_on_reset = false;
     debug_print_on_error = false;
     transform_spin_assume = false;
+    transform_assume_await = false;
     transform_loop_unroll = -1;
     svcomp_nondet_int = nullptr;
     print_progress = false;
@@ -191,6 +192,8 @@ public:
   bool transform_cast_elim = true;
   /* In module transformation, enable the PartialLoopPurity pass. */
   bool transform_partial_loop_purity = true;
+  /* In module transformation, enable the AssumeAwait pass. */
+  bool transform_assume_await;
   /* If transform_loop_unroll is non-negative, in module
    * transformation, enable loop unrolling with depth
    * transform_loop_unroll.

--- a/src/DPORDriver.cpp
+++ b/src/DPORDriver.cpp
@@ -234,6 +234,8 @@ void DPORDriver::print_progress(uint64_t computation_count, long double estimate
       llvm::dbgs() << ", " << res.sleepset_blocked_trace_count << " ssb";
     if(res.assume_blocked_trace_count)
       llvm::dbgs() << ", " << res.assume_blocked_trace_count << " ab";
+    if(res.await_blocked_trace_count)
+      llvm::dbgs() << ", " << res.await_blocked_trace_count << " awb";
     if(tasks_left != -1)
       llvm::dbgs() << " (" << tasks_left << " jobs)";
     if(conf.print_progress_estimate){
@@ -258,6 +260,8 @@ bool DPORDriver::handle_trace(TraceBuilder *TB, Trace *t, uint64_t *computation_
     ++res.sleepset_blocked_trace_count;
   }else if(assume_blocked){
     ++res.assume_blocked_trace_count;
+  }else if(TB->await_blocked()){
+    ++res.await_blocked_trace_count;
   }else{
     ++res.trace_count;
   }

--- a/src/DPORDriver.h
+++ b/src/DPORDriver.h
@@ -110,13 +110,15 @@ public:
   public:
     /* Empty result */
     Result() : trace_count(0), sleepset_blocked_trace_count(0),
-               assume_blocked_trace_count(0) {};
+               assume_blocked_trace_count(0), await_blocked_trace_count(0) {};
     /* The number of explored (non-sleepset-blocked) traces */
     uint64_t trace_count;
     /* The number of explored sleepset-blocked traces */
     uint64_t sleepset_blocked_trace_count;
     /* The number of explored assume-blocked traces */
     uint64_t assume_blocked_trace_count;
+    /* The number of explored assume-blocked traces */
+    uint64_t await_blocked_trace_count;
 
     bool has_errors() const { return error_trace && error_trace->has_errors(); };
   };

--- a/src/Interpreter.h
+++ b/src/Interpreter.h
@@ -72,6 +72,8 @@
 #include <random>
 #include <stdexcept>
 
+#include <boost/container/flat_map.hpp>
+
 namespace llvm {
 
 class IntrinsicLowering;
@@ -219,6 +221,10 @@ protected:
    * The key is the location of the object.
    */
   std::map<void*,PthreadMutex> PthreadMutexes;
+
+  /* The threads that are blocking in an await statement */
+  boost::container::flat_map
+  <SymAddrSize, boost::container::flat_map<int, AwaitCond>> blocking_awaits;
 
   /* The runtime stack of executing code. The top of the stack is the
    * current function record.
@@ -565,6 +571,16 @@ protected:  // Helper functions
    * stored to *ptr.
    */
   virtual bool isPthreadMutexLock(Instruction &I, GenericValue **ptr);
+  /* Returns true iff I is a call to __VERIFIER_load_await_*.
+   *
+   * The address is stored to *ptr, and the condition is stored to *cond.
+   */
+  virtual bool isLoadAwait(Instruction &I, GenericValue **ptr, AwaitCond *cond);
+  /* Returns true iff I is a call to __VERIFIER_xchg_await_*.
+   *
+   * The address is stored to *ptr, and the condition is stored to *cond.
+   */
+  virtual bool isXchgAwait(Instruction &I, GenericValue **ptr, AwaitCond *cond);
   /* Returns true iff CS is a call to inline assembly.
    *
    * If CS is a call to inline assembly, then *asmstr is assigned the
@@ -614,6 +630,13 @@ protected:  // Helper functions
   virtual void callFree(Function *F, const std::vector<GenericValue> &ArgVals);
   virtual void callAssertFail(Function *F, const std::vector<GenericValue> &ArgVals);
   virtual void callAtexit(Function *F, const std::vector<GenericValue> &ArgVals);
+  virtual void callLoadAwait(Function *F, const std::vector<GenericValue> &ArgVals);
+  virtual void callXchgAwait(Function *F, const std::vector<GenericValue> &ArgVals);
+
+private:
+  void CheckAwaitWakeup(const GenericValue &Val, const void *ptr, const SymAddrSize &sas);
+  bool isAnyAwait(Instruction &I, GenericValue **ptr, AwaitCond *cond,
+                  const char *name_prefix, unsigned nargs);
 };
 
 } // End llvm namespace

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ AUTOMAKE_OPTIONS = -Wno-override ## Make autotools quit complaining about explic
 noinst_LIBRARIES = libnidhugg.a
 libnidhugg_a_SOURCES = \
   AddLibPass.cpp AddLibPass.h \
+  AssumeAwaitPass.cpp AssumeAwaitPass.h \
   AwaitCond.cpp AwaitCond.h \
   BVClock.cpp BVClock.h \
   CastElimPass.cpp CastElimPass.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ AUTOMAKE_OPTIONS = -Wno-override ## Make autotools quit complaining about explic
 noinst_LIBRARIES = libnidhugg.a
 libnidhugg_a_SOURCES = \
   AddLibPass.cpp AddLibPass.h \
+  AwaitCond.cpp AwaitCond.h \
   BVClock.cpp BVClock.h \
   CastElimPass.cpp CastElimPass.h \
   CheckModule.cpp CheckModule.h \

--- a/src/RMWAction.cpp
+++ b/src/RMWAction.cpp
@@ -25,18 +25,32 @@
 #include <llvm/Support/SwapByteOrder.h> /* On llvm >= 11 */
 
 namespace {
-  int smemcmp(const void *lhs, const void *rhs, std::size_t count) {
+  int apcmp(const void *lhsv, const void *rhsv, std::size_t count) {
+    if (llvm::sys::IsBigEndianHost) {
+      return std::memcmp(lhsv, rhsv, count);
+    } else {
+      const uint8_t *lhs = static_cast<const uint8_t*>(lhsv);
+      const uint8_t *rhs = static_cast<const uint8_t*>(rhsv);
+      while(count--) {
+        if (lhs[count] > rhs[count]) return 1;
+        else if (lhs[count] < rhs[count]) return -1;
+      }
+      return 0;
+    }
+  }
+
+  int sapcmp(const void *lhs, const void *rhs, std::size_t count) {
     if (!count) return 0;
     std::size_t big_byte_index;
     if (llvm::sys::IsBigEndianHost) {
-      big_byte_index = count-1;
-    } else {
       big_byte_index = 0;
+    } else {
+      big_byte_index = count-1;
     }
     bool lsign = ((const char*)lhs)[big_byte_index] >> (CHAR_BIT-1);
     bool rsign = ((const char*)rhs)[big_byte_index] >> (CHAR_BIT-1);
     if (lsign != rsign) return lsign ? -1 : 1;
-    return std::memcmp(lhs, rhs, count);
+    return apcmp(lhs, rhs, count);
   }
 }
 
@@ -51,10 +65,13 @@ const char *RmwAction::name(Kind kind) {
 void RmwAction::apply_to(SymData &dst, const SymData &data) {
   assert(dst.get_ref() == data.get_ref());
   assert(dst.get_shared_block().unique());
-  std::size_t size = dst.get_ref().size;
-  uint8_t *outp = static_cast<uint8_t*>(dst.get_block());
+  apply_to(dst.get_block(), dst.get_ref().size, data.get_block());
+}
+
+void RmwAction::apply_to(void *dst, std::size_t size, void *data) {
+  uint8_t *outp = static_cast<uint8_t*>(dst);
   const uint8_t *inp, *argp;
-  inp = static_cast<uint8_t*>(data.get_block());
+  inp = static_cast<uint8_t*>(data);
   argp = static_cast<uint8_t*>(operand.get());
 
   switch (kind) {
@@ -64,7 +81,7 @@ void RmwAction::apply_to(SymData &dst, const SymData &data) {
     outp += shift;
     inp += shift;
     argp += shift;
-    uint8_t carry = 0;
+    int8_t carry = 0;
     for (size_t i = 0; i < size; ++i) {
       uint16_t sum;
       if (kind == ADD) sum = inp[i*multiplier] + argp[i*multiplier] + carry;
@@ -90,7 +107,7 @@ void RmwAction::apply_to(SymData &dst, const SymData &data) {
   } break;
   case MAX: case MIN: case UMAX: case UMIN:  {
     bool is_signed = kind == MAX || kind == MIN;
-    int out = (is_signed ? smemcmp : memcmp)(data.get_block(), operand.get(), size);
+    int out = (is_signed ? sapcmp : apcmp)(data, operand.get(), size);
     bool take_rhs = out > 0;
     if (kind == MAX || kind == UMAX) take_rhs = !take_rhs;
     const uint8_t *res = take_rhs ? argp : inp;

--- a/src/RMWAction.h
+++ b/src/RMWAction.h
@@ -48,6 +48,7 @@ struct RmwAction {
 
   /* Computes the result of this rmw action when given data as input */
   void apply_to(SymData &dst, const SymData &data);
+  void apply_to(void *dst, std::size_t size, void *data);
 };
 
 #endif

--- a/src/SymAddr.h
+++ b/src/SymAddr.h
@@ -170,6 +170,9 @@ public:
 
   bool operator==(const SymAddrSize &o) const { return addr == o.addr && size == o.size; };
   bool operator!=(const SymAddrSize &o) const { return !(*this == o); };
+  bool operator<(const SymAddrSize &o) const {
+    return addr < o.addr || (addr == o.addr && size < o.size);
+  }
 
   std::string to_string(std::function<std::string(int)> pid_str
                         = (std::string(&)(int))std::to_string) const;

--- a/src/SymEv.cpp
+++ b/src/SymEv.cpp
@@ -38,6 +38,15 @@ bool SymEv::is_compatible_with(SymEv other) const {
     }
   }
   switch(kind) {
+  case LOAD_AWAIT: case XCHG_AWAIT:
+    if (arg2.await_op != other.arg2.await_op) return false;
+    if (_expected) {
+      assert(other._expected);
+      // We need stable addresses
+      // if (memcmp(_expected.get(), other._expected.get(), arg.addr.size) != 0)
+      //   return false;
+    }
+    /* fallthrough */
   case LOAD:
   case M_INIT: case M_LOCK: case M_UNLOCK: case M_DELETE:
   case M_TRYLOCK: case M_TRYLOCK_FAIL:
@@ -83,6 +92,10 @@ std::string SymEv::to_string(std::function<std::string(int)> pid_str) const {
     case NONDET:   return "Nondet(" + std::to_string(arg.num) + ")";
 
     case LOAD:     return "Load("    + arg.addr.to_string(pid_str) + ")";
+    case LOAD_AWAIT:
+      return "LoadAwait(" + arg.addr.to_string(pid_str) + ", "
+        + AwaitCond::name(arg2.await_op) + " "
+        + block_to_string(_expected, arg.addr.size) + ")";
     case STORE:    return "Store("   + arg.addr.to_string(pid_str)
         + "," + block_to_string(_written, arg.addr.size) + ")";
     case FULLMEM:  return "Fullmem()";
@@ -112,6 +125,10 @@ std::string SymEv::to_string(std::function<std::string(int)> pid_str) const {
         + "," + block_to_string(_written, arg.addr.size)
         + "," + RmwAction::name(arg2.rmw_kind)
         + " " + block_to_string(_expected, arg.addr.size) + ")";
+    case XCHG_AWAIT: return "XchgAwait(" + arg.addr.to_string(pid_str)
+        + "," + block_to_string(_written, arg.addr.size) + ", "
+        + AwaitCond::name(arg2.await_op) + " "
+        + block_to_string(_expected, arg.addr.size)+ ")";
     case CMPXHG: return "CmpXhg("
         + arg.addr.to_string(pid_str)
         + "," + block_to_string(_expected, arg.addr.size)
@@ -126,13 +143,13 @@ std::string SymEv::to_string(std::function<std::string(int)> pid_str) const {
 
 bool SymEv::has_addr() const {
   switch(kind) {
-  case LOAD: case STORE:
+  case LOAD: case LOAD_AWAIT: case STORE:
   case M_INIT: case M_LOCK: case M_UNLOCK: case M_DELETE:
   case M_TRYLOCK: case M_TRYLOCK_FAIL:
   case C_INIT: case C_SIGNAL: case C_BRDCST: case C_DELETE:
   case C_WAIT: case C_AWAKE:
   case UNOBS_STORE:
-  case RMW: case CMPXHG: case CMPXHGFAIL:
+  case RMW: case XCHG_AWAIT: case CMPXHG: case CMPXHGFAIL:
     return true;
   case NONE:
   case FULLMEM: case NONDET:
@@ -150,12 +167,12 @@ bool SymEv::has_num() const {
   case NONE:
   case C_WAIT: case C_AWAKE:
   case FULLMEM:
-  case LOAD: case STORE:
+  case LOAD: case LOAD_AWAIT: case STORE:
   case M_INIT: case M_LOCK: case M_UNLOCK: case M_DELETE:
   case M_TRYLOCK: case M_TRYLOCK_FAIL:
   case C_INIT: case C_SIGNAL: case C_BRDCST: case C_DELETE:
   case UNOBS_STORE:
-  case RMW: case CMPXHG: case CMPXHGFAIL:
+  case RMW: case XCHG_AWAIT: case CMPXHG: case CMPXHGFAIL:
     return false;
   }
   abort();
@@ -164,14 +181,14 @@ bool SymEv::has_num() const {
 bool SymEv::has_data() const {
   switch(kind) {
   case STORE: case UNOBS_STORE:
-  case RMW: case CMPXHG: case CMPXHGFAIL:
+  case RMW: case XCHG_AWAIT: case CMPXHG: case CMPXHGFAIL:
     return (bool)_written;
   case NONE:
   case SPAWN: case JOIN:
   case NONDET:
   case C_WAIT: case C_AWAKE:
   case FULLMEM:
-  case LOAD:
+  case LOAD: case LOAD_AWAIT:
   case M_INIT: case M_LOCK: case M_UNLOCK: case M_DELETE:
   case M_TRYLOCK: case M_TRYLOCK_FAIL:
   case C_INIT: case C_SIGNAL: case C_BRDCST: case C_DELETE:
@@ -189,12 +206,12 @@ bool SymEv::has_expected() const {
   case NONDET:
   case C_WAIT: case C_AWAKE:
   case FULLMEM:
-  case LOAD:
+  case LOAD: case LOAD_AWAIT:
   case STORE: case UNOBS_STORE:
   case M_INIT: case M_LOCK: case M_UNLOCK: case M_DELETE:
   case M_TRYLOCK: case M_TRYLOCK_FAIL:
   case C_INIT: case C_SIGNAL: case C_BRDCST: case C_DELETE:
-  case RMW:
+  case RMW: case XCHG_AWAIT:
     return false;
   }
   abort();

--- a/src/TSOPSOTraceBuilder.h
+++ b/src/TSOPSOTraceBuilder.h
@@ -25,6 +25,7 @@
 #include "Configuration.h"
 #include "SymAddr.h"
 #include "RMWAction.h"
+#include "AwaitCond.h"
 #include "Trace.h"
 #include "DetCheckTraceBuilder.h"
 #include "CompilerHelp.h"
@@ -150,6 +151,15 @@ public:
     return load(ml.get_ref())
       && atomic_store(ml);
   }
+  virtual NODISCARD bool xchg_await(const SymData &ml, AwaitCond cond) {
+    invalid_input_error("Exchange-await not supported by selected algorithm");
+    return false;
+  }
+  virtual NODISCARD bool xchg_await_fail(const SymData &ml, AwaitCond cond) {
+    invalid_input_error("Exchange-await not supported by selected algorithm");
+    return false;
+  }
+
   /* Perform a compare-exchange to sd.get_ref().
    *
    * success is true iff ml.get_ref() contained the value of expected.
@@ -165,6 +175,14 @@ public:
    * Returns true on success, false if an error has been generated.
    */
   virtual NODISCARD bool load(const SymAddrSize &ml) = 0;
+  virtual NODISCARD bool load_await(const SymAddrSize &ml, AwaitCond cond) {
+    invalid_input_error("Load-await not supported by selected algorithm");
+    return false;
+  }
+  virtual NODISCARD bool load_await_fail(const SymAddrSize &ml, AwaitCond cond) {
+    invalid_input_error("Load-await not supported by selected algorithm");
+    return false;
+  }
   /* Perform an action that conflicts with all memory accesses and all
    * other full memory conflicts.
    *

--- a/src/TSOTraceBuilder.h
+++ b/src/TSOTraceBuilder.h
@@ -44,6 +44,7 @@ public:
   virtual bool is_replaying() const override;
   virtual void metadata(const llvm::MDNode *md) override;
   virtual bool sleepset_is_empty() const override;
+  virtual bool await_blocked() const override { return blocked_awaits.size(); }
   virtual bool check_for_cycles() override;
   virtual Trace *get_trace() const override;
   virtual bool reset() override;

--- a/src/TSOTraceBuilder.h
+++ b/src/TSOTraceBuilder.h
@@ -28,6 +28,7 @@
 #include "Option.h"
 
 #include <boost/container/flat_map.hpp>
+#include <unordered_map>
 
 typedef llvm::SmallVector<SymEv,1> sym_ty;
 
@@ -54,9 +55,16 @@ public:
   virtual NODISCARD bool store(const SymData &ml) override;
   virtual NODISCARD bool atomic_store(const SymData &ml) override;
   virtual NODISCARD bool atomic_rmw(const SymData &ml, RmwAction action) override;
+  virtual NODISCARD bool xchg_await(const SymData &ml, AwaitCond cond) override;
+  virtual NODISCARD bool xchg_await_fail(const SymData &ml, AwaitCond cond) override;
+
   virtual NODISCARD bool compare_exchange
   (const SymData &sd, const SymData::block_type expected, bool success) override;
   virtual NODISCARD bool load(const SymAddrSize &ml) override;
+  virtual NODISCARD bool load_await(const SymAddrSize &ml, AwaitCond cond)
+    override;
+  virtual NODISCARD bool load_await_fail(const SymAddrSize &ml, AwaitCond cond)
+    override;
   virtual NODISCARD bool full_memory_conflict() override;
   virtual NODISCARD bool fence() override;
   virtual NODISCARD bool join(int tgt_proc) override;
@@ -334,7 +342,7 @@ protected:
 
   struct Race {
   public:
-    enum Kind {
+    enum Kind : uint8_t {
       /* Any kind of event that does not block any other process */
       NONBLOCK,
       /* A nonblocking race where additionally a third event is
@@ -347,27 +355,29 @@ protected:
       LOCK_SUC,
       /* A nondeterministic event that can be performed differently */
       NONDET,
+      /* An event that can be blocked by other processes. Includes a set
+       * "exclude" to exclude from the wakeup sequence. */
+      SEQUENCE,
     };
+    SymEv ev;
     Kind kind;
     int first_event;
     int second_event;
     IID<IPid> second_process;
+    std::vector<unsigned> exclude; // XXX: Make me fixed_vector
     union{
-      const Mutex *mutex;
       int witness_event;
       int alternative;
       int unlock_event;
     };
     static Race Nonblock(int first, int second) {
-      return Race(NONBLOCK, first, second, {-1,0}, nullptr);
+      return Race(NONBLOCK, first, second, {-1,0}, -1);
     };
     static Race Observed(int first, int second, int witness) {
       return Race(OBSERVED, first, second, {-1,0}, witness);
     };
-    static Race LockFail(int first, int second, IID<IPid> process,
-                         const Mutex *mutex) {
-      assert(mutex);
-      return Race(LOCK_FAIL, first, second, process, mutex);
+    static Race LockFail(int first, int second, IID<IPid> process) {
+      return Race(LOCK_FAIL, first, second, process, -1);
     };
     static Race LockSuc(int first, int second, int unlock) {
       return Race(LOCK_SUC, first, second, {-1,0}, unlock);
@@ -375,18 +385,38 @@ protected:
     static Race Nondet(int event, int alt) {
       return Race(NONDET, event, -1, {-1,0}, alt);
     };
+    static Race Sequence(int first, int second, IID<IPid> process, SymEv ev,
+                         std::vector<unsigned> exclude) {
+      return Race(SEQUENCE, first, second, process, std::move(ev),
+                  std::move(exclude));
+    }
+    bool is_fail_kind() const {
+      return kind == LOCK_FAIL || kind == SEQUENCE;
+    }
   private:
-    Race(Kind k, int f, int s, IID<IPid> p, const Mutex *m) :
-      kind(k), first_event(f), second_event(s), second_process(p), mutex(m) {}
     Race(Kind k, int f, int s, IID<IPid> p, int w) :
       kind(k), first_event(f), second_event(s), second_process(p),
       witness_event(w) {}
+    Race(Kind k, int f, int s, IID<IPid> p, SymEv &&ev,
+         std::vector<unsigned> &&exclude) :
+      ev(std::move(ev)), kind(k), first_event(f), second_event(s),
+      second_process(p), exclude(std::move(exclude)) {}
   };
 
   /* Locations in the trace where a process is blocked waiting for a
    * lock. All are of kind LOCK_FAIL.
    */
   std::vector<Race> lock_fail_races;
+
+  /* All currently blocking Await-events. */
+  struct BlockedAwait {
+    BlockedAwait(int index, SymEv ev)
+      : ev(std::move(ev)), index(index) {}
+    SymEv ev;
+    int index;
+  };
+  std::unordered_map<SymAddr, boost::container::flat_map<IPid,BlockedAwait>>
+    blocked_awaits;
 
   /* Information about a (short) sequence of consecutive events by the
    * same thread. At most one event in the sequence may have conflicts
@@ -417,6 +447,16 @@ protected:
      * involving this event as the main event.
      */
     std::vector<Race> races;
+    /* Events that unblock the current event (and thus are not races),
+     * but are not inherently needed to enable this event.
+     *
+     * For a lock-event, the prior unlock event does not need to be in
+     * here, as it is handles specially by LockSuc races in races.
+     *
+     * May not contain -1
+     */
+    VecSet<int> happens_after_later;
+
     /* Is it possible for any event in this sequence to have a
      * conflict with another event?
      */
@@ -520,6 +560,8 @@ protected:
     return Branch(prefix.branch(index), prefix[index].sym);
   };
 
+  IID<CPid> get_iid(unsigned i) const;
+
   /* Perform the logic of atomic_store(), aside from recording a
    * symbolic event.
    */
@@ -536,6 +578,12 @@ protected:
                       VecSet<int> &seen_accesses,
                       VecSet<std::pair<int,int>> &seen_pairs,
                       bool is_update);
+  /* Adds the races implied by an await at position pos in prefix to
+   * races. pos may be prefix.len() (corresponding to a deadlocked
+   * await).
+   * Returns false if an error was added */
+  bool do_await(unsigned pos, const IID<IPid> &iid, const SymEv &e,
+                const VClock<IPid> &above_clock, std::vector<Race> &races);
 
   /* Finds the index in prefix of the event of process pid that has iid-index
    * index.
@@ -572,9 +620,9 @@ protected:
    */
   void add_lock_suc_race(int lock, int unlock);
   /* Record that the currently executing event is being blocked trying
-   * to aquire mutex m, which is held by the lock event event.
+   * to aquire a mutex, which is held by the lock event event.
    */
-  void add_lock_fail_race(const Mutex &m, int event);
+  void add_lock_fail_race(int event);
   /* Check if two events in the current prefix are in conflict. */
   bool do_events_conflict(int i, int j) const;
   bool do_events_conflict(const Event &fst, const Event &snd) const;
@@ -597,10 +645,14 @@ protected:
   bool is_observed_conflict(IPid fst_pid, const SymEv &fst,
                             IPid snd_pid, const SymEv &snd,
                             IPid thd_pid, const SymEv &thd) const;
-  /* Reconstruct the vector cloc and symbolic event of a blocked attempt
-   * at aquiring a mutex recorded in race.
+  /* Reconstruct the above-vector clock of a blocked event with IID
+   * iid. */
+  VClock<IPid> reconstruct_blocked_clock(IID<IPid> iid) const;
+  /* Reconstruct the vector clock and symbolic event of a blocked event
+   * recorded in race, for example a blocked attempt at aquiring a
+   * mutex.
    */
-  Event reconstruct_lock_event(const Race &race) const;
+  Event reconstruct_blocked_event(const Race &race) const;
   /* Computes a mapping between IPid and current local clock value
    * (index) of that process after executing the prefix [0,event).
    */
@@ -659,6 +711,16 @@ protected:
     const;
   /* Recompute the observation states on the symbolic events in v. */
   void recompute_observed(std::vector<Branch> &v) const;
+  /* Check whether an await would be satisfied if played at position i
+   * in the current prefix.
+   */
+  bool awaitcond_satisfied_before(unsigned i, const SymAddrSize &ml,
+                                  const AwaitCond &cond) const;
+  /* The same, but assuming that before playing the await, we play a set
+   * of events given as seq (referring to events in prefix)
+   */
+  bool awaitcond_satisfied_by(unsigned i, const std::vector<unsigned> &seq,
+                              const SymAddrSize &ml, const AwaitCond &cond) const;
   struct obs_sleep {
     struct sleeper {
       IPid pid;

--- a/src/TraceBuilder.h
+++ b/src/TraceBuilder.h
@@ -44,6 +44,10 @@ public:
   virtual ~TraceBuilder();
   /* Returns true iff the sleepset is currently empty. */
   virtual bool sleepset_is_empty() const = 0;
+  /* When called at the end of an execution, returns true iff there are
+   * any await-statements that are blocking.
+   */
+  virtual bool await_blocked() const { return false; }
   /* Returns true iff this trace contains any happens-before cycle.
    *
    * If there is a happens-before cycle, and conf.check_robustness is

--- a/src/Transform.cpp
+++ b/src/Transform.cpp
@@ -23,6 +23,7 @@
 #include "DeadCodeElimPass.h"
 #include "CastElimPass.h"
 #include "PartialLoopPurityPass.h"
+#include "AssumeAwaitPass.h"
 #include "StrModule.h"
 #include "Transform.h"
 
@@ -122,6 +123,9 @@ namespace Transform {
     }
     if (conf.transform_loop_unroll >= 0) {
       PM.add(new LoopBoundPass(conf.transform_loop_unroll));
+    }
+    if(conf.transform_assume_await){
+      PM.add(new AssumeAwaitPass());
     }
     PM.add(new AddLibPass());
     bool modified = PM.run(mod);

--- a/src/VClock.cpp
+++ b/src/VClock.cpp
@@ -194,6 +194,13 @@ bool VClock<int>::gt(const VClock<int> &vc) const{
   return greater;
 }
 
+bool VClock<int>::intersects_below(const VClock<int> &vc) const{
+  for (std::size_t i = 0; i < vc.size_ub(); ++i) {
+    if ((*this)[i] >= vc[i]) return true;
+  }
+  return false;
+}
+
 std::string VClock<int>::to_string() const{
   int m = vec.size() - 1;
   while(0 <= m && vec[m] == 0) --m;

--- a/src/VClock.h
+++ b/src/VClock.h
@@ -168,6 +168,10 @@ public:
   bool leq(const VClock<int> &vc) const;
   bool gt(const VClock<int> &vc) const;
   bool geq(const VClock<int> &vc) const;
+  /* A vector clock u intersects a (below) clock v if there is at least
+   * one d within the domain of v such that u[d] >= v[d]
+   */
+  bool intersects_below(const VClock<int> &vc) const;
 
   /* *** Total order comparisons *** */
   bool operator==(const VClock<int> &vc) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,6 +120,9 @@ int main(int argc, char *argv[]){
 
       DPORDriver::Result res = driver->run();
       std::cout << "Trace count: " << res.trace_count << std::endl;
+      if (res.await_blocked_trace_count > 0)
+        std::cout << "Await-blocked trace count: "
+                  << res.await_blocked_trace_count << std::endl;
       if (res.assume_blocked_trace_count > 0)
         std::cout << "Assume-blocked trace count: "
                   << res.assume_blocked_trace_count << std::endl;

--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -32,6 +32,9 @@ nidhuggcparamslist = [
     Param('--spin-assume','Use the spin-assume transformation on module before calling nidhugg.',False,True),
     Param('--no-dead-code-elim','Don\'t use the dead code elimination pass on module before calling nidhugg.',False,True),
     Param('--no-cast-elim','Don\'t use the cast elimination pass on module before calling nidhugg.',False,True),
+    Param('--no-assume-await','Don\'t use the assume-await transformation on module before calling nidhugg.',False,True),
+    Param('--assume-await','Always use the assume-await transformation on module before calling nidhugg.',False,True),
+    Param('--no-assume-xchgawait','Don\'t transform assume statements to xchg-await before calling nidhugg.',False,True),
     Param('--unroll','Use unroll transformation on module before calling nidhugg.','N',True),
 ]
 nidhuggcparams = { p.name : p for p in nidhuggcparamslist }

--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import collections
 
 #########################
 # Default Configuration #
@@ -15,43 +16,33 @@ NIDHUGG=os.path.join(sys.path[0], 'nidhugg')
 CLANG='%%CLANG%%'
 CLANGXX='%%CLANGXX%%'
 
-nidhuggcparams = [
-    {'name':'--help','help':'Prints this text.','param':False},
-    {'name':'--verbose','help':'Show commands being run.','param':False},
-    {'name':'--version','help':'Prints the nidhugg version.','param':False},
-    {'name':'--c','help':'Interpret input FILE as C code. (Compile with clang.)','param':False},
-    {'name':'--cxx','help':'Interpret input FILE as C++ code. (Compile with clang++.)','param':False},
-    {'name':'--ll','help':'Interpret input FILE as LLVM IR code. (Preprocess with cpp.)','param':False},
-    {'name':'--clang','help':'Specify the path to clang.','param':'PATH'},
-    {'name':'--clangxx','help':'Specify the path to clang++.','param':'PATH'},
-    {'name':'--nidhugg','help':'Specify the path to the nidhugg binary.','param':'PATH'},
-    {'name':'--no-partial-loop-purity','help':'Don\'t reduce partially pure loops with assumes before calling nidhugg.','param':False},
-    {'name':'--spin-assume','help':'Use the spin-assume transformation on module before calling nidhugg.','param':False},
-    {'name':'--no-dead-code-elim','help':'Don\'t use the dead code elimination pass on module before calling nidhugg.','param':False},
-    {'name':'--no-cast-elim','help':'Don\'t use the cast elimination pass on module before calling nidhugg.','param':False},
-    {'name':'--unroll','help':'Use unroll transformation on module before calling nidhugg.','param':'N'},
+Param = collections.namedtuple("Param",["name","help","param","transform"])
+
+nidhuggcparamslist = [
+    Param("--help",'Prints this text.',False,False),
+    Param('--verbose','Show commands being run.',False,False),
+    Param('--version','Prints the nidhugg version.',False,False),
+    Param('--c','Interpret input FILE as C code. (Compile with clang.)',False,False),
+    Param('--cxx','Interpret input FILE as C++ code. (Compile with clang++.)',False,False),
+    Param('--ll','Interpret input FILE as LLVM IR code. (Preprocess with cpp.)',False,False),
+    Param('--clang','Specify the path to clang.','PATH',False),
+    Param('--clangxx','Specify the path to clang++.','PATH',False),
+    Param('--nidhugg','Specify the path to the nidhugg binary.','PATH',False),
+    Param('--no-partial-loop-purity','Don\'t reduce partially pure loops with assumes before calling nidhugg.',False,True),
+    Param('--spin-assume','Use the spin-assume transformation on module before calling nidhugg.',False,True),
+    Param('--no-dead-code-elim','Don\'t use the dead code elimination pass on module before calling nidhugg.',False,True),
+    Param('--no-cast-elim','Don\'t use the cast elimination pass on module before calling nidhugg.',False,True),
+    Param('--unroll','Use unroll transformation on module before calling nidhugg.','N',True),
 ]
+nidhuggcparams = { p.name : p for p in nidhuggcparamslist }
 
 nidhuggcparamaliases = {
-    '-help':'--help',
     '-h':'--help',
     '-?':'--help',
-    '-version':'--version',
     '-V':'--version',
-    '-verbose':'--verbose',
     '-v':'--verbose',
-    '-c':'--c',
-    '-cxx':'--cxx',
-    '-ll':'--ll',
-    '-clang':'--clang',
-    '-clangxx':'--clangxx',
-    '-nidhugg':'--nidhugg',
-    '-no-partial-loop-purity':'--no-partial-loop-purity',
-    '-spin-assume':'--spin-assume',
-    '-no-dead-code-elim':'--no-dead-code-elim',
-    '-no-cast-elim':'--no-cast-elim',
-    '-unroll':'--unroll',
-}
+    }
+nidhuggcparamaliases.update({name[1:] : name for name in nidhuggcparams})
 
 # The name (absolute path) of the temporary directory where all
 # temporary files will be created.
@@ -106,7 +97,7 @@ def get_args():
         if 0 <= i and (arg[:i] in nidhuggcparamaliases):
             return nidhuggcparamaliases[arg[:i]]+arg[i:]
         return arg
-    fornidhuggcsingle=[p['name'] for p in nidhuggcparams if p['param'] == False]
+    fornidhuggcsingle=[p.name for p in nidhuggcparams.values() if p.param == False]
     hascompilerargs=False
     i = 1
     argc = len(sys.argv)
@@ -117,15 +108,15 @@ def get_args():
             A[arg]=''
         else:
             foundparam=False
-            for ap in nidhuggcparams:
-                if ap['param'] == False: continue
-                if arg.startswith(ap['name']+'='):
-                    A[ap['name']]=arg[len(ap['name'])+1:]
+            for ap in nidhuggcparams.values():
+                if ap.param == False: continue
+                if arg.startswith(ap.name+'='):
+                    A[ap.name]=arg[len(ap.name)+1:]
                     foundparam=True
                     break
-                elif arg == ap['name']:
-                    if i == argc: print_help(); raise Exception('Switch '+ap['name']+' requires an argument.')
-                    A[ap['name']]=sys.argv[i]
+                elif arg == ap.name:
+                    if i == argc: print_help(); raise Exception('Switch '+ap.name+' requires an argument.')
+                    A[ap.name]=sys.argv[i]
                     i = i+1 # Ignore the next argument
                     foundparam=True
                     break
@@ -175,11 +166,11 @@ def print_help():
     print(' - PROGRAM ARGUMENTS will be sent as arguments (argv) to the test case.')
     print('')
     print('NIDHUGGC OPTIONS:')
-    for p in nidhuggcparams:
-        if p['param'] == False:
-            print('  {0}\n{1}'.format(p['name'],help_indent(p['help'],6)))
+    for p in nidhuggcparams.values():
+        if p.param == False:
+            print('  {0}\n{1}'.format(p.name,help_indent(p.help,6)))
         else:
-            print('  {0}={1}\n{2}'.format(p['name'],p['param'],help_indent(p['help'],6)))
+            print('  {0}={1}\n{2}'.format(p.name,p.param,help_indent(p.help,6)))
 
 def print_version():
     subprocess.call([NIDHUGG,'-version'])
@@ -270,16 +261,12 @@ def main():
                 CLANGXX=argarg
             elif argname == '--nidhugg':
                 NIDHUGG=argarg
-            elif argname == '--no-partial-loop-purity':
-                transformargs.append(argname)
-            elif argname == '--spin-assume':
-                transformargs.append(argname)
-            elif argname == '--no-dead-code-elim':
-                transformargs.append(argname)
-            elif argname == '--no-cast-elim':
-                transformargs.append(argname)
-            elif argname == '--unroll':
-                transformargs.append('--unroll={0}'.format(argarg))
+            elif argname in nidhuggcparams \
+                 and nidhuggcparams[argname].transform:
+                if nidhuggcparams[argname].param:
+                    transformargs.append(argname+"="+argarg)
+                else:
+                    transformargs.append(argname)
         if '--version' in nidhuggcargs:
             # Wait with printing version until all arguments have been parsed.
             # Because the nidhugg binary may be specified after --version.

--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -281,7 +281,7 @@ def main():
         # Compile
         irfname = get_IR(nidhuggcargs,compilerargs)
         # Transform
-        irfname = transform(nidhuggcargs,transformargs,irfname)
+        irfname = transform(nidhuggcargs,transformargs+nidhuggargs,irfname)
         # Run stateless model-checker
         ret = run_nidhugg(nidhuggcargs,nidhuggargs,irfname)
         print('Total wall-clock time: {0:.2f} s'.format(time.time()-t0))

--- a/tests/litmus/test-nidhugg.py
+++ b/tests/litmus/test-nidhugg.py
@@ -143,7 +143,9 @@ def run_test(tst):
                                       stderr = subprocess.STDOUT).decode()
         lines = out.split("\n")
         res['tracecount'] = grep_count(lines, "Trace count: ") \
-            + grep_count(lines, "Assume-blocked trace count: ")
+            + grep_count(lines, "Assume-blocked trace count: ") \
+            + grep_count(lines, "Await-blocked trace count: ") \
+            + grep_count(lines, "Sleepset-blocked trace count: ")
         if out.find('No errors were detected') >= 0:
             res['allow'] = False
         else:

--- a/tests/smoke/C-tests/await_mud_opt.c
+++ b/tests/smoke/C-tests/await_mud_opt.c
@@ -1,0 +1,45 @@
+// nidhuggc: -sc -optimal
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <pthread.h>
+
+atomic_int y, z;
+
+static void *t(void *arg) {
+  y = 1;
+  return arg;
+}
+
+atomic_int x, w;
+static void *v(void *arg) {
+  /* Thread 2 of sub-program */
+  x = 1;
+  w = 1;
+  return arg;
+}
+
+static void *u(void *arg) {
+  if (y == 0) {
+    /* An entire program */
+    pthread_t vt;
+    pthread_create(&vt, NULL, v, NULL);
+    atomic_load(&x);
+    pthread_join(vt, NULL);
+    z = 1; /* With changes to the await preceeding some loads */
+    atomic_load(&w);
+    /* Ending with an unblock of the initial await */
+    z = 42;
+  }
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t tt, ut;
+  pthread_create(&tt, NULL, t, NULL);
+  pthread_create(&ut, NULL, u, NULL);
+
+  /* Load-await */
+  while (z != 42);
+
+  return 0;
+}

--- a/tests/smoke/C-tests/await_muddier_opt.c
+++ b/tests/smoke/C-tests/await_muddier_opt.c
@@ -1,0 +1,53 @@
+// nidhuggc: -sc -optimal
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <pthread.h>
+
+atomic_int y, z, å;
+
+static void *t(void *arg) {
+  y = 1;
+  return arg;
+}
+
+static void *s(void *arg) {
+  if (y == 0) {
+    å = 1;
+  }
+  return arg;
+}
+
+atomic_int x, w;
+static void *v(void *arg) {
+  /* Thread 2 of sub-program */
+  x = 1;
+  w = 1;
+  return arg;
+}
+
+static void *u(void *arg) {
+  if (å == 1) {
+    /* An entire program */
+    pthread_t vt;
+    pthread_create(&vt, NULL, v, NULL);
+    atomic_load(&x);
+    pthread_join(vt, NULL);
+    z = 1; /* With changes to the await preceeding some loads */
+    atomic_load(&w);
+    /* Ending with an unblock of the initial await */
+    z = 42;
+  }
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t tt, ut, st;
+  pthread_create(&tt, NULL, t, NULL);
+  pthread_create(&ut, NULL, u, NULL);
+  pthread_create(&st, NULL, s, NULL);
+
+  /* Load-await */
+  while (z != 42);
+
+  return 0;
+}

--- a/tests/smoke/C-tests/await_vs_indep_inc.c
+++ b/tests/smoke/C-tests/await_vs_indep_inc.c
@@ -1,0 +1,26 @@
+// nidhuggc: -sc -optimal -commute-rmws
+#include <pthread.h>
+#include <stdatomic.h>
+
+static void await(atomic_int *var, int value) {
+  while (*var != value);
+}
+
+atomic_int x;
+
+static void *p(void *arg) {
+  atomic_fetch_add(&x, (int)(intptr_t)arg);
+  return arg;
+};
+
+int main(int argc, char *argv[]) {
+  pthread_t pt[4];
+  pthread_create(pt+0, NULL, p, (void*)(intptr_t)2);
+  pthread_create(pt+1, NULL, p, (void*)(intptr_t)4);
+  pthread_create(pt+2, NULL, p, (void*)(intptr_t)3);
+  pthread_create(pt+3, NULL, p, (void*)(intptr_t)1);
+
+  await(&x, 7);
+
+  return 0;
+}

--- a/tests/smoke/C-tests/await_vs_indep_inc_2.c
+++ b/tests/smoke/C-tests/await_vs_indep_inc_2.c
@@ -1,0 +1,36 @@
+// nidhuggc: -sc -optimal -commute-rmws
+#include <pthread.h>
+#include <stdatomic.h>
+
+static void await(atomic_int *var, int value) {
+  while (*var != value);
+}
+
+atomic_int x;
+
+static void *p(void *arg) {
+  atomic_fetch_add(&x, (int)(intptr_t)arg);
+  return arg;
+};
+
+static void *q(void *arg) {
+  atomic_fetch_add(&x, 1);
+  atomic_fetch_add(&x, 1);
+  atomic_fetch_add(&x, 8);
+  return arg;
+}
+
+static void *r(void *arg) {
+  await(&x, 10);
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t pt[3], qt, rt;
+  pthread_create(pt+0, NULL, p, (void*)(intptr_t)3);
+  pthread_create(&qt,  NULL, q, NULL);
+  pthread_create(pt+1, NULL, p, (void*)(intptr_t)3);
+  pthread_create(pt+2, NULL, p, (void*)(intptr_t)4);
+  pthread_create(&rt,  NULL, r, NULL);
+
+  return 0;
+}

--- a/tests/smoke/C-tests/await_vs_indep_inc_easy.c
+++ b/tests/smoke/C-tests/await_vs_indep_inc_easy.c
@@ -1,0 +1,26 @@
+// nidhuggc: -sc -optimal -commute-rmws
+#include <pthread.h>
+#include <stdatomic.h>
+
+static void await(atomic_int *var, int value) {
+  while (*var != value);
+}
+
+atomic_int x;
+
+static void *p(void *arg) {
+  atomic_fetch_add(&x, (int)(intptr_t)arg);
+  return arg;
+};
+
+int main(int argc, char *argv[]) {
+  pthread_t pt[4];
+  pthread_create(pt+0, NULL, p, (void*)(intptr_t)2);
+  pthread_create(pt+1, NULL, p, (void*)(intptr_t)4);
+  pthread_create(pt+2, NULL, p, (void*)(intptr_t)1);
+  pthread_create(pt+3, NULL, p, (void*)(intptr_t)3);
+
+  await(&x, 7);
+
+  return 0;
+}

--- a/tests/smoke/C-tests/broken_mutual_exclusion_obs.c
+++ b/tests/smoke/C-tests/broken_mutual_exclusion_obs.c
@@ -1,0 +1,2 @@
+// nidhuggc: -sc -observers
+#include "broken_mutual_exclusion_opt.c"

--- a/tests/smoke/C-tests/broken_mutual_exclusion_opt.c
+++ b/tests/smoke/C-tests/broken_mutual_exclusion_opt.c
@@ -1,0 +1,26 @@
+// nidhuggc: -sc -optimal
+/*
+ * A too simplistic mutual exclusion protocol.
+ * Safety: Safe
+ * Traces: 1 + 2 blocked
+ */
+#include <pthread.h>
+#include <stdatomic.h>
+
+atomic_int x;
+
+static void *t(void *arg) {
+  while (x != 0);
+  x = 1;
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t tid;
+  pthread_create(&tid, NULL, t, NULL);
+
+  while(x != 0);
+  x = 1;
+
+  pthread_join(tid, NULL);
+}

--- a/tests/smoke/C-tests/dekker_lock_trylock_opt.c
+++ b/tests/smoke/C-tests/dekker_lock_trylock_opt.c
@@ -1,0 +1,31 @@
+// nidhuggc: -sc -optimal
+/* Lock vs trylock for a simplified dekker's mutex */
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+void __VERIFIER_assume(int);
+
+/* Dekker's mutex */
+atomic_int x = 0, y = 0;
+
+void *t(void *_arg){
+  // trylock
+  x = 1;
+  (void)y;
+  x = 0;
+
+  return NULL;
+}
+
+int main(int argc, char *argv[]){
+  pthread_t t1;
+  pthread_create(&t1,NULL,t,NULL);
+
+  // lock
+  y = 1;
+  __VERIFIER_assume(x == 0);
+  y = 0;
+
+  return 0;
+}

--- a/tests/smoke/C-tests/linuxrwlocks_repro.c
+++ b/tests/smoke/C-tests/linuxrwlocks_repro.c
@@ -1,0 +1,60 @@
+// nidhuggc: -sc -optimal -no-commute-rmws -unroll=4
+#include <stdlib.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+#define RW_LOCK_BIAS            0x00100000
+
+void __VERIFIER_assume(int);
+
+/* Reproduction case for await bug where nidhugg incorrectly thought
+ * that an assume-condition would be satisfied. */
+
+typedef union {
+  atomic_int lock;
+} rwlock_t;
+
+static inline void write_unlock(rwlock_t *rw) {
+  atomic_fetch_add(&rw->lock, RW_LOCK_BIAS);
+}
+
+rwlock_t lock;
+int shareddata;
+
+void *threadR(void *arg) {
+  int priorvalue = atomic_fetch_sub(&lock.lock, 1);
+  while (priorvalue <= 0) {
+    atomic_fetch_add(&lock.lock, 1);
+    while (atomic_load(&lock.lock) <= 0);
+    priorvalue = atomic_fetch_sub(&lock.lock, 1);
+  }
+  return NULL;
+}
+
+void *threadW1(void *arg) {
+  {
+    int priorvalue = atomic_exchange(&lock.lock, 0);
+    __VERIFIER_assume(!(priorvalue != RW_LOCK_BIAS));
+  }
+  write_unlock(&lock);
+  return NULL;
+}
+
+void *threadW2(void *arg) {
+  {
+    int priorvalue = atomic_fetch_sub(&lock.lock, RW_LOCK_BIAS);
+    __VERIFIER_assume(!(priorvalue != RW_LOCK_BIAS));
+  }
+  return NULL;
+}
+
+int main() {
+  pthread_t r, w1, w2;
+
+  atomic_init(&lock.lock, RW_LOCK_BIAS);
+  pthread_create(&w1, NULL, threadW1, NULL);
+  pthread_create(&w2, NULL, threadW2, NULL);
+  pthread_create(&r, NULL, threadR, NULL);
+
+  return 0;
+}

--- a/tests/smoke/C-tests/linuxrwlocks_repro_ifaa.c
+++ b/tests/smoke/C-tests/linuxrwlocks_repro_ifaa.c
@@ -1,0 +1,2 @@
+// nidhuggc: -sc -optimal -unroll=4
+#include "linuxrwlocks_repro.c"

--- a/tests/smoke/C-tests/parker_reproc_1_obs.c
+++ b/tests/smoke/C-tests/parker_reproc_1_obs.c
@@ -1,2 +1,2 @@
-// nidhuggc: -sc -observers
+// nidhuggc: -sc -observers -assume-await
 #include "parker_reproc_1_opt.c"

--- a/tests/smoke/C-tests/parker_reproc_1_obs.c
+++ b/tests/smoke/C-tests/parker_reproc_1_obs.c
@@ -1,0 +1,2 @@
+// nidhuggc: -sc -observers
+#include "parker_reproc_1_opt.c"

--- a/tests/smoke/C-tests/parker_reproc_1_opt.c
+++ b/tests/smoke/C-tests/parker_reproc_1_opt.c
@@ -1,0 +1,64 @@
+// nidhuggc: -sc -optimal
+/* Reproduction case for an implementation bug in RF-SMC for Await
+ * Based on a benchmark "parker", which is a recreation of the bug
+ * http://bugs.sun.com/view_bug.do?bug_id=6822370
+ *
+ * based on the description in
+ * https://blogs.oracle.com/dave/entry/a_race_in_locksupport_park
+ */
+
+void __VERIFIER_assume(int);
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <assert.h>
+
+/* Testing */
+atomic_int global_cond = 0; // Some global condition variable which the parker will wait for
+atomic_int unparker_finished = 0; // Flag indicating that the unparker thread has finished
+
+/* Small low-level mutex implementation */
+atomic_int x = 0, y = 0;
+
+/* The parker */
+atomic_int parker_counter = 0;
+atomic_int parker_cond = 0;
+
+/* Testing */
+
+void *parker(void *_arg){
+  x = 1;
+  if(y != 0){
+    return NULL;
+  }
+  parker_cond = 1;
+  x = 0;
+  parker_counter = 0;
+
+  return NULL;
+}
+
+void *unparker(void *_arg){
+  y = 1;
+  __VERIFIER_assume(x == 0);
+  int s = parker_counter;
+  parker_counter = 1;
+  y = 0;
+  if(s < 1){
+    parker_cond = 0;
+  }
+
+  global_cond = 1;
+
+  // Done
+  unparker_finished = 1;
+
+  return NULL;
+}
+
+int main(int argc, char *argv[]){
+  pthread_t t1;
+  pthread_create(&t1,NULL,parker,NULL);
+  unparker(NULL);
+  return 0;
+}

--- a/tests/smoke/C-tests/plptest_cmpxchg_member_reuse.c
+++ b/tests/smoke/C-tests/plptest_cmpxchg_member_reuse.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal
+// nidhuggc: -sc -optimal -no-assume-await
 
 #include <pthread.h>
 #include <stdatomic.h>

--- a/tests/smoke/C-tests/plptest_cmpxchg_reuse.c
+++ b/tests/smoke/C-tests/plptest_cmpxchg_reuse.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal
+// nidhuggc: -sc -optimal -no-assume-await
 
 #include <pthread.h>
 #include <stdatomic.h>

--- a/tests/smoke/C-tests/plptest_cmpxchg_reuse_await.c
+++ b/tests/smoke/C-tests/plptest_cmpxchg_reuse_await.c
@@ -1,0 +1,2 @@
+// nidhuggc: -sc -optimal
+#include "plptest_cmpxchg_reuse.c"

--- a/tests/smoke/C-tests/plptest_cmpxchg_reuse_reorder.c
+++ b/tests/smoke/C-tests/plptest_cmpxchg_reuse_reorder.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal
+// nidhuggc: -sc -optimal -no-assume-await
 
 #include <pthread.h>
 #include <stdatomic.h>

--- a/tests/smoke/C-tests/plptest_cmpxchg_weak_reuse.c
+++ b/tests/smoke/C-tests/plptest_cmpxchg_weak_reuse.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal
+// nidhuggc: -sc -optimal -no-assume-await
 
 #include <pthread.h>
 #include <stdatomic.h>

--- a/tests/smoke/C-tests/plptest_safestack_21.c
+++ b/tests/smoke/C-tests/plptest_safestack_21.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal -unroll=4
+// nidhuggc: -sc -optimal -no-assume-await -unroll=4
 /* Test based on the SafeStack benchmark from SCTBench. */
 
 #include <stdio.h>

--- a/tests/smoke/C-tests/plptest_safestack_21_easy.c
+++ b/tests/smoke/C-tests/plptest_safestack_21_easy.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal -unroll=4
+// nidhuggc: -sc -optimal -no-assume-await -unroll=4
 /* Test based on the SafeStack benchmark from SCTBench. */
 
 #include <stdio.h>

--- a/tests/smoke/C-tests/plptest_safestack_21_inlined.c
+++ b/tests/smoke/C-tests/plptest_safestack_21_inlined.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal -unroll=4
+// nidhuggc: -sc -optimal -no-assume-await -unroll=4
 /* Test based on the SafeStack benchmark from SCTBench. */
 
 #include <stdio.h>

--- a/tests/smoke/C-tests/plptest_safestack_21_inlined_xchg.c
+++ b/tests/smoke/C-tests/plptest_safestack_21_inlined_xchg.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal -unroll=3
+// nidhuggc: -sc -optimal -no-assume-await -unroll=3
 /* Test based on the SafeStack benchmark from SCTBench. */
 
 #include <stdio.h>

--- a/tests/smoke/C-tests/plptest_seqlock.c
+++ b/tests/smoke/C-tests/plptest_seqlock.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal
+// nidhuggc: -sc -optimal -no-assume-await
 
 #include <stdbool.h>
 #include <pthread.h>

--- a/tests/smoke/C-tests/plptest_treiber_pop_easier.c
+++ b/tests/smoke/C-tests/plptest_treiber_pop_easier.c
@@ -1,4 +1,4 @@
-// nidhuggc: -sc -optimal -unroll=4
+// nidhuggc: -sc -optimal -no-assume-await -unroll=4
 
 // #undef USE_ATOMIC_POINTER_TYPE
 #include "treiber_pop.inc"

--- a/tests/smoke/C-tests/revealed_write_opt.c
+++ b/tests/smoke/C-tests/revealed_write_opt.c
@@ -1,0 +1,24 @@
+// nidhuggc: -sc -optimal
+#include <stdio.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+atomic_uint x, y;
+extern void __VERIFIER_assume(int cond);
+
+static void *thread(void *arg) {
+  __VERIFIER_assume(x == 0);
+  y = 1;
+  return NULL;
+}
+
+int main() {
+    pthread_t t;
+    pthread_create(&t, NULL, thread, NULL);
+
+    int ret;
+    x = 1;
+    __VERIFIER_assume(y == 1);
+
+    pthread_join(t, NULL);
+}

--- a/tests/smoke/C-tests/revealed_write_reverse_opt.c
+++ b/tests/smoke/C-tests/revealed_write_reverse_opt.c
@@ -1,0 +1,26 @@
+// nidhuggc: -sc -optimal
+#include <stdio.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+atomic_uint mem[2];
+#define y mem[0]
+#define x mem[1]
+extern void __VERIFIER_assume(int cond);
+
+static void *thread(void *arg) {
+  __VERIFIER_assume(x == 0);
+  y = 1;
+  return NULL;
+}
+
+int main() {
+    pthread_t t;
+    pthread_create(&t, NULL, thread, NULL);
+
+    int ret;
+    x = 1;
+    __VERIFIER_assume(y == 1);
+
+    pthread_join(t, NULL);
+}

--- a/tests/smoke/C-tests/safestack_c21_21_opt.c
+++ b/tests/smoke/C-tests/safestack_c21_21_opt.c
@@ -1,2 +1,2 @@
-// nidhuggc: -sc -optimal -no-commute-rmws
+// nidhuggc: -sc -optimal -no-commute-rmws -no-assume-await
 #include "safestack_c21_21.c"

--- a/tests/smoke/C-tests/safestack_c21_21_opt_rmwcomm.c
+++ b/tests/smoke/C-tests/safestack_c21_21_opt_rmwcomm.c
@@ -1,2 +1,2 @@
-// nidhuggc: -sc -optimal
+// nidhuggc: -sc -optimal -no-assume-await
 #include "safestack_c21_21.c"

--- a/tests/smoke/C-tests/simplified_dekker_opt.c
+++ b/tests/smoke/C-tests/simplified_dekker_opt.c
@@ -1,0 +1,29 @@
+// nidhuggc: -sc -optimal
+/*
+ * Simplified dekker's mutex
+ * Safety: Safe
+ * Traces: 2
+ * Await-blocked traces: 1
+ */
+#include <pthread.h>
+#include <stdatomic.h>
+
+atomic_int x, y;
+
+static void *t(void *arg) {
+  x = 1;
+  while (y != 0);
+  x = 0;
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t tid;
+  pthread_create(&tid, NULL, t, NULL);
+
+  y = 1;
+  while(x != 0);
+  y = 0;
+
+  pthread_join(tid, NULL);
+}

--- a/tests/smoke/C-tests/xchgawait_test.inc
+++ b/tests/smoke/C-tests/xchgawait_test.inc
@@ -1,0 +1,58 @@
+#include <assert.h>
+#include <stdatomic.h>
+#include <pthread.h>
+#include <stdbool.h>
+
+atomic_int a = 0;
+
+#ifndef N
+#  warning "N was not defined, assuming 2"
+#  define N 2
+#endif
+
+#ifndef M
+#  warning "M was not defined, assuming N"
+#  define M N
+#endif
+
+#ifndef O
+#  warning "O was not defined, assuming M"
+#  define O M
+#endif
+
+void __VERIFIER_assume(bool truth);
+int __VERIFIER_xchg_await_aint(atomic_int *var, int value, int cond,
+			       int comp_operand);
+#define AWAIT_COND_NE 0b101
+
+void *tfa(void* arg) {
+#ifdef USE_ASSUME
+  int res = atomic_exchange(&a, (int)(intptr_t)arg);
+  __VERIFIER_assume(res != (int)(intptr_t)arg + 1);
+#else
+  __VERIFIER_xchg_await_aint(&a, (int)(intptr_t)arg,
+			     AWAIT_COND_NE, (int)(intptr_t)arg + 1);
+#endif
+}
+
+void *tl(void* arg) {
+  atomic_load(&a);
+}
+
+void *ts(void* arg) {
+  atomic_store(&a, (int)(intptr_t)arg + N);
+}
+
+int
+main(int argc, char **argv)
+{
+  pthread_t tfaid[N], tlid[M], tsid[O];
+
+  for (int i = 0; i < N || i < M || i < O; ++i) {
+    if (i < N) pthread_create(tfaid + i, NULL, tfa, (void*)(intptr_t)(i+1));
+    if (i < M) pthread_create(tlid + i, NULL, tl, (void*)(intptr_t)(i+1));
+    if (i < O) pthread_create(tsid + i, NULL, ts, (void*)(intptr_t)(i+1));
+  }
+
+  return 0;
+}

--- a/tests/smoke/C-tests/xchgawait_test1_opt.c
+++ b/tests/smoke/C-tests/xchgawait_test1_opt.c
@@ -1,0 +1,5 @@
+// nidhuggc: -sc -optimal
+#define N 1
+#define M 0
+#define O 0
+#include "xchgawait_test.inc"

--- a/tests/smoke/C-tests/xchgawait_test2_obs.c
+++ b/tests/smoke/C-tests/xchgawait_test2_obs.c
@@ -1,0 +1,2 @@
+// nidhuggc: -sc -observers
+#include "xchgawait_test2_opt.c"

--- a/tests/smoke/C-tests/xchgawait_test2_obs.c
+++ b/tests/smoke/C-tests/xchgawait_test2_obs.c
@@ -1,2 +1,2 @@
-// nidhuggc: -sc -observers
+// nidhuggc: -sc -observers -assume-await
 #include "xchgawait_test2_opt.c"

--- a/tests/smoke/C-tests/xchgawait_test2_opt.c
+++ b/tests/smoke/C-tests/xchgawait_test2_opt.c
@@ -1,0 +1,5 @@
+// nidhuggc: -sc -optimal
+#define N 2
+#define M 2
+#define O 2
+#include "xchgawait_test.inc"

--- a/tests/smoke/C-tests/xchgawait_test3_opt.c
+++ b/tests/smoke/C-tests/xchgawait_test3_opt.c
@@ -1,0 +1,5 @@
+// nidhuggc: -sc -optimal
+#define N 2
+#define M 1
+#define O 0
+#include "xchgawait_test.inc"

--- a/tests/smoke/C-tests/xchgawait_test4_opt.c
+++ b/tests/smoke/C-tests/xchgawait_test4_opt.c
@@ -1,0 +1,5 @@
+// nidhuggc: -sc -optimal
+#define N 2
+#define M 0
+#define O 1
+#include "xchgawait_test.inc"

--- a/tests/smoke/C-tests/xchgawait_vs_inc_chain_2_opt.c
+++ b/tests/smoke/C-tests/xchgawait_vs_inc_chain_2_opt.c
@@ -1,0 +1,57 @@
+// nidhuggc: -sc -optimal
+#include <assert.h>
+#include <stdatomic.h>
+#include <pthread.h>
+#include <stdbool.h>
+
+atomic_int a = 0;
+
+#ifndef N
+#  warning "N was not defined, assuming 3"
+#  define N 3
+#endif
+
+#ifndef STORE
+#  warning "STORE was not defined, assuming 0"
+#  define STORE 0
+#endif
+
+#ifndef SKIP
+#  warning "SKIP was not defined, assuming 2"
+#  define SKIP 2
+#endif
+
+void __VERIFIER_assume(bool truth);
+int __VERIFIER_xchg_await_aint(atomic_int *var, int value, int cond,
+			       int comp_operand);
+#define AWAIT_COND_NE 0b101
+#define AWAIT_COND_SLT 0b1100
+
+static int do_exchange_await(atomic_int *var, int value, int cond,
+			     int comp_operand) {
+#ifdef USE_ASSUME
+  int res = atomic_exchange(var, value);
+  assert(cond == AWAIT_COND_SLT);
+  bool comp_res = res < comp_operand;
+  __VERIFIER_assume(comp_res);
+#else
+  __VERIFIER_xchg_await_aint(var, value, cond, comp_operand);
+#endif
+}
+
+void *incrementer(void* arg) {
+  for (unsigned n = 0; n < N; ++n) {
+    atomic_fetch_add(&a, 1);
+  }
+}
+
+int
+main(int argc, char **argv)
+{
+  pthread_t it;
+  pthread_create(&it, NULL, incrementer, NULL);
+
+  do_exchange_await(&a, STORE, AWAIT_COND_SLT, SKIP);
+
+  return 0;
+}

--- a/tests/smoke/C-tests/xchgawait_vs_inc_chain_opt.c
+++ b/tests/smoke/C-tests/xchgawait_vs_inc_chain_opt.c
@@ -1,0 +1,56 @@
+// nidhuggc: -sc -optimal
+#include <assert.h>
+#include <stdatomic.h>
+#include <pthread.h>
+#include <stdbool.h>
+
+atomic_int a = 0;
+
+#ifndef N
+#  warning "N was not defined, assuming 3"
+#  define N 3
+#endif
+
+#ifndef STORE
+#  warning "STORE was not defined, assuming 0"
+#  define STORE 0
+#endif
+
+#ifndef SKIP
+#  warning "SKIP was not defined, assuming 2"
+#  define SKIP 2
+#endif
+
+void __VERIFIER_assume(bool truth);
+int __VERIFIER_xchg_await_aint(atomic_int *var, int value, int cond,
+			       int comp_operand);
+#define AWAIT_COND_NE 0b101
+
+static int do_exchange_await(atomic_int *var, int value, int cond,
+			     int comp_operand) {
+#ifdef USE_ASSUME
+  int res = atomic_exchange(var, value);
+  assert(cond == AWAIT_COND_NE);
+  bool comp_res = res != comp_operand;
+  __VERIFIER_assume(comp_res);
+#else
+  __VERIFIER_xchg_await_aint(var, value, cond, comp_operand);
+#endif
+}
+
+void *incrementer(void* arg) {
+  for (unsigned n = 0; n < N; ++n) {
+    atomic_fetch_add(&a, 1);
+  }
+}
+
+int
+main(int argc, char **argv)
+{
+  pthread_t it;
+  pthread_create(&it, NULL, incrementer, NULL);
+
+  do_exchange_await(&a, STORE, AWAIT_COND_NE, SKIP);
+
+  return 0;
+}

--- a/tests/smoke/C-tests/xchgawait_vs_inc_chain_reverse_blocked_opt.c
+++ b/tests/smoke/C-tests/xchgawait_vs_inc_chain_reverse_blocked_opt.c
@@ -1,0 +1,57 @@
+// nidhuggc: -sc -optimal
+#include <assert.h>
+#include <stdatomic.h>
+#include <pthread.h>
+#include <stdbool.h>
+
+atomic_int a = 0;
+
+#ifndef N
+#  warning "N was not defined, assuming 3"
+#  define N 3
+#endif
+
+#ifndef STORE
+#  warning "STORE was not defined, assuming 0"
+#  define STORE 0
+#endif
+
+#ifndef SKIP
+#  warning "SKIP was not defined, assuming 2"
+#  define SKIP 2
+#endif
+
+void __VERIFIER_assume(bool truth);
+int __VERIFIER_xchg_await_aint(atomic_int *var, int value, int cond,
+			       int comp_operand);
+#define AWAIT_COND_NE 0b101
+#define AWAIT_COND_SLT 0b1100
+
+static int do_exchange_await(atomic_int *var, int value, int cond,
+			     int comp_operand) {
+#ifdef USE_ASSUME
+  int res = atomic_exchange(var, value);
+  assert(cond == AWAIT_COND_SLT);
+  bool comp_res = res < comp_operand;
+  __VERIFIER_assume(comp_res);
+#else
+  __VERIFIER_xchg_await_aint(var, value, cond, comp_operand);
+#endif
+}
+
+void *awaiter(void* arg) {
+  do_exchange_await(&a, STORE, AWAIT_COND_SLT, SKIP);
+}
+
+int
+main(int argc, char **argv)
+{
+  pthread_t it;
+  pthread_create(&it, NULL, awaiter, NULL);
+
+  for (unsigned n = 0; n < N; ++n) {
+    atomic_fetch_add(&a, 1);
+  }
+
+  return 0;
+}

--- a/tests/smoke/C-tests/xchgawait_vs_inc_chain_reverse_opt.c
+++ b/tests/smoke/C-tests/xchgawait_vs_inc_chain_reverse_opt.c
@@ -1,0 +1,56 @@
+// nidhuggc: -sc -optimal
+#include <assert.h>
+#include <stdatomic.h>
+#include <pthread.h>
+#include <stdbool.h>
+
+atomic_int a = 0;
+
+#ifndef N
+#  warning "N was not defined, assuming 3"
+#  define N 3
+#endif
+
+#ifndef STORE
+#  warning "STORE was not defined, assuming 0"
+#  define STORE 0
+#endif
+
+#ifndef SKIP
+#  warning "SKIP was not defined, assuming 1"
+#  define SKIP 1
+#endif
+
+void __VERIFIER_assume(bool truth);
+int __VERIFIER_xchg_await_aint(atomic_int *var, int value, int cond,
+			       int comp_operand);
+#define AWAIT_COND_NE 0b101
+
+static int do_exchange_await(atomic_int *var, int value, int cond,
+			     int comp_operand) {
+#ifdef USE_ASSUME
+  int res = atomic_exchange(var, value);
+  assert(cond == AWAIT_COND_NE);
+  bool comp_res = res != comp_operand;
+  __VERIFIER_assume(comp_res);
+#else
+  __VERIFIER_xchg_await_aint(var, value, cond, comp_operand);
+#endif
+}
+
+void *awaiter(void* arg) {
+  do_exchange_await(&a, STORE, AWAIT_COND_NE, SKIP);
+}
+
+int
+main(int argc, char **argv)
+{
+  pthread_t it;
+  pthread_create(&it, NULL, awaiter, NULL);
+
+  for (unsigned n = 0; n < N; ++n) {
+    atomic_fetch_add(&a, 1);
+  }
+
+  return 0;
+}

--- a/tests/smoke/C-tests/xchgawait_vs_indep_inc.c
+++ b/tests/smoke/C-tests/xchgawait_vs_indep_inc.c
@@ -1,0 +1,43 @@
+// nidhuggc: -sc -optimal -commute-rmws
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+void __VERIFIER_assume(bool truth);
+int __VERIFIER_xchg_await_aint(atomic_int *var, int value, int cond,
+			       int comp_operand);
+#define AWAIT_COND_EQ 0b010
+
+static int do_exchange_await(atomic_int *var, int value, int cond,
+			     int comp_operand) {
+  int res;
+#ifdef USE_ASSUME
+  res = atomic_exchange(var, value);
+  assert(cond == AWAIT_COND_EQ);
+  bool comp_res = res == comp_operand;
+  __VERIFIER_assume(comp_res);
+#else
+  res = __VERIFIER_xchg_await_aint(var, value, cond, comp_operand);
+#endif
+  return res;
+}
+
+
+atomic_int x;
+
+static void *p(void *arg) {
+  atomic_fetch_add(&x, (int)(intptr_t)arg);
+  return arg;
+};
+
+int main(int argc, char *argv[]) {
+  pthread_t pt[4];
+  pthread_create(pt+0, NULL, p, (void*)(intptr_t)2);
+  pthread_create(pt+1, NULL, p, (void*)(intptr_t)4);
+  pthread_create(pt+2, NULL, p, (void*)(intptr_t)3);
+  pthread_create(pt+3, NULL, p, (void*)(intptr_t)1);
+
+  do_exchange_await(&x, 999, AWAIT_COND_EQ, 7);
+
+  return 0;
+}

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -110,7 +110,8 @@ plptest_seqlock Forbid : 7
 plptest_seqlock_harder Forbid : 5
 plptest_treiber_pop_easier Forbid : 27
 plptest_cmpxchg_reuse Forbid : 12
-plptest_cmpxchg_reuse_await Forbid : 10
+# Crashes at transform stage in CI images with LLVM <= 4
+#plptest_cmpxchg_reuse_await Forbid : 10
 plptest_cmpxchg_member_reuse Forbid : 12
 plptest_cmpxchg_weak_reuse Forbid : 12
 # These should not be transformed

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -61,36 +61,36 @@ safestack_c21_21_opt Forbid : 36
 unroll_double_loop Forbid : 1
 
 # Optimal/Observers with load-await
-simplified_dekker_opt Forbid : 5 # 3 with await
+simplified_dekker_opt Forbid : 3
 broken_mutual_exclusion_opt Forbid : 4
 broken_mutual_exclusion_obs Forbid : 3
-revealed_write_opt Forbid : 3 # 2 with await
-revealed_write_reverse_opt Forbid : 3 # 2 with await
-parker_reproc_1_opt Forbid : 8 # 7 with await
-parker_reproc_1_obs Forbid : 6 # 5 with await
-dekker_lock_trylock_opt Forbid : 6 # 4 with await
-await_mud_opt Forbid : 7 # 3 with await
-await_muddier_opt Forbid : 8 # 4 with await
-linuxrwlocks_repro Forbid : 26 # 17 with await
+revealed_write_opt Forbid : 2
+revealed_write_reverse_opt Forbid : 2
+parker_reproc_1_opt Forbid : 7
+parker_reproc_1_obs Forbid : 5
+dekker_lock_trylock_opt Forbid : 4
+await_mud_opt Forbid : 3
+await_muddier_opt Forbid : 4
+linuxrwlocks_repro Forbid : 17
 
 # Optimal/Observers with xchg-await. These use the xchgawait intrinsic
 # directly, and so does not yet run.
-#xchgawait_vs_inc_chain_opt Forbid : 3
-#xchgawait_vs_inc_chain_2_opt Forbid : 3
-#xchgawait_vs_inc_chain_reverse_opt Forbid : 3
-#xchgawait_vs_inc_chain_reverse_blocked_opt Forbid : 3
-#xchgawait_test1_opt Forbid : 1
-#xchgawait_test2_opt Forbid : 398
-#xchgawait_test2_obs Forbid : 369
-#xchgawait_test3_opt Forbid : 5
-#xchgawait_test4_opt Forbid : 4
+xchgawait_vs_inc_chain_opt Forbid : 3
+xchgawait_vs_inc_chain_2_opt Forbid : 3
+xchgawait_vs_inc_chain_reverse_opt Forbid : 3
+xchgawait_vs_inc_chain_reverse_blocked_opt Forbid : 3
+xchgawait_test1_opt Forbid : 1
+xchgawait_test2_opt Forbid : 398
+xchgawait_test2_obs Forbid : 369
+xchgawait_test3_opt Forbid : 5
+xchgawait_test4_opt Forbid : 4
 
 # Optimal/Observers with awaits and commuting rmws
-#xchgawait_vs_indep_inc Forbid : 3
-await_vs_indep_inc Forbid : 16 # 3 with await
-await_vs_indep_inc_2 Forbid : 32 # 3 with await
-await_vs_indep_inc_easy Forbid : 16 # 3 with await
-linuxrwlocks_repro_ifaa Forbid : 21 # 12 with await
+xchgawait_vs_indep_inc Forbid : 3
+await_vs_indep_inc Forbid : 3
+await_vs_indep_inc_2 Forbid : 3
+await_vs_indep_inc_easy Forbid : 3
+linuxrwlocks_repro_ifaa Forbid : 12
 
 # Optimal/Observers with commuting rmws
 safestack_c21_21_opt_rmwcomm Forbid : 21
@@ -100,17 +100,17 @@ safestack_c21_21_opt_rmwcomm Forbid : 21
 plptest_fully_pure Forbid : 2
 plptest_risk_of_segfault Forbid : 2
 plptest_spinloop Forbid : 2
-plptest_br_cond_not Forbid : 4 # 1 with await
+plptest_br_cond_not Forbid : 1
 plptest_safestack_21_easy Forbid : 11
 plptest_safestack_21_inlined Forbid : 11
 plptest_safestack_21_inlined_xchg Forbid : 11
 plptest_safestack_21 Forbid : 11
-plptest_burns_nobound Forbid : 16 # 9 with await
+plptest_burns_nobound Forbid : 9
 plptest_seqlock Forbid : 7
-plptest_seqlock_harder Forbid : 7 # 5 with await
+plptest_seqlock_harder Forbid : 5
 plptest_treiber_pop_easier Forbid : 27
 plptest_cmpxchg_reuse Forbid : 12
-plptest_cmpxchg_reuse_await Forbid : 12 # 10 with await
+plptest_cmpxchg_reuse_await Forbid : 10
 plptest_cmpxchg_member_reuse Forbid : 12
 plptest_cmpxchg_weak_reuse Forbid : 12
 # These should not be transformed

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -60,6 +60,38 @@ safestack_c21_21_opt Forbid : 36
 # Unroller
 unroll_double_loop Forbid : 1
 
+# Optimal/Observers with load-await
+simplified_dekker_opt Forbid : 5 # 3 with await
+broken_mutual_exclusion_opt Forbid : 4
+broken_mutual_exclusion_obs Forbid : 3
+revealed_write_opt Forbid : 3 # 2 with await
+revealed_write_reverse_opt Forbid : 3 # 2 with await
+parker_reproc_1_opt Forbid : 8 # 7 with await
+parker_reproc_1_obs Forbid : 6 # 5 with await
+dekker_lock_trylock_opt Forbid : 6 # 4 with await
+await_mud_opt Forbid : 7 # 3 with await
+await_muddier_opt Forbid : 8 # 4 with await
+linuxrwlocks_repro Forbid : 26 # 17 with await
+
+# Optimal/Observers with xchg-await. These use the xchgawait intrinsic
+# directly, and so does not yet run.
+#xchgawait_vs_inc_chain_opt Forbid : 3
+#xchgawait_vs_inc_chain_2_opt Forbid : 3
+#xchgawait_vs_inc_chain_reverse_opt Forbid : 3
+#xchgawait_vs_inc_chain_reverse_blocked_opt Forbid : 3
+#xchgawait_test1_opt Forbid : 1
+#xchgawait_test2_opt Forbid : 398
+#xchgawait_test2_obs Forbid : 369
+#xchgawait_test3_opt Forbid : 5
+#xchgawait_test4_opt Forbid : 4
+
+# Optimal/Observers with awaits and commuting rmws
+#xchgawait_vs_indep_inc Forbid : 3
+await_vs_indep_inc Forbid : 16 # 3 with await
+await_vs_indep_inc_2 Forbid : 32 # 3 with await
+await_vs_indep_inc_easy Forbid : 16 # 3 with await
+linuxrwlocks_repro_ifaa Forbid : 21 # 12 with await
+
 # Optimal/Observers with commuting rmws
 safestack_c21_21_opt_rmwcomm Forbid : 21
 
@@ -68,16 +100,17 @@ safestack_c21_21_opt_rmwcomm Forbid : 21
 plptest_fully_pure Forbid : 2
 plptest_risk_of_segfault Forbid : 2
 plptest_spinloop Forbid : 2
-plptest_br_cond_not Forbid : 4
+plptest_br_cond_not Forbid : 4 # 1 with await
 plptest_safestack_21_easy Forbid : 11
 plptest_safestack_21_inlined Forbid : 11
 plptest_safestack_21_inlined_xchg Forbid : 11
 plptest_safestack_21 Forbid : 11
-plptest_burns_nobound Forbid : 16
+plptest_burns_nobound Forbid : 16 # 9 with await
 plptest_seqlock Forbid : 7
-plptest_seqlock_harder Forbid : 7
+plptest_seqlock_harder Forbid : 7 # 5 with await
 plptest_treiber_pop_easier Forbid : 27
 plptest_cmpxchg_reuse Forbid : 12
+plptest_cmpxchg_reuse_await Forbid : 12 # 10 with await
 plptest_cmpxchg_member_reuse Forbid : 12
 plptest_cmpxchg_weak_reuse Forbid : 12
 # These should not be transformed


### PR DESCRIPTION
Add support for _await statements_ to Optimal-DPOR, optimising it as in an upcoming paper.

Assume-statements are automatically transformed to await-statements, yielding a program with less traces than the original