### PR TITLE
Fix PLP regression on "mutex" benchmark

### DIFF
--- a/src/PartialLoopPurityPass.cpp
+++ b/src/PartialLoopPurityPass.cpp
@@ -1166,10 +1166,10 @@ namespace {
 
   bool recurseLoops(llvm::Loop *L, const std::function<bool(llvm::Loop*)> &f) {
     bool changed = false;
+    changed |= f(L);
     for (auto it = L->begin(); it != L->end(); ++it) {
       changed |= recurseLoops(*it, f);
     }
-    changed |= f(L);
     return changed;
   }
 

--- a/tests/smoke/C-tests/plptest_futex_mutex.c
+++ b/tests/smoke/C-tests/plptest_futex_mutex.c
@@ -1,0 +1,55 @@
+// nidhuggc: -std=gnu11 -- -sc -optimal
+#include <stdatomic.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <assert.h>
+
+static atomic_int mutex, signal;
+int value;
+
+#define compare_exchange(var, expected, desired) ({			\
+      int __expected = (expected);					\
+      atomic_compare_exchange_strong((var), &__expected, (desired)); })
+
+
+static void futex_wait(atomic_int *var, int if_equals) {
+  int old_sig = signal;
+  if (*var != if_equals) return;
+  while (signal == old_sig);
+}
+
+static int mutex_trylock(atomic_int *mutex) {
+  return compare_exchange(mutex, 0, 2);
+}
+
+static void mutex_lock(atomic_int *mutex) {
+  if (compare_exchange(mutex, 0, 1)) return;
+
+  while (1) {
+    compare_exchange(mutex, 1, 2);
+
+    futex_wait(mutex, 2);
+    if (mutex_trylock(mutex)) return;
+  }
+}
+
+static void mutex_unlock(atomic_int *mutex) {
+  if (compare_exchange(mutex, 1, 0)) return;
+  *mutex = 0;
+  signal++;
+}
+
+static void *p(void *arg) {
+  mutex_lock(&mutex);
+  value = (int)(intptr_t)arg;
+  assert(value == (int)(intptr_t)arg);
+  mutex_unlock(&mutex);
+  return arg;
+}
+
+int main(int argc, char *argv[]) {
+  pthread_t ts[2];
+  for (unsigned i = 0; i < 2; ++i) {
+    pthread_create(ts+i, NULL, p, (void*)(intptr_t)i);
+  }
+}

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -114,6 +114,7 @@ plptest_cmpxchg_reuse Forbid : 12
 #plptest_cmpxchg_reuse_await Forbid : 10
 plptest_cmpxchg_member_reuse Forbid : 12
 plptest_cmpxchg_weak_reuse Forbid : 12
+plptest_futex_mutex Forbid : 10
 # These should not be transformed
 plptest_cmpxchg_reuse_reorder Forbid : 14
 plptest_leaky_counter Forbid : 4


### PR DESCRIPTION
The extension of loop purity conditions to conjunctions caused our performance to regress on the mutex benchmark, due to a more complex purity condition being inferred for an outer loop and placed inside an inner loop, before the assume of the inner loops purity condition. As a result, the assume-await transformation got cold feet and no longer rewrote the load in the inner loop.

As a quick fix, insert assumes of inner purity conditions before the assumes of the outer ones.