### PR TITLE
plp: Don't segfault on inline assembly

### DIFF
--- a/tests/smoke/C-tests/inlineasm.c
+++ b/tests/smoke/C-tests/inlineasm.c
@@ -1,0 +1,48 @@
+// nidhuggc: -tso
+#include <pthread.h>
+#include <stdint.h>
+#include <assert.h>
+
+#ifndef N
+#  define N 1
+#endif
+
+volatile int wants_to_enter[2];
+volatile int turn;
+volatile int critical_section;
+
+void *p(void *arg) {
+  intptr_t i = (intptr_t)arg;
+
+  for (unsigned times = 0; times < N; ++times) {
+    // lock
+    wants_to_enter[i] = 1;
+    __asm__ volatile ("mfence");
+    while (wants_to_enter[!i]) {
+      __asm__ volatile ("");
+      if (turn != i) {
+	wants_to_enter[i] = 0;
+	while (turn != i);
+	wants_to_enter[i] = 1;
+      }
+      // __asm__ volatile ("mfence"); // To be supported by plp, needed for N>1
+    }
+
+    // cs
+    critical_section = i;
+    __asm__ volatile ("");
+    assert(critical_section == i);
+
+    // unlock
+    turn = !i;
+    wants_to_enter[i] = 0;
+  }
+  return NULL;
+}
+
+int main() {
+  pthread_t ts[2];
+  pthread_create(ts+0, NULL, p, (void*)(intptr_t)0);
+  pthread_create(ts+1, NULL, p, (void*)(intptr_t)1);
+  return 0;
+}

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -118,6 +118,9 @@ plptest_cmpxchg_weak_reuse Forbid : 12
 plptest_cmpxchg_reuse_reorder Forbid : 14
 plptest_leaky_counter Forbid : 4
 
+# TSO test with inline assembly
+inlineasm Forbid : 12
+
 # Tests where we find some bugs
 trivial_bug_arm Allow : 1716
 bug_after_1k_sc Allow : 1716


### PR DESCRIPTION
Partial Loop Purity transformation segfaults if the input module contains inline assembly. Add support for this.

TODO:

- [x] Add a test case