### PR TITLE
Optimal-DPOR: Optimise wakeup tree insertion

### DIFF
--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -2191,10 +2191,12 @@ void TSOTraceBuilder::race_detect_optimal
     enum { NO, RECURSE, NEXT } skip = NO;
     for (auto child_it = node.begin(); child_it != node.end(); ++child_it) {
       const sym_ty &child_sym = child_it.branch().sym;
+      bool found_match = false;
 
       for (auto vei = v.begin(); skip == NO && vei != v.end(); ++vei) {
         const Branch &ve = *vei;
         if (child_it.branch() == ve) {
+          found_match = true;
           if (child_sym != ve.sym) {
             /* This can happen due to observer effects. We must now make sure
              * ve.second->sym does not have any conflicts with any previous
@@ -2264,6 +2266,11 @@ void TSOTraceBuilder::race_detect_optimal
         }
       }
       if (skip == NEXT) { skip = NO; continue; }
+
+      if (!found_match) {
+        /* Insertion is not necessary in this case */
+        return;
+      }
 
       /* The child is compatible with v, recurse into it. */
       node = child_it.node();


### PR DESCRIPTION
During wakeup tree insertion, if a child is found which is independent of the wakeup sequence, insertion is not necessary and may be stopped.