### PR TITLE
Fix incorrectness bug in PLP regarding nested loops

### DIFF
--- a/src/PartialLoopPurityPass.cpp
+++ b/src/PartialLoopPurityPass.cpp
@@ -150,7 +150,7 @@ namespace {
       /* FCMP_TRUE and FCMP_FALSE are used as special values indicating
        * unconditional purity
        */
-      llvm::CmpInst::Predicate op = llvm::CmpInst::FCMP_TRUE;
+      llvm::CmpInst::Predicate op = llvm::CmpInst::FCMP_FALSE;
 
       BinaryPredicate() {}
       BinaryPredicate(bool static_value) {
@@ -387,7 +387,7 @@ namespace {
   };
 
   struct PurityCondition {
-    PurityCondition(BinaryPredLoc cond = true) {
+    PurityCondition(BinaryPredLoc cond = false) {
       if (!cond.is_false()) condset.insert_gt(cond);
     }
     PurityCondition(bool b){
@@ -818,7 +818,7 @@ namespace {
     }
 
     /* Generic implementation; no concern for branch conditions */
-    PurityCondition cond;
+    PurityCondition cond(true);
     for (const llvm::BasicBlock *s : llvm::successors(BB)) {
       cond &= getIn(L, conds, BB, s);
     }

--- a/tests/smoke/C-tests/plptest_nested.c
+++ b/tests/smoke/C-tests/plptest_nested.c
@@ -1,0 +1,32 @@
+#include <pthread.h>
+#include <stdatomic.h>
+
+#define NUM_DATA 8
+
+struct data {
+  int field;
+} data[NUM_DATA];
+
+atomic_int x;
+
+void *p(void *arg) {
+  x = NUM_DATA + 1;
+  return arg;
+}
+
+void problem() {
+  struct data *p = data;
+  for (int i = 0; i < NUM_DATA - 2; ++i) {
+    while (i > p->field) p++;
+    x = 42;
+  }
+}
+
+int main(int argc, char *argv[]) {
+  for (int i = 0; i < NUM_DATA; ++i) data[i].field = i;
+  problem();
+  pthread_t pt;
+  pthread_create(&pt, NULL, p, NULL);
+  return x;
+}
+

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -106,8 +106,8 @@ plptest_safestack_21_inlined Forbid : 11
 plptest_safestack_21_inlined_xchg Forbid : 11
 plptest_safestack_21 Forbid : 11
 plptest_burns_nobound Forbid : 9
-plptest_seqlock Forbid : 7
-plptest_seqlock_harder Forbid : 5
+plptest_seqlock Forbid : 9 // Expected failing. Correct: 7
+plptest_seqlock_harder Forbid : 9 // Expected failing. Correct: 5
 plptest_treiber_pop_easier Forbid : 27
 plptest_cmpxchg_reuse Forbid : 12
 # Crashes at transform stage in CI images with LLVM <= 4

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -117,6 +117,7 @@ plptest_cmpxchg_weak_reuse Forbid : 12
 # These should not be transformed
 plptest_cmpxchg_reuse_reorder Forbid : 14
 plptest_leaky_counter Forbid : 4
+plptest_nested Forbid : 2
 
 # TSO test with inline assembly
 inlineasm Forbid : 12


### PR DESCRIPTION
When loops are nested, PLP might incorrectly decide that running the inner loop forever is a pure path of the outer loop. Fix that.

Unfortunately, we regress our performance at seqlock for now, but at least we're correct.