### PR TITLE
Add some smoke tests where we find bugs

### DIFF
--- a/tests/smoke/C-tests/bug_after_1k.c
+++ b/tests/smoke/C-tests/bug_after_1k.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+#define N 6
+
+atomic_int x;
+
+void *p(void *arg) {
+  for (int i = 0; i < N; ++i) {
+    x = i;
+  }
+
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t t;
+  pthread_create(&t, NULL, p, NULL);
+
+  int n = x;
+  p(NULL);
+
+  assert(n != (N - 1));
+}

--- a/tests/smoke/C-tests/bug_after_1k_power.c
+++ b/tests/smoke/C-tests/bug_after_1k_power.c
@@ -1,0 +1,2 @@
+// nidhuggc: -power
+#include "bug_after_1k.c"

--- a/tests/smoke/C-tests/bug_after_1k_pso.c
+++ b/tests/smoke/C-tests/bug_after_1k_pso.c
@@ -1,0 +1,2 @@
+// nidhuggc: -pso
+#include "bug_after_1k.c"

--- a/tests/smoke/C-tests/bug_after_1k_rf.c
+++ b/tests/smoke/C-tests/bug_after_1k_rf.c
@@ -1,0 +1,26 @@
+// nidhuggc: -sc -rf
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+#define N 6
+
+atomic_int x;
+
+void *p(void *arg) {
+  for (int i = 0; i < N; ++i) {
+    atomic_exchange(&x, i);
+  }
+
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t t;
+  pthread_create(&t, NULL, p, NULL);
+
+  int n = x;
+  p(NULL);
+
+  assert(n != (N - 1));
+}

--- a/tests/smoke/C-tests/bug_after_1k_sc.c
+++ b/tests/smoke/C-tests/bug_after_1k_sc.c
@@ -1,0 +1,2 @@
+// nidhuggc: -sc
+#include "bug_after_1k.c"

--- a/tests/smoke/C-tests/trivial_bug.c
+++ b/tests/smoke/C-tests/trivial_bug.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+#define N 6
+
+atomic_int x;
+
+void *p(void *arg) {
+  for (int i = 0; i < N; ++i) {
+    x = i;
+  }
+
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t t;
+  pthread_create(&t, NULL, p, NULL);
+
+  x = 42;
+  p(NULL);
+
+  assert(0);
+}

--- a/tests/smoke/C-tests/trivial_bug_arm.c
+++ b/tests/smoke/C-tests/trivial_bug_arm.c
@@ -1,0 +1,2 @@
+// nidhuggc: -arm -keep-going
+#include "trivial_bug.c"

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -118,5 +118,12 @@ plptest_cmpxchg_weak_reuse Forbid : 12
 plptest_cmpxchg_reuse_reorder Forbid : 14
 plptest_leaky_counter Forbid : 4
 
+# Tests where we find some bugs
+trivial_bug_arm Allow : 1716
+bug_after_1k_sc Allow : 1716
+bug_after_1k_pso Allow : 1716
+bug_after_1k_rf Allow : 1716
+bug_after_1k_power Allow : 1716
+
 # Total number of traces: 1116
 # Total running time: 9.51 s


### PR DESCRIPTION
These will also serve as regression tests for reporting bugs with a
memory leak fix (a6d7f868), which is why they need to explore >1000
traces.