### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/src/AddLibPass.h
+++ b/src/AddLibPass.h
@@ -37,13 +37,13 @@
 class AddLibPass : public llvm::ModulePass{
 public:
   static char ID;
-  AddLibPass() : llvm::ModulePass(ID) {};
+  AddLibPass() : llvm::ModulePass(ID) {}
   virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
   virtual bool runOnModule(llvm::Module &M);
 #ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF
-  virtual llvm::StringRef getPassName() const { return "AddLibPass"; };
+  virtual llvm::StringRef getPassName() const { return "AddLibPass"; }
 #else
-  virtual const char *getPassName() const { return "AddLibPass"; };
+  virtual const char *getPassName() const { return "AddLibPass"; }
 #endif
 protected:
   /* If a function named name is already defined in M, then return

--- a/src/AnyCallInst.h
+++ b/src/AnyCallInst.h
@@ -47,8 +47,8 @@ class AnyCallInst {
 
   operator bool() const { return (bool)CB; }
   bool operator==(std::nullptr_t) { return !CB; }
-  llvm::Instruction* operator &() { return CB; };
-  const llvm::Instruction* operator &() const { return CB; };
+  llvm::Instruction* operator &() { return CB; }
+  const llvm::Instruction* operator &() const { return CB; }
   llvm::Function *getCalledFunction() const { return CB->getCalledFunction(); }
   llvm::Value *getCalledOperand() const { return CB->getCalledOperand(); }
   auto arg_begin() { return CB->arg_begin(); }
@@ -67,8 +67,8 @@ class AnyCallInst {
 
   operator bool() const { return (bool)CS; }
   bool operator==(std::nullptr_t) { return !CS.getInstruction(); }
-  llvm::Instruction* operator &() { return CS.getInstruction(); };
-  const llvm::Instruction* operator &() const { return CS.getInstruction(); };
+  llvm::Instruction* operator &() { return CS.getInstruction(); }
+  const llvm::Instruction* operator &() const { return CS.getInstruction(); }
   llvm::Function *getCalledFunction() const { return CS.getCalledFunction(); }
   llvm::Value *getCalledOperand() const { return CS.getCalledValue(); }
   auto arg_begin() { return CS.arg_begin(); }

--- a/src/AssumeAwaitPass.h
+++ b/src/AssumeAwaitPass.h
@@ -31,7 +31,7 @@
 class AssumeAwaitPass final : public llvm::FunctionPass{
 public:
   static char ID;
-  AssumeAwaitPass() : llvm::FunctionPass(ID) {};
+  AssumeAwaitPass() : llvm::FunctionPass(ID) {}
   bool doInitialization(llvm::Module &M) override;
   void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
   bool runOnFunction(llvm::Function &F) override;

--- a/src/BVClock.h
+++ b/src/BVClock.h
@@ -37,11 +37,11 @@ class FBVClock;
 class BVClock{
 public:
   /* Create a vector clock where each clock is initialized to 0. */
-  BVClock(){};
-  BVClock(const BVClock &vc) : vec(vc.vec) {};
-  BVClock(BVClock &&vc) : vec(std::move(vc.vec)) {};
-  BVClock &operator=(const BVClock &vc) { vec = vc.vec; return *this; };
-  BVClock &operator=(BVClock &&vc) { vec = std::move(vc.vec); return *this; };
+  BVClock() {}
+  BVClock(const BVClock &vc) : vec(vc.vec) {}
+  BVClock(BVClock &&vc) : vec(std::move(vc.vec)) {}
+  BVClock &operator=(const BVClock &vc) { vec = vc.vec; return *this; }
+  BVClock &operator=(BVClock &&vc) { vec = std::move(vc.vec); return *this; }
   BVClock &operator=(FBVClock &vc);
   /* A vector clock v such that the clock of d in v takes the value
    * max((*this)[d],vc[d]) for all d.
@@ -56,7 +56,7 @@ public:
       vec[i] = vec[i] || vc.vec[i];
     }
     return *this;
-  };
+  }
   /* Assign this vector clock to (*this + vc). */
   BVClock &operator+=(BVClock &&vc);
   /* Assign this vector clock to (*this + vc). */
@@ -65,15 +65,15 @@ public:
   bool operator[](int d) const{
     if(d < int(vec.size())) return vec[d];
     return false;
-  };
+  }
   void set(int d) {
     if(d >= int(vec.size())){
       vec.resize(d+1,false);
     }
     vec[d] = true;
-  };
+  }
   /* Assign 0 to all clocks */
-  void clear() { vec.clear(); };
+  void clear() { vec.clear(); }
 
   /* *** Partial order comparisons ***
    *

--- a/src/CPid.h
+++ b/src/CPid.h
@@ -75,12 +75,12 @@ public:
   std::string to_string() const;
 
   /* Comparison implements a total order over CPids. */
-  bool operator==(const CPid &c) const { return compare(c) == 0; };
-  bool operator!=(const CPid &c) const { return compare(c) != 0; };
-  bool operator<(const CPid &c) const { return compare(c) < 0; };
-  bool operator<=(const CPid &c) const { return compare(c) <= 0; };
-  bool operator>(const CPid &c) const { return compare(c) > 0; };
-  bool operator>=(const CPid &c) const { return compare(c) >= 0; };
+  bool operator==(const CPid &c) const { return compare(c) == 0; }
+  bool operator!=(const CPid &c) const { return compare(c) != 0; }
+  bool operator<(const CPid &c) const { return compare(c) < 0; }
+  bool operator<=(const CPid &c) const { return compare(c) <= 0; }
+  bool operator>(const CPid &c) const { return compare(c) > 0; }
+  bool operator>=(const CPid &c) const { return compare(c) >= 0; }
 private:
   /* For a CPid <p0.p1.....pn> or <p0.p1.....pn/i>, the vector
    * proc_seq is [p1,...,pn]. */

--- a/src/CastElimPass.h
+++ b/src/CastElimPass.h
@@ -30,7 +30,7 @@
 class CastElimPass final : public llvm::FunctionPass{
 public:
   static char ID;
-  CastElimPass() : llvm::FunctionPass(ID) {};
+  CastElimPass() : llvm::FunctionPass(ID) {}
   void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
   bool runOnFunction(llvm::Function &F) override;
 #ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF

--- a/src/CheckModule.h
+++ b/src/CheckModule.h
@@ -42,11 +42,11 @@ namespace CheckModule {
 
   class CheckModuleError : public std::exception{
   public:
-    CheckModuleError(const std::string &msg) : msg("CheckModuleError: "+msg) {};
+    CheckModuleError(const std::string &msg) : msg("CheckModuleError: "+msg) {}
     CheckModuleError(const CheckModuleError&) = default;
-    virtual ~CheckModuleError() throw() {};
+    virtual ~CheckModuleError() throw() {}
     CheckModuleError &operator=(const CheckModuleError&) = default;
-    virtual const char *what() const throw() { return msg.c_str(); };
+    virtual const char *what() const throw() { return msg.c_str(); }
   private:
     std::string msg;
   };

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -106,7 +106,7 @@ public:
     sat_solver = SMTLIB;
 #endif
     argv.push_back(get_default_program_name());
-  };
+  }
   /* Read the switches given to the program by the user. Assign
    * configuration options accordingly.
    */

--- a/src/DPORDriver.h
+++ b/src/DPORDriver.h
@@ -73,7 +73,7 @@ private:
    * constructors and operators for all fields.
    */
   struct ResultBase {
-    ResultBase() : error_trace(nullptr) {};
+    ResultBase() : error_trace(nullptr) {}
     ~ResultBase(){
       if(all_traces.empty()){ // Otherwise error_trace also appears in all_traces.
         delete error_trace;
@@ -81,7 +81,7 @@ private:
       for(Trace *t : all_traces){
         delete t;
       }
-    };
+    }
     ResultBase(const ResultBase&) = delete;
     ResultBase(ResultBase &&other)
       : error_trace(std::exchange(other.error_trace, nullptr)),
@@ -118,7 +118,7 @@ public:
   public:
     /* Empty result */
     Result() : trace_count(0), sleepset_blocked_trace_count(0),
-               assume_blocked_trace_count(0), await_blocked_trace_count(0) {};
+               assume_blocked_trace_count(0), await_blocked_trace_count(0) {}
     /* The number of explored (non-sleepset-blocked) traces */
     uint64_t trace_count;
     /* The number of explored sleepset-blocked traces */
@@ -128,7 +128,7 @@ public:
     /* The number of explored assume-blocked traces */
     uint64_t await_blocked_trace_count;
 
-    bool has_errors() const { return error_trace && error_trace->has_errors(); };
+    bool has_errors() const { return error_trace && error_trace->has_errors(); }
   };
 
   /* Explore the traces of the given module, and return the result.

--- a/src/DeadCodeElimPass.h
+++ b/src/DeadCodeElimPass.h
@@ -32,7 +32,7 @@
 class DeadCodeElimPass final : public llvm::FunctionPass{
 public:
   static char ID;
-  DeadCodeElimPass() : llvm::FunctionPass(ID) {};
+  DeadCodeElimPass() : llvm::FunctionPass(ID) {}
   void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
   bool runOnFunction(llvm::Function &F) override;
 #ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF

--- a/src/DetCheckTraceBuilder.h
+++ b/src/DetCheckTraceBuilder.h
@@ -33,7 +33,7 @@
 class DetCheckTraceBuilder : public TraceBuilder {
 public:
   DetCheckTraceBuilder(const Configuration &conf = Configuration::default_conf);
-  virtual ~DetCheckTraceBuilder(){};
+  virtual ~DetCheckTraceBuilder() {}
   /* Execute a conditional branch instruction, branching on the value
    * cnd.
    *

--- a/src/ExternalFunctions.cpp
+++ b/src/ExternalFunctions.cpp
@@ -431,8 +431,9 @@ GenericValue lle_X_sprintf(FunctionType *FT,
             FmtBuf[Size-1] = 'l';
           }
           sprintf(Buffer, FmtBuf, Args[ArgNo++].IntVal.getZExtValue());
-        } else
+        } else {
           sprintf(Buffer, FmtBuf,uint32_t(Args[ArgNo++].IntVal.getZExtValue()));
+	}
         break;
       case 'e': case 'E': case 'g': case 'G': case 'f':
         sprintf(Buffer, FmtBuf, Args[ArgNo++].DoubleVal); break;

--- a/src/ExternalFunctions.cpp
+++ b/src/ExternalFunctions.cpp
@@ -433,7 +433,7 @@ GenericValue lle_X_sprintf(FunctionType *FT,
           sprintf(Buffer, FmtBuf, Args[ArgNo++].IntVal.getZExtValue());
         } else {
           sprintf(Buffer, FmtBuf,uint32_t(Args[ArgNo++].IntVal.getZExtValue()));
-	}
+        }
         break;
       case 'e': case 'E': case 'g': case 'G': case 'f':
         sprintf(Buffer, FmtBuf, Args[ArgNo++].DoubleVal); break;

--- a/src/FBVClock.h
+++ b/src/FBVClock.h
@@ -37,20 +37,20 @@ public:
   bool operator[](int i);
   FBVClock &operator+=(FBVClock &c);
   std::string to_string() const;
-  void invalidate() { cid = id = -1; };
+  void invalidate() { cid = id = -1; }
   /* Returns some natural number i such that for all j s.t. i<=j, it
    * holds that (*this)[j] == false.
    *
    * In particular i will be the number of clock elements currently
    * kept track of by this clock.
    */
-  int size() const { return sys[cid].idx_to_id.size(); };
+  int size() const { return sys[cid].idx_to_id.size(); }
 private:
   ClockSystemID cid;
   int id;
   int idx;
   struct ClockSystem{
-    ClockSystem() : allocated(true), time(0) {};
+    ClockSystem() : allocated(true), time(0) {}
     bool allocated;
     int time;
     std::vector<int> change_ts;
@@ -60,7 +60,7 @@ private:
   };
   static std::vector<ClockSystem> sys;
 
-  void update() const { update(cid,id); };
+  void update() const { update(cid,id); }
 
   static void update(ClockSystemID cid, int id);
   static void add_clock(std::vector<bool> &dst, std::vector<bool> &src);

--- a/src/GenMap.h
+++ b/src/GenMap.h
@@ -90,7 +90,7 @@ namespace gen {
       leaf(gen_type generation, const leaf &other)
         : value_container(other), next(other.next) {
         child::_generation = -1-generation;
-      };
+      }
       leaf(const leaf&) = delete;
       /* Always a leaf */
       child *next;
@@ -123,7 +123,7 @@ namespace gen {
       std::make_unique<_debug_refcount_type>(0);
     void assert_writable() const;
 #else
-    inline constexpr void assert_writable() const {};
+    inline constexpr void assert_writable() const {}
 #endif
 
     template<typename Fn>
@@ -131,7 +131,7 @@ namespace gen {
 
   public:
     /* Empty */
-    map(){};
+    map() {}
     /* Copy-on-write duplicate another map. It must not be modified after this. */
     explicit map(const map &);
     /* Steal another map. It will be empty after this. It is allowed to steal

--- a/src/GenVector.h
+++ b/src/GenVector.h
@@ -94,7 +94,7 @@ namespace gen {
         std::make_unique<_debug_refcount_type>(0);
     void assert_writable() const;
 #else
-    inline constexpr void assert_writable() const {};
+    inline constexpr void assert_writable() const {}
 #endif
     typedef T limb_type[limb_size];
     static_assert(sizeof(T) * limb_size == sizeof(limb_type), "Packing assumption");

--- a/src/IID.h
+++ b/src/IID.h
@@ -44,24 +44,24 @@ template<typename Pid_t>
 class IID{
 public:
   /* Create the null IID. */
-  IID() : idx(), pid() {};
+  IID() : idx(), pid() {}
   /* Create the IID (p,i). */
-  IID(const Pid_t &p, int i) : idx(i), pid(p) { assert(i >= 0); };
+  IID(const Pid_t &p, int i) : idx(i), pid(p) { assert(i >= 0); }
   IID(const IID&) = default;
   IID &operator=(const IID&) = default;
 
-  const Pid_t &get_pid() const { return pid; };
-  int get_index() const { return idx; };
+  const Pid_t &get_pid() const { return pid; }
+  int get_index() const { return idx; }
 
-  bool valid() const { return idx > 0; };
-  bool is_null() const { return idx == 0; };
+  bool valid() const { return idx > 0; }
+  bool is_null() const { return idx == 0; }
 
-  IID &operator++() { ++idx; return *this; };
-  IID operator++(int) { return IID(pid,idx++); };
-  IID &operator--() { assert(idx > 0); --idx; return *this; };
-  IID operator--(int) { assert(idx > 0); return IID(pid,idx--); };
-  IID operator+(int d) const { return IID(pid,idx+d); };
-  IID operator-(int d) const { return IID(pid,idx-d); };
+  IID &operator++() { ++idx; return *this; }
+  IID operator++(int) { return IID(pid,idx++); }
+  IID &operator--() { assert(idx > 0); --idx; return *this; }
+  IID operator--(int) { assert(idx > 0); return IID(pid,idx--); }
+  IID operator+(int d) const { return IID(pid,idx+d); }
+  IID operator-(int d) const { return IID(pid,idx-d); }
 
   /* Comparison:
    * The comparison operators implement a total order over IIDs.
@@ -70,14 +70,14 @@ public:
    */
   bool operator==(const IID &iid) const{
     return (idx == iid.idx && pid == iid.pid);
-  };
-  bool operator!=(const IID &iid) const { return !((*this) == iid); };
+  }
+  bool operator!=(const IID &iid) const { return !((*this) == iid); }
   bool operator<(const IID &iid) const {
     return (pid < iid.pid || (pid == iid.pid && idx < iid.idx));
-  };
-  bool operator<=(const IID &iid) const { return (*this) < iid || (*this) == iid; };
-  bool operator>(const IID &iid) const { return iid < (*this); };
-  bool operator>=(const IID &iid) const { return iid <= (*this); };
+  }
+  bool operator<=(const IID &iid) const { return (*this) < iid || (*this) == iid; }
+  bool operator>(const IID &iid) const { return iid < (*this); }
+  bool operator>=(const IID &iid) const { return iid <= (*this); }
 
   std::string to_string() const;
 private:

--- a/src/Interpreter.h
+++ b/src/Interpreter.h
@@ -120,7 +120,7 @@ protected:
   /* A Thread object keeps track of each running thread. */
   class Thread{
   public:
-    Thread() : AssumeBlocked(false), RandEng(42), pending_mutex_lock(0), pending_condvar_awake(0) {};
+    Thread() : AssumeBlocked(false), RandEng(42), pending_mutex_lock(0), pending_condvar_awake(0) {}
     /* The complex thread identifier of this thread. */
     CPid cpid;
     /* The runtime stack of executing code. The top of the stack is the
@@ -207,7 +207,7 @@ protected:
    */
   class PthreadMutex{
   public:
-    PthreadMutex() : owner(-1) {};
+    PthreadMutex() : owner(-1) {}
     /* The ID of the thread which currently holds the mutex object. If
      * no thread holds the mutex object, then owner is -1.
      */
@@ -216,10 +216,10 @@ protected:
      * pthread_mutex_lock) to acquire the mutex object.
      */
     VecSet<int> waiting;
-    bool isLocked() const { return 0 <= owner; };
-    bool isUnlocked() const { return owner < 0; };
-    void lock(int Proc) { assert(owner < 0); owner = Proc; };
-    void unlock() { owner = -1; };
+    bool isLocked() const { return 0 <= owner; }
+    bool isUnlocked() const { return owner < 0; }
+    void lock(int Proc) { assert(owner < 0); owner = Proc; }
+    void unlock() { owner = -1; }
   };
   /* The pthread mutex objects which have been initialized, and not
    * destroyed in this execution.
@@ -237,7 +237,7 @@ protected:
    *
    * This is the stack of the currently executing thread.
    */
-  std::vector<ExecutionContext> *ECStack() { return &Threads[CurrentThread].ECStack; };
+  std::vector<ExecutionContext> *ECStack() { return &Threads[CurrentThread].ECStack; }
 
   struct SymMBlockSize {
     SymMBlockSize(SymMBlock block, uint32_t size) :
@@ -298,13 +298,13 @@ public:
                                   bool AbortOnFailure = true) {
     // FIXME: not implemented.
     return 0;
-  };
+  }
 
   void *getPointerToNamedFunction(llvm::StringRef Name,
                                   bool AbortOnFailure = true) {
     // FIXME: not implemented.
     return 0;
-  };
+  }
 
   /* Returns true iff this trace contains any happens-before cycle.
    *
@@ -313,7 +313,7 @@ public:
    *
    * Call this method only at the end of execution.
    */
-  virtual bool checkForCycles() const { return TB.check_for_cycles(); };
+  virtual bool checkForCycles() const { return TB.check_for_cycles(); }
 
   /// runAtExitHandlers - Run any functions registered by the program's calls to
   /// atexit(3), which we intercept and store in AtExitHandlers.
@@ -386,7 +386,7 @@ public:
   virtual void visitExtractValueInst(ExtractValueInst &I);
   virtual void visitInsertValueInst(InsertValueInst &I);
 
-  virtual void visitFenceInst(FenceInst &I) { /* Do nothing */ };
+  virtual void visitFenceInst(FenceInst &I) { /* Do nothing */ }
   virtual void visitAtomicCmpXchgInst(AtomicCmpXchgInst &I);
   virtual void visitAtomicRMWInst(AtomicRMWInst &I);
   virtual void visitInlineAsm(llvm::CallInst &CI, const std::string &asmstr);
@@ -463,7 +463,7 @@ protected:  // Helper functions
    */
   virtual void runAux(int proc, int aux){
     llvm_unreachable("Interpreter::runAux: No auxiliary threads defined in basic Interpreter.");
-  };
+  }
 
   /* Creates a new thread with an empty stack and CPid cpid, and
    * returns its ID (index into Threads).
@@ -472,7 +472,7 @@ protected:  // Helper functions
     Threads.push_back(Thread());
     Threads.back().cpid = cpid;
     return int(Threads.size())-1;
-  };
+  }
 
   /* Set the return value from the current thread to Result of type
    * retTy.
@@ -543,7 +543,7 @@ protected:  // Helper functions
     SymData B(Ptr,alloc_size);
     StoreValueToMemory(Val,static_cast<GenericValue*>(B.get_block()),Ty);
     return B;
-  };
+  }
 
   /* Checks whether F refers to a valid function, returns true if so, or
    * false if not. If invalid also reports the error in TB and calls

--- a/src/LoopBoundPass.h
+++ b/src/LoopBoundPass.h
@@ -36,13 +36,13 @@ public:
         << "WARNING: Negative depth given to loop bounding pass. Defaulting to depth zero.\n";
       unroll_depth = 0;
     }
-  };
+  }
   virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
   virtual bool runOnLoop(llvm::Loop *L, llvm::LPPassManager &LPM);
 #ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF
-  virtual llvm::StringRef getPassName() const { return "LoopBoundingPass"; };
+  virtual llvm::StringRef getPassName() const { return "LoopBoundingPass"; }
 #else
-  virtual const char *getPassName() const { return "LoopBoundingPass"; };
+  virtual const char *getPassName() const { return "LoopBoundingPass"; }
 #endif
 protected:
   int unroll_depth;

--- a/src/MRef.h
+++ b/src/MRef.h
@@ -36,7 +36,7 @@ public:
   void *ref;
   /* The number of bytes in the sequence. */
   int size;
-  MRef(void *r, int sz) : ref(r), size(sz) { assert(0 < size); };
+  MRef(void *r, int sz) : ref(r), size(sz) { assert(0 < size); }
   /* Returns true iff all bytes in this MRef are also in mr. */
   bool subsetof(const MRef &mr) const;
   bool subsetof(const ConstMRef &mr) const;
@@ -49,13 +49,13 @@ public:
   bool includes(void const *bptr) const {
     return ref <= bptr &&
       bptr < (void const*)((uint8_t const*)ref + size);
-  };
-  bool operator==(const MRef &ml) const { return ref == ml.ref && size == ml.size; };
-  bool operator!=(const MRef &ml) const { return ref != ml.ref || size != ml.size; };
-  bool operator<(const MRef &ml) const { return ref < ml.ref || (ref == ml.ref && size < ml.size); };
-  bool operator<=(const MRef &ml) const { return ref <= ml.ref && (ref != ml.ref || size <= ml.size); };
-  bool operator>(const MRef &ml) const { return ref > ml.ref || (ref == ml.ref && size > ml.size); };
-  bool operator>=(const MRef &ml) const { return ref >=ml.ref && (ref != ml.ref || size >= ml.size); };
+  }
+  bool operator==(const MRef &ml) const { return ref == ml.ref && size == ml.size; }
+  bool operator!=(const MRef &ml) const { return ref != ml.ref || size != ml.size; }
+  bool operator<(const MRef &ml) const { return ref < ml.ref || (ref == ml.ref && size < ml.size); }
+  bool operator<=(const MRef &ml) const { return ref <= ml.ref && (ref != ml.ref || size <= ml.size); }
+  bool operator>(const MRef &ml) const { return ref > ml.ref || (ref == ml.ref && size > ml.size); }
+  bool operator>=(const MRef &ml) const { return ref >=ml.ref && (ref != ml.ref || size >= ml.size); }
 
   class const_iterator{
   public:
@@ -65,45 +65,45 @@ public:
     typedef void const ** pointer;
     typedef unsigned difference_type;
 
-    bool operator<(const const_iterator &it) const { return ptr < it.ptr; };
-    bool operator>(const const_iterator &it) const { return ptr > it.ptr; };
-    bool operator==(const const_iterator &it) const { return ptr == it.ptr; };
-    bool operator!=(const const_iterator &it) const { return ptr != it.ptr; };
-    bool operator<=(const const_iterator &it) const { return ptr <= it.ptr; };
-    bool operator>=(const const_iterator &it) const { return ptr >= it.ptr; };
+    bool operator<(const const_iterator &it) const { return ptr < it.ptr; }
+    bool operator>(const const_iterator &it) const { return ptr > it.ptr; }
+    bool operator==(const const_iterator &it) const { return ptr == it.ptr; }
+    bool operator!=(const const_iterator &it) const { return ptr != it.ptr; }
+    bool operator<=(const const_iterator &it) const { return ptr <= it.ptr; }
+    bool operator>=(const const_iterator &it) const { return ptr >= it.ptr; }
     const_iterator operator++(int) {
       const_iterator it = *this;
       ++ptr;
       return it;
-    };
+    }
     const_iterator &operator++() {
       ++ptr;
       return *this;
-    };
+    }
     const_iterator operator--(int) {
       const_iterator it = *this;
       --ptr;
       return it;
-    };
+    }
     const_iterator &operator--() {
       --ptr;
       return *this;
-    };
-    void const *operator*() const{ return ptr; };
+    }
+    void const *operator*() const{ return ptr; }
   private:
     const_iterator(void const *ref, int sz, int i) {
       assert(0 <= sz);
       assert(0 <= i);
       assert(i <= sz);
       ptr = (uint8_t const *)ref + i;
-    };
+    }
     friend class MRef;
     friend class ConstMRef;
     uint8_t const *ptr;
   };
 
-  const_iterator begin() const { return const_iterator(ref,size,0); };
-  const_iterator end() const { return const_iterator(ref,size,size); };
+  const_iterator begin() const { return const_iterator(ref,size,0); }
+  const_iterator end() const { return const_iterator(ref,size,size); }
 };
 
 /* A ConstMRef object is as an MRef object, but refers to const
@@ -114,8 +114,8 @@ public:
   const void *ref;
   /* The number of bytes in the sequence. */
   int size;
-  ConstMRef(const void *r, int sz) : ref(r), size(sz) { assert(0 < size); };
-  ConstMRef(const MRef &R) : ref(R.ref), size(R.size) { assert(0 < size); };
+  ConstMRef(const void *r, int sz) : ref(r), size(sz) { assert(0 < size); }
+  ConstMRef(const MRef &R) : ref(R.ref), size(R.size) { assert(0 < size); }
   /* Returns true iff all bytes in this ConstMRef are also in mr. */
   bool subsetof(const MRef &mr) const;
   bool subsetof(const ConstMRef &mr) const;
@@ -128,16 +128,16 @@ public:
   bool includes(void const *bptr) const {
     return ref <= bptr &&
       bptr < (void const*)((uint8_t const*)ref + size);
-  };
-  bool operator==(const ConstMRef &ml) const { return ref == ml.ref && size == ml.size; };
-  bool operator!=(const ConstMRef &ml) const { return ref != ml.ref || size != ml.size; };
-  bool operator<(const ConstMRef &ml) const { return ref < ml.ref || (ref == ml.ref && size < ml.size); };
-  bool operator<=(const ConstMRef &ml) const { return ref <= ml.ref && (ref != ml.ref || size <= ml.size); };
-  bool operator>(const ConstMRef &ml) const { return ref > ml.ref || (ref == ml.ref && size > ml.size); };
-  bool operator>=(const ConstMRef &ml) const { return ref >=ml.ref && (ref != ml.ref || size >= ml.size); };
+  }
+  bool operator==(const ConstMRef &ml) const { return ref == ml.ref && size == ml.size; }
+  bool operator!=(const ConstMRef &ml) const { return ref != ml.ref || size != ml.size; }
+  bool operator<(const ConstMRef &ml) const { return ref < ml.ref || (ref == ml.ref && size < ml.size); }
+  bool operator<=(const ConstMRef &ml) const { return ref <= ml.ref && (ref != ml.ref || size <= ml.size); }
+  bool operator>(const ConstMRef &ml) const { return ref > ml.ref || (ref == ml.ref && size > ml.size); }
+  bool operator>=(const ConstMRef &ml) const { return ref >=ml.ref && (ref != ml.ref || size >= ml.size); }
 
-  MRef::const_iterator begin() const { return MRef::const_iterator(ref,size,0); };
-  MRef::const_iterator end() const { return MRef::const_iterator(ref,size,size); };
+  MRef::const_iterator begin() const { return MRef::const_iterator(ref,size,0); }
+  MRef::const_iterator end() const { return MRef::const_iterator(ref,size,size); }
 };
 
 /* An MBlock object is an MRef ref together with a chunk of memory,
@@ -168,8 +168,8 @@ public:
   MBlock(const MBlock &B);
   MBlock &operator=(const MBlock &B);
   ~MBlock();
-  const MRef &get_ref() const { return ref; };
-  void *get_block() const { return block; };
+  const MRef &get_ref() const { return ref; }
+  void *get_block() const { return block; }
 };
 
 #endif

--- a/src/POWERARMTraceBuilder.h
+++ b/src/POWERARMTraceBuilder.h
@@ -53,8 +53,8 @@
 class POWERARMTraceBuilder : public TraceBuilder {
 public:
   POWERARMTraceBuilder(const Configuration &conf = Configuration::default_conf)
-    : TraceBuilder(conf) {};
-  virtual ~POWERARMTraceBuilder(){};
+    : TraceBuilder(conf) {}
+  virtual ~POWERARMTraceBuilder() {}
 
   /* Access identification:
    *
@@ -159,7 +159,7 @@ public:
 
   virtual bool check_for_cycles(){
     throw std::logic_error("POWERARMTraceBuilder::check_for_cycles: Not supported.");
-  };
+  }
   /* Call to spawn a new thread. proc should be the parent thread. The
    * identifier of the new thread is returned.
    */

--- a/src/POWERARMTraceBuilder_decl.h
+++ b/src/POWERARMTraceBuilder_decl.h
@@ -45,7 +45,7 @@ namespace PATB_impl{
     Access(Type tp)
       : type(tp), addr(0,1), data(addr,1),
         addr_known(false), data_known(false),
-        load_req(0) {};
+        load_req(0) {}
     /* Is this a store or a load? */
     Type type;
     /* The memory location accessed. */
@@ -65,7 +65,7 @@ namespace PATB_impl{
      */
     POWERARMTraceBuilder::ldreqfun_t *load_req;
     /* Is address and data (if a store) known? */
-    bool satisfied() const { return addr_known && (type != STORE || data_known); };
+    bool satisfied() const { return addr_known && (type != STORE || data_known); }
   };
 
   /* An Access corresponds to a number of byte-sized accesses. These
@@ -80,9 +80,9 @@ namespace PATB_impl{
       STORE
     };
     ByteAccess(Type tp, void *addr) // Load or store
-      : type(tp), addr(addr), data(0), data_known(false) {};
+      : type(tp), addr(addr), data(0), data_known(false) {}
     ByteAccess(void *addr, char data) // Store
-      : type(STORE), addr(addr), data(data), data_known(true) {};
+      : type(STORE), addr(addr), data(data), data_known(true) {}
     /* Is this a store or a load? */
     Type type;
     /* The address of the accessed byte. Guaranteed to be known. */
@@ -93,7 +93,7 @@ namespace PATB_impl{
     /* Is the data known? (Always false for loads.) */
     bool data_known;
     /* Is address and data (if a store) known? */
-    bool satisfied() const { return type != STORE || data_known; };
+    bool satisfied() const { return type != STORE || data_known; }
   };
 
   /* Rel objects are used to encode relations over events (such as co,
@@ -178,8 +178,8 @@ namespace PATB_impl{
      */
     class Choice{
     public:
-      Choice(int cp) : co_pos(cp) { assert(0 <= cp); }; // coherence choice
-      Choice(IID<int> src) : co_pos(-1), src(src) {}; // source choice
+      Choice(int cp) : co_pos(cp) { assert(0 <= cp); } // coherence choice
+      Choice(IID<int> src) : co_pos(-1), src(src) {} // source choice
       /* co_pos represents a position in the coherence order at the
        * time that this event is committed. The represented position
        * is the position such that the event is preceded by precisely
@@ -194,8 +194,8 @@ namespace PATB_impl{
        * value. Null if this event reads the initial value.
        */
       IID<int> src;
-      bool is_coherence_choice() const { return 0 <= co_pos; };
-      bool is_source_choice() const { return !is_coherence_choice(); };
+      bool is_coherence_choice() const { return 0 <= co_pos; }
+      bool is_source_choice() const { return !is_coherence_choice(); }
       bool operator<(const Choice &C) const{
         if(is_coherence_choice() != C.is_coherence_choice()){
           return is_coherence_choice();
@@ -205,14 +205,14 @@ namespace PATB_impl{
         }else{
           return src < C.src;
         }
-      };
+      }
       bool operator==(const Choice &C) const{
         if(is_coherence_choice()){
           return co_pos == C.co_pos; // Note: this also implies C.is_coherence_choice()
         }else{
           return !C.is_coherence_choice() && src == C.src;
         }
-      };
+      }
     };
     /* A vector containing the choices for each byte-access. The
      * choice choices[i] corresponds to the byte-access baccesses[i]
@@ -234,8 +234,8 @@ namespace PATB_impl{
     Relations rel;
     ExtraRel ER;
 
-    bool operator<(const Param &B) const { return choices < B.choices; };
-    bool operator==(const Param &B) const { return choices == B.choices; };
+    bool operator<(const Param &B) const { return choices < B.choices; }
+    bool operator==(const Param &B) const { return choices == B.choices; }
   };
 
   class Branch{
@@ -243,8 +243,8 @@ namespace PATB_impl{
     struct PEvent{
       IID<int> iid;
       Param param;
-      bool operator<(const PEvent &e) const { return iid < e.iid || (iid == e.iid && param < e.param); };
-      bool operator==(const PEvent &e) const { return iid == e.iid && param == e.param; };
+      bool operator<(const PEvent &e) const { return iid < e.iid || (iid == e.iid && param < e.param); }
+      bool operator==(const PEvent &e) const { return iid == e.iid && param == e.param; }
     };
     std::vector<PEvent> branch;
     /* param_type describes how e.recalc_params and
@@ -276,7 +276,7 @@ namespace PATB_impl{
         if(!(branch[i] == B.branch[i])) return branch[i] < B.branch[i];
       }
       return false;
-    };
+    }
     bool operator==(const Branch &B) const{
       if(param_type != B.param_type) return false;
       if(branch.size() != B.branch.size()) return false;
@@ -284,7 +284,7 @@ namespace PATB_impl{
         if(!(branch[i] == B.branch[i])) return false;
       }
       return true;
-    };
+    }
   };
 
   /* An event is some atomic operation performing memory accesses. */
@@ -307,7 +307,7 @@ namespace PATB_impl{
       accesses.resize(load_count+store_count,Access(Access::STORE));
       cb_bwd.set(clock_index);
       recalc_params = RECALC_NO;
-    };
+    }
     /* The identifier of this event. */
     IID<int> iid;
     /* Is the event committed? */
@@ -364,7 +364,7 @@ namespace PATB_impl{
     int unknown_data_count;
     bool all_addr_and_data_known() const {
       return unknown_addr_count == 0 && unknown_data_count == 0;
-    };
+    }
     /* The indices of the events which are address dependencies of
      * this event. I.e. i is in addr_deps iff IID(proc,i) is an
      * address dependency of this event, where proc ==
@@ -473,7 +473,7 @@ namespace PATB_impl{
      * branch_start and branch_end are -1.
      */
     int branch_start, branch_end;
-    bool in_locked_branch() const { return 0 <= branch_start; };
+    bool in_locked_branch() const { return 0 <= branch_start; }
     /* If this event is part of a locked branch, and branch_start is
      * the index in prefix of this event, then cur_branch is that
      * locked branch. Otherwise, cur_branch is undefined.
@@ -509,7 +509,7 @@ namespace PATB_impl{
         }
       }
       return ss.str();
-    };
+    }
 
     /* Returns true iff any access of this event has a load_req */
     bool has_load_req() const {
@@ -519,7 +519,7 @@ namespace PATB_impl{
         }
       }
       return false;
-    };
+    }
   };
 
   /* POWER specific version of PAEvent. */
@@ -529,7 +529,7 @@ namespace PATB_impl{
                const VecSet<int> addr_deps, const VecSet<int> &data_deps,
                int eieio_idx, int lwsync_idx, int sync_idx, int clk_idx)
       : PAEvent(load_count,store_count,addr_deps,data_deps,
-                eieio_idx,lwsync_idx,sync_idx,clk_idx) {};
+                eieio_idx,lwsync_idx,sync_idx,clk_idx) {}
   };
 
   /* ARM specific version of PAEvent. */
@@ -540,7 +540,7 @@ namespace PATB_impl{
              int eieio_idx, int lwsync_idx, int sync_idx,
              int clk_idx)
       : PAEvent(load_count,store_count,addr_deps,data_deps,
-                eieio_idx,lwsync_idx,sync_idx,clk_idx) {};
+                eieio_idx,lwsync_idx,sync_idx,clk_idx) {}
   };
 
   /* A Mem object contains information about the accesses to one
@@ -549,7 +549,7 @@ namespace PATB_impl{
   template<MemoryModel MemMod,CB_T CB,class Event>
   class Mem{
   public:
-    Mem() : loads(1) {};
+    Mem() : loads(1) {}
     /* The coherence vector contains all committed events that store
      * to this byte, in co-order.
      */
@@ -572,7 +572,7 @@ namespace PATB_impl{
    */
   class TraceRecorder : public Trace{
   public:
-    TraceRecorder(const std::vector<CPid> *cpids) : Trace({}), cpids(cpids), active(false) {};
+    TraceRecorder(const std::vector<CPid> *cpids) : Trace({}), cpids(cpids), active(false) {}
     /* Get the recorded trace representation. */
     std::string to_string(int ind = 0) const;
     /* Called when an event is committed by the TraceBuilder. */
@@ -589,15 +589,15 @@ namespace PATB_impl{
     /* Called when the ExecutionEngine detects an error. */
     void trace_register_error(int proc, const std::string &err_msg);
     /* Clear the recorded trace */
-    void clear() { lines.clear(); last_committed.consumed = true; fun_call_stack.clear(); };
-    void activate() { active = true; };
-    void deactivate() { active = false; };
-    bool is_active() const { return active; };
+    void clear() { lines.clear(); last_committed.consumed = true; fun_call_stack.clear(); }
+    void activate() { active = true; }
+    void deactivate() { active = false; }
+    bool is_active() const { return active; }
   private:
     const std::vector<CPid> *cpids;
     bool active;
     struct Committed{
-      Committed() : consumed(true) {};
+      Committed() : consumed(true) {}
       bool consumed;
       IID<int> iid;
       Param param;
@@ -660,7 +660,7 @@ namespace PATB_impl{
 
     virtual bool check_for_cycles(){
       throw std::logic_error("POWERARMTraceBuilder::check_for_cycles: Not supported.");
-    };
+    }
     virtual int spawn(int proc);
     virtual void abort();
     virtual Trace *get_trace() const;
@@ -728,7 +728,7 @@ namespace PATB_impl{
         : fch_count(0), committed_prefix(0), addr_known_prefix(0),
           last_fetched_eieio_idx(-1),
           last_fetched_lwsync_idx(-1),
-          last_fetched_sync_idx(-1) {};
+          last_fetched_sync_idx(-1) {}
       /* The number of events which have been fetched for this thread
        * in the current computation.
        */
@@ -788,17 +788,17 @@ namespace PATB_impl{
       int i = int(prefix.size())-1;
       while(0 <= i && prefix[i] != iid) --i;
       return i;
-    };
+    }
     Event &get_evt(const IID<int> &iid) {
       assert(0 <= iid.get_pid() && iid.get_pid() < int(fch.size()));
       assert(0 < iid.get_index() && iid.get_index() <= int(fch[iid.get_pid()].size()));
       return fch[iid.get_pid()][iid.get_index()-1];
-    };
+    }
     const Event &get_evt(const IID<int> &iid) const {
       assert(0 <= iid.get_pid() && iid.get_pid() < int(fch.size()));
       assert(0 < iid.get_index() && iid.get_index() <= int(fch[iid.get_pid()].size()));
       return fch[iid.get_pid()][iid.get_index()-1];
-    };
+    }
     /* Update the value of committed_prefix in threads[proc].
      */
     void update_committed_prefix(int proc);
@@ -1035,7 +1035,7 @@ namespace PATB_impl{
         pfx[iid.get_pid()] = iid.get_index();
       }
       return true;
-    };
+    }
 
     /* Replaces A with the set A union C, where C is the set of all
      * elements in B except the smallest element in B.
@@ -1056,8 +1056,8 @@ namespace PATB_impl{
             const std::vector<Error*> &errors,
             const std::string &str_rep = "",
             bool blocked = false)
-      : Trace(errors,blocked), events(events), cpids(cpids), string_rep(str_rep), conf(conf) {};
-    virtual ~PATrace(){};
+      : Trace(errors,blocked), events(events), cpids(cpids), string_rep(str_rep), conf(conf) {}
+    virtual ~PATrace(){}
     virtual std::string to_string(int ind = 0) const;
   protected:
     std::vector<Evt> events;

--- a/src/POWERExecution.cpp
+++ b/src/POWERExecution.cpp
@@ -1822,9 +1822,9 @@ llvm::GenericValue POWERInterpreter::executeBitCastInst(llvm::Value *SrcVal,
         Dest = TempDst;
       }
     } else {
-      if (DstElemTy->isDoubleTy())
+      if (DstElemTy->isDoubleTy()) {
         Dest.DoubleVal = TempDst.AggregateVal[0].IntVal.bitsToDouble();
-      else if (DstElemTy->isFloatTy()) {
+      } else if (DstElemTy->isFloatTy()) {
         Dest.FloatVal = TempDst.AggregateVal[0].IntVal.bitsToFloat();
       } else {
         Dest.IntVal = TempDst.AggregateVal[0].IntVal;
@@ -1847,15 +1847,15 @@ llvm::GenericValue POWERInterpreter::executeBitCastInst(llvm::Value *SrcVal,
         llvm_unreachable("Invalid BitCast");
       }
     } else if (DstTy->isFloatTy()) {
-      if (SrcTy->isIntegerTy())
+      if (SrcTy->isIntegerTy()) {
         Dest.FloatVal = Src.IntVal.bitsToFloat();
-      else {
+      } else {
         Dest.FloatVal = Src.FloatVal;
       }
     } else if (DstTy->isDoubleTy()) {
-      if (SrcTy->isIntegerTy())
+      if (SrcTy->isIntegerTy()) {
         Dest.DoubleVal = Src.IntVal.bitsToDouble();
-      else {
+      } else {
         Dest.DoubleVal = Src.DoubleVal;
       }
     } else {
@@ -2681,8 +2681,8 @@ std::shared_ptr<POWERInterpreter::FetchedInstruction> POWERInterpreter::fetch(ll
   }
 
   struct ExtraAccess{
-    ExtraAccess(int aid, MRef addr) : is_addr(true), aid(aid), addr(addr), data(addr,0) {};
-    ExtraAccess(int staid, MBlock data) : is_addr(false), aid(staid), addr(data.get_ref()), data(data) {};
+    ExtraAccess(int aid, MRef addr) : is_addr(true), aid(aid), addr(addr), data(addr,0) {}
+    ExtraAccess(int staid, MBlock data) : is_addr(false), aid(staid), addr(data.get_ref()), data(data) {}
     bool is_addr;
     int aid;
     MRef addr;

--- a/src/POWERInterpreter.h
+++ b/src/POWERInterpreter.h
@@ -119,17 +119,17 @@ public:
     FetchedInstruction(llvm::Instruction &I)
       : I(I),
         Committed(false), EventIndex(0),
-        IsBranch(false) {};
+        IsBranch(false) {}
     llvm::Instruction &I;
     struct Operand{
-      Operand() : Available(false), IsAddrOf(-1), IsDataOf(-1) {};
-      Operand(const llvm::GenericValue &Value) : Value(Value), Available(true), IsAddrOf(-1), IsDataOf(-1) {};
+      Operand() : Available(false), IsAddrOf(-1), IsDataOf(-1) {}
+      Operand(const llvm::GenericValue &Value) : Value(Value), Available(true), IsAddrOf(-1), IsDataOf(-1) {}
       llvm::GenericValue Value;
       bool Available;
       int IsAddrOf; // This operand holds the address for the IsAddrOf:th access of this instruction. -1 if not an address.
       int IsDataOf; // This operand holds the data for the IsDataOf:th access of this instruction. -1 if not data for an access.
-      bool isAddr() const { return 0 <= IsAddrOf; };
-      bool isData() const { return 0 <= IsDataOf; };
+      bool isAddr() const { return 0 <= IsAddrOf; }
+      bool isData() const { return 0 <= IsDataOf; }
     };
     std::vector<Operand> Operands;
     struct Dependent{
@@ -141,10 +141,10 @@ public:
       int op_idx;
       bool operator<(const Dependent &D) const {
         return FI < D.FI || (FI == D.FI && op_idx < D.op_idx);
-      };
+      }
       bool operator==(const Dependent &D) const{
         return FI == D.FI && op_idx == D.op_idx;
-      };
+      }
     };
     VecSet<Dependent> Dependents; // The instructions which depend on this instruction
     VecSet<int> AddrDeps;
@@ -153,13 +153,13 @@ public:
     bool Committed;
     int EventIndex; // 0 if not an event
     bool IsBranch; // This instruction should be interpreted as branching
-    bool isEvent() const { return EventIndex; };
+    bool isEvent() const { return EventIndex; }
     bool committable() const {
       for(unsigned i = 0; i < Operands.size(); ++i){
         if(!Operands[i].Available) return false;
       }
       return true;
-    };
+    }
   };
 
   // ExecutionContext struct - This struct represents one stack frame currently
@@ -205,13 +205,13 @@ private:
     Thread(const CPid &cpid)
       : cpid(cpid), status(new uint8_t()) {
       *status = 0;
-    };
+    }
     Thread(Thread &&T) noexcept
       : cpid(T.cpid), ECStack(std::move(T.ECStack)),
         CommittableEvents(T.CommittableEvents),
         CreateEvent(T.CreateEvent),
         Allocas(std::move(T.Allocas)),
-        status(T.status) {};
+        status(T.status) {}
     CPid cpid;
     // The runtime stack of executing code.  The top of the stack is the current
     // function record.
@@ -389,7 +389,7 @@ private:  // Helper functions
     assert(0 <= n && n < int(CurInstr->Operands.size()));
     assert(CurInstr->Operands[n].Available);
     return CurInstr->Operands[n].Value;
-  };
+  }
   llvm::GenericValue getConstantOperandValue(llvm::Value *V);
   llvm::GenericValue getConstantValue(llvm::Constant *V);
   llvm::GenericValue executeTruncInst(llvm::Value *SrcVal, const llvm::GenericValue &Src,
@@ -449,14 +449,14 @@ private:  // Helper functions
 #else
     return {Ptr,int(getDataLayout().getTypeStoreSize(Ty))};
 #endif
-  };
+  }
   ConstMRef GetConstMRef(void const *Ptr, llvm::Type *Ty){
 #ifdef LLVM_EXECUTIONENGINE_DATALAYOUT_PTR
     return {Ptr,int(getDataLayout()->getTypeStoreSize(Ty))};
 #else
     return {Ptr,int(getDataLayout().getTypeStoreSize(Ty))};
 #endif
-  };
+  }
   /* Get an MBlock associated with the location Ptr, and holding the
    * value Val of type Ty. The size of the memory location will be
    * that of Ty.
@@ -470,13 +470,13 @@ private:  // Helper functions
     MBlock B(GetMRef(Ptr,Ty),alloc_size);
     StoreValueToMemory(Val,static_cast<llvm::GenericValue*>(B.get_block()),Ty);
     return B;
-  };
+  }
 
   void commit();
   void commit(const std::shared_ptr<FetchedInstruction> &FI){
     CurInstr = FI;
     commit();
-  };
+  }
   void fetchAll();
   std::shared_ptr<FetchedInstruction> fetch(llvm::Instruction &I);
   /* When a thread terminates, it needs to execute a few extra

--- a/src/PSOInterpreter.h
+++ b/src/PSOInterpreter.h
@@ -68,7 +68,7 @@ protected:
    */
   class PendingStoreByte{
   public:
-    PendingStoreByte(const SymAddrSize &ml, uint8_t val) : ml(ml), val(val) {};
+    PendingStoreByte(const SymAddrSize &ml, uint8_t val) : ml(ml), val(val) {}
     /* ml is the complete memory location of the pending store of
      * which this byte is part.
      */
@@ -82,7 +82,7 @@ protected:
    */
   class PSOThread{
   public:
-    PSOThread() : awaiting_buffer_flush(BFL_NO), buffer_flush_ml({SymMBlock::Global(0),0},1) {};
+    PSOThread() : awaiting_buffer_flush(BFL_NO), buffer_flush_ml({SymMBlock::Global(0),0},1) {}
     /* aux_to_byte and byte_to_aux provide the mapping between
      * auxiliary thread indices and the first byte in the memory
      * locations for which that auxiliary thread is responsible.
@@ -132,7 +132,7 @@ protected:
       }
 #endif
       return store_buffers.empty();
-    };
+    }
   };
   /* All threads that are or have been running during this execution
    * have an entry in Threads, in the order in which they were

--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -1146,7 +1146,7 @@ bool PSOTraceBuilder::has_cycle(IID<IPid> *loc) const{
     int update;
     bool operator<(const stupd_t &su) const{
       return store < su.store;
-    };
+    }
   };
   /* stores[proc] is all store events of thread proc, ordered by
    * store index.
@@ -1167,7 +1167,7 @@ bool PSOTraceBuilder::has_cycle(IID<IPid> *loc) const{
   /* Attempt to replay computation under SC */
   struct thread_t {
     thread_t()
-      : pc(0), pfx_index(0), store_index(0), blocked(false), block_clock() {};
+      : pc(0), pfx_index(0), store_index(0), blocked(false), block_clock() {}
     int pc; // Current program counter
     int pfx_index; // Index into prefix
     int store_index; // Index into stores

--- a/src/PSOTraceBuilder.h
+++ b/src/PSOTraceBuilder.h
@@ -97,19 +97,19 @@ protected:
     SymAddr ml;
     bool operator<(const Access &a) const{
       return type < a.type || (type == a.type && ml < a.ml);
-    };
+    }
     bool operator==(const Access &a) const{
       return type == a.type && (type == NA || ml == a.ml);
-    };
-    Access() : type(NA), ml(SymMBlock::Global(0),0) {};
-    Access(Type t, SymAddr m) : type(t), ml(m) {};
+    }
+    Access() : type(NA), ml(SymMBlock::Global(0),0) {}
+    Access(Type t, SymAddr m) : type(t), ml(m) {}
   };
 
   /* A byte of a store pending in a store buffer. */
   class PendingStoreByte{
   public:
     PendingStoreByte(const SymAddrSize &ml, const VClock<IPid> &clk, const llvm::MDNode *md)
-      : ml(ml), clock(clk), last_rowe(-1), md(md) {};
+      : ml(ml), clock(clk), last_rowe(-1), md(md) {}
     /* The memory location that is being written to. */
     SymAddrSize ml;
     /* The clock of the store event which produced this store buffer
@@ -134,7 +134,7 @@ protected:
   public:
     Thread(int proc, const CPid &cpid, const VClock<IPid> &clk, IPid parent)
       : proc(proc), cpid(cpid), available(true), clock(clk), parent(parent),
-        sleeping(false), sleep_full_memory_conflict(false) {};
+        sleeping(false), sleep_full_memory_conflict(false) {}
     /* The process number used to communicate process identities with
      * the interpreter. For auxiliary threads, proc is the process
      * number of the corresponding real thread.
@@ -206,7 +206,7 @@ protected:
       }
 #endif
       return store_buffers.empty();
-    };
+    }
   };
   /* The threads in the current execution, in the order they were
    * created. Threads on even indexes are real, threads on odd indexes
@@ -241,7 +241,7 @@ protected:
    */
   class ByteInfo{
   public:
-    ByteInfo() : last_update(-1), last_update_ml({SymMBlock::Global(0),0},1) {};
+    ByteInfo() : last_update(-1), last_update_ml({SymMBlock::Global(0),0},1) {}
     /* An index into prefix, to the latest update that accessed this
      * byte. last_update == -1 if there has been no update to this
      * byte.
@@ -262,17 +262,17 @@ protected:
      */
     struct last_read_t {
       std::vector<int> v;
-      int operator[](int i) const { return (i < int(v.size()) ? v[i] : -1); };
+      int operator[](int i) const { return (i < int(v.size()) ? v[i] : -1); }
       int &operator[](int i) {
         if(int(v.size()) <= i){
           v.resize(i+1,-1);
         }
         return v[i];
-      };
-      std::vector<int>::iterator begin() { return v.begin(); };
-      std::vector<int>::const_iterator begin() const { return v.begin(); };
-      std::vector<int>::iterator end() { return v.end(); };
-      std::vector<int>::const_iterator end() const { return v.end(); };
+      }
+      std::vector<int>::iterator begin() { return v.begin(); }
+      std::vector<int>::const_iterator begin() const { return v.begin(); }
+      std::vector<int>::iterator end() { return v.end(); }
+      std::vector<int>::const_iterator end() const { return v.end(); }
     } last_read;
   };
   std::map<SymAddr,ByteInfo> mem;
@@ -285,8 +285,8 @@ protected:
    */
   class Mutex{
   public:
-    Mutex() : last_access(-1), last_lock(-1), locked(false) {};
-    Mutex(int lacc) : last_access(lacc), last_lock(-1), locked(false) {};
+    Mutex() : last_access(-1), last_lock(-1), locked(false) {}
+    Mutex(int lacc) : last_access(lacc), last_lock(-1), locked(false) {}
     int last_access;
     int last_lock;
     bool locked;
@@ -300,8 +300,8 @@ protected:
   /* A CondVar represents a pthread_cond_t object. */
   class CondVar{
   public:
-    CondVar() : last_signal(-1) {};
-    CondVar(int init_idx) : last_signal(init_idx) {};
+    CondVar() : last_signal(-1) {}
+    CondVar(int init_idx) : last_signal(init_idx) {}
     /* Index in prefix of the latest call to either of
      * pthread_cond_init, pthread_cond_signal, or
      * pthread_cond_broadcast for this condition variable.
@@ -333,10 +333,10 @@ protected:
     int alt;
     bool operator<(const Branch &b) const{
       return pid < b.pid || (pid == b.pid && alt < b.alt);
-    };
+    }
     bool operator==(const Branch &b) const{
       return pid == b.pid && alt == b.alt;
-    };
+    }
   };
 
   /* Information about a (short) sequence of consecutive events by the
@@ -349,7 +349,7 @@ protected:
     Event(const IID<IPid> &iid,
           const VClock<IPid> &clk)
       : iid(iid), origin_iid(iid), size(1), alt(0), md(0), clock(clk),
-        may_conflict(false), sleep_branch_trace_count(0) {};
+        may_conflict(false), sleep_branch_trace_count(0) {}
     /* The identifier for the first event in this event sequence. */
     IID<IPid> iid;
     /* The IID of the program instruction which is the origin of this
@@ -434,19 +434,19 @@ protected:
       p = threads[p].aux_to_ipid[aux];
     }
     return p;
-  };
+  }
 
   Event &curnode() {
     assert(0 <= prefix_idx);
     assert(prefix_idx < int(prefix.size()));
     return prefix[prefix_idx];
-  };
+  }
 
   const Event &curnode() const {
     assert(0 <= prefix_idx);
     assert(prefix_idx < int(prefix.size()));
     return prefix[prefix_idx];
-  };
+  }
 
   std::string iid_string(const Event &evt) const;
   void add_branch(int i, int j);

--- a/src/PartialLoopPurityPass.cpp
+++ b/src/PartialLoopPurityPass.cpp
@@ -452,7 +452,7 @@ namespace {
       for (BinaryPredicate &term : vec)
         res.addConjunct(std::move(term));
       return res;
-    };
+    }
 
     /* Earliest location that can support an insertion. */
     InsertionPoint insertion_point;
@@ -463,7 +463,7 @@ namespace {
       }
       bool operator()(const BinaryPredicate &a, const BinaryPredicate &b) const {
         return tupleit(a) < tupleit(b);
-      };
+      }
     };
 
     // &=, if you will
@@ -490,11 +490,11 @@ namespace {
       }
       conjuncts = std::move(newset);
       conjuncts.insert(cond);
-    };
+    }
     void addConjuncts(const VecSet<BinaryPredicate, LexicalCompare> &conds) {
       for(const BinaryPredicate &cond : conds)
         addConjunct(cond); /* Can be more efficient */
-    };
+    }
 
     VecSet<BinaryPredicate, LexicalCompare> conjuncts;
 
@@ -585,7 +585,7 @@ namespace {
       for (Elem &term : vec)
         res.addCond(std::move(term));
       return res;
-    };
+    }
 
   private:
     using Elem = ConjunctionLoc;
@@ -614,7 +614,7 @@ namespace {
       }
       bool operator()(const Elem &a, const Elem &b) const {
         return tupleit(a) < tupleit(b);
-      };
+      }
     };
 
 
@@ -627,11 +627,11 @@ namespace {
       }
       disjuncts = std::move(newset);
       disjuncts.insert(cond);
-    };
+    }
     void addConds(const VecSet<Elem, LexicalCompare> &conds) {
       for(const Elem &cond : conds)
         addCond(cond); /* Can be more efficient */
-    };
+    }
 
     static bool erase_greater(VecSet<Elem, LexicalCompare> &set,
                              const Elem &c) {

--- a/src/PartialLoopPurityPass.h
+++ b/src/PartialLoopPurityPass.h
@@ -28,7 +28,7 @@
 class PartialLoopPurityPass : public llvm::ModulePass{
 public:
   static char ID;
-  PartialLoopPurityPass() : llvm::ModulePass(ID) {};
+  PartialLoopPurityPass() : llvm::ModulePass(ID) {}
   void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
   bool runOnModule(llvm::Module &M) override;
 };

--- a/src/RFSCDecisionTree.h
+++ b/src/RFSCDecisionTree.h
@@ -226,8 +226,7 @@ public:
     : scheduler(std::move(scheduler)) {
     // Initiallize the work_queue with a "root"-node
     this->scheduler->enqueue(std::make_shared<DecisionNode>());
-  };
-
+  }
 
   /* Backtracks a TraceBuilders DecisionNode up to an ancestor with not yet
    * evaluated sibling. */

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -212,7 +212,7 @@ Trace *RFSCTraceBuilder::get_trace() const{
   for(unsigned i = 0; i < prefix.size(); ++i){
     cmp.push_back(IID<CPid>(threads[prefix[i].iid.get_pid()].cpid,prefix[i].iid.get_index()));
     cmp_md.push_from(prefix[i].md);
-  };
+  }
   for(unsigned i = 0; i < errors.size(); ++i){
     errs.push_back(errors[i]->clone());
   }
@@ -1485,7 +1485,9 @@ void RFSCTraceBuilder::add_event_to_graph(SaturatedGraph &g, unsigned i) const {
   if (is_load(i)) {
     if (is_store(i)) kind = SaturatedGraph::RMW;
     else kind = SaturatedGraph::LOAD;
-  } else if (is_store(i)) kind = SaturatedGraph::STORE;
+  } else {
+    if (is_store(i)) kind = SaturatedGraph::STORE;
+  }
   if (kind != SaturatedGraph::NONE) addr = get_addr(i).addr;
   Option<IID<IPid>> read_from;
   if (prefix[i].read_from && *prefix[i].read_from != -1)
@@ -1625,7 +1627,7 @@ std::vector<bool> RFSCTraceBuilder::causal_past(int decision) const {
     if (prefix[i].get_decision_depth() != -1 && prefix[i].get_decision_depth() <= decision) {
       causal_past_1(acc, i);
     }
-  };
+  }
   return acc;
 }
 

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -1482,12 +1482,10 @@ template<typename T, typename F> auto map(const std::vector<T> &vec, F f)
 void RFSCTraceBuilder::add_event_to_graph(SaturatedGraph &g, unsigned i) const {
   SaturatedGraph::EventKind kind = SaturatedGraph::NONE;
   SymAddr addr;
-  if (is_load(i)) {
-    if (is_store(i)) kind = SaturatedGraph::RMW;
-    else kind = SaturatedGraph::LOAD;
-  } else {
-    if (is_store(i)) kind = SaturatedGraph::STORE;
-  }
+  if (is_load(i))
+    kind = (is_store(i)) ? SaturatedGraph::RMW : SaturatedGraph::LOAD;
+  else if (is_store(i))
+    kind = SaturatedGraph::STORE;
   if (kind != SaturatedGraph::NONE) addr = get_addr(i).addr;
   Option<IID<IPid>> read_from;
   if (prefix[i].read_from && *prefix[i].read_from != -1)

--- a/src/RFSCTraceBuilder.h
+++ b/src/RFSCTraceBuilder.h
@@ -124,19 +124,19 @@ protected:
     const void *ml;
     bool operator<(const Access &a) const{
       return type < a.type || (type == a.type && ml < a.ml);
-    };
+    }
     bool operator==(const Access &a) const{
       return type == a.type && (type == NA || ml == a.ml);
-    };
-    Access() : type(NA), ml(0) {};
-    Access(Type t, const void *m) : type(t), ml(m) {};
+    }
+    Access() : type(NA), ml(0) {}
+    Access(Type t, const void *m) : type(t), ml(m) {}
   };
 
   /* Various information about a thread in the current execution. */
   class Thread{
   public:
     Thread(const CPid &cpid, int spawn_event)
-      : cpid(cpid), available(true), spawn_event(spawn_event) {};
+      : cpid(cpid), available(true), spawn_event(spawn_event) {}
     CPid cpid;
     /* Is the thread available for scheduling? */
     bool available;
@@ -177,7 +177,7 @@ protected:
    */
   class ByteInfo{
   public:
-    ByteInfo() : last_update(-1) {};
+    ByteInfo() : last_update(-1) {}
     /* An index into prefix, to the latest update that accessed this
      * byte. last_update == -1 if there has been no update to this
      * byte.
@@ -194,8 +194,8 @@ protected:
    */
   class Mutex{
   public:
-    Mutex() : last_access(-1), last_lock(-1), locked(false) {};
-    Mutex(int lacc) : last_access(lacc), last_lock(-1), locked(false) {};
+    Mutex() : last_access(-1), last_lock(-1), locked(false) {}
+    Mutex(int lacc) : last_access(lacc), last_lock(-1), locked(false) {}
     int last_access;
     int last_lock;
     bool locked;
@@ -209,8 +209,8 @@ protected:
   /* A CondVar represents a pthread_cond_t object. */
   class CondVar{
   public:
-    CondVar() : last_signal(-1) {};
-    CondVar(int init_idx) : last_signal(init_idx) {};
+    CondVar() : last_signal(-1) {}
+    CondVar(int init_idx) : last_signal(init_idx) {}
     /* Index in prefix of the latest call to either of
      * pthread_cond_init, pthread_cond_signal, or
      * pthread_cond_broadcast for this condition variable.
@@ -243,7 +243,7 @@ protected:
     Event(const IID<IPid> &iid, int alt = 0, SymEv sym = {})
       : alt(0), size(1), pinned(false),
         iid(iid), origin_iid(iid), md(0), clock(), may_conflict(false),
-        sym(std::move(sym)), sleep_branch_trace_count(0), decision_depth(-1) {};
+        sym(std::move(sym)), sleep_branch_trace_count(0), decision_depth(-1) {}
     /* Some instructions may execute in several alternative ways
      * nondeterministically. (E.g. malloc may succeed or fail
      * nondeterministically if Configuration::malloy_may_fail is set.)
@@ -300,20 +300,20 @@ protected:
 
     int get_decision_depth() const {
       return decision_depth;
-    };
+    }
     void set_decision(std::shared_ptr<DecisionNode> decision) {
       decision_ptr = std::move(decision);
       decision_depth = decision_ptr ? decision_ptr->depth : -1;
-    };
+    }
     void set_branch_decision(int decision, const std::shared_ptr<DecisionNode> &work_item) {
       decision_depth = decision;
       decision_ptr = decision == -1 ? nullptr : RFSCDecisionTree::find_ancestor(work_item, decision_depth);
-    };
+    }
 
     void decision_swap(Event &e) {
       std::swap(decision_ptr, e.decision_ptr);
       std::swap(decision_depth, e.decision_depth);
-    };
+    }
 
   private:
     /* The hierarchical order of events. */
@@ -365,19 +365,19 @@ protected:
     assert(aux == -1);
     assert(proc < int(threads.size()));
     return proc;
-  };
+  }
 
   Event &curev() {
     assert(0 <= prefix_idx);
     assert(prefix_idx < int(prefix.size()));
     return prefix[prefix_idx];
-  };
+  }
 
   const Event &curev() const {
     assert(0 <= prefix_idx);
     assert(prefix_idx < int(prefix.size()));
     return prefix[prefix_idx];
-  };
+  }
 
   /* Perform the logic of atomic_store(), aside from recording a
    * symbolic event.

--- a/src/RFSCUnfoldingTree.h
+++ b/src/RFSCUnfoldingTree.h
@@ -45,7 +45,7 @@
  */
 class RFSCUnfoldingTree final {
 public:
-  RFSCUnfoldingTree() {};
+  RFSCUnfoldingTree() {}
 
   struct UnfoldingNode;
   typedef std::shared_ptr<const UnfoldingNode> NodePtr;
@@ -65,7 +65,7 @@ public:
      * RFSCUnfoldingTree::find_unfolding_node() */
     UnfoldingNode(NodePtr parent, NodePtr read_from)
       : parent(std::move(parent)), read_from(std::move(read_from)),
-        seqno(++RFSCUnfoldingTree::unf_ctr) {};
+        seqno(++RFSCUnfoldingTree::unf_ctr) {}
   private:
     /* The children of this node. Used by get_or_create. */
     mutable UnfoldingNodeChildren children;

--- a/src/SExpr.h
+++ b/src/SExpr.h
@@ -58,7 +58,7 @@ public:
         std::vector<SExpr> elems;
     };
 
-    Kind kind() const { return Kind(variant.which()); };
+    Kind kind() const { return Kind(variant.which()); }
     const Token &token() const { return boost::get<Token>(variant); }
     const Int &num() const { return boost::get<Int>(variant); }
           List &list()       { return boost::get<List>(variant); }

--- a/src/SatSolver.h
+++ b/src/SatSolver.h
@@ -25,7 +25,7 @@
 
 class SatSolver {
 public:
-  virtual ~SatSolver() {};
+  virtual ~SatSolver() {}
   /* Clear all variables and constraints. */
   virtual void reset() = 0;
   /* Allocate variables [0,count). Must not be called twice without an

--- a/src/SaturatedGraph.h
+++ b/src/SaturatedGraph.h
@@ -81,7 +81,7 @@ public:
      * queue data structures */
     assert(wq_empty());
     return SaturatedGraph(*this);
-  };
+  }
 
 private:
   explicit SaturatedGraph(const SaturatedGraph &other) = default;
@@ -98,7 +98,7 @@ private:
           Option<ID> po_predecessor)
       : iid(iid), ext_id(ext_id), is_load(is_load), is_store(is_store), addr(addr),
         read_from(read_from), readers(std::move(readers)),
-        po_predecessor(po_predecessor) {};
+        po_predecessor(po_predecessor) {}
     IID<Pid> iid;
     ExtID ext_id;
     bool is_load;
@@ -149,7 +149,7 @@ private:
 #ifndef NDEBUG
   void check_graph_consistency() const;
 #else
-  void check_graph_consistency() const {};
+  void check_graph_consistency() const {}
 #endif
 
   std::deque<ID> wq_queue;

--- a/src/SpinAssumePass.h
+++ b/src/SpinAssumePass.h
@@ -35,7 +35,7 @@
 class DeclareAssumePass : public llvm::ModulePass {
 public:
   static char ID;
-  DeclareAssumePass() : llvm::ModulePass(ID) {};
+  DeclareAssumePass() : llvm::ModulePass(ID) {}
   virtual bool runOnModule(llvm::Module &M);
 };
 
@@ -61,13 +61,13 @@ public:
 class SpinAssumePass : public llvm::LoopPass{
 public:
   static char ID;
-  SpinAssumePass() : llvm::LoopPass(ID) {};
+  SpinAssumePass() : llvm::LoopPass(ID) {}
   virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
   virtual bool runOnLoop(llvm::Loop *L, llvm::LPPassManager &LPM);
 #ifdef LLVM_PASS_GETPASSNAME_IS_STRINGREF
-  virtual llvm::StringRef getPassName() const { return "SpinAssumePass"; };
+  virtual llvm::StringRef getPassName() const { return "SpinAssumePass"; }
 #else
-  virtual const char *getPassName() const { return "SpinAssumePass"; };
+  virtual const char *getPassName() const { return "SpinAssumePass"; }
 #endif
 protected:
   bool is_spin(const llvm::Loop *l) const;

--- a/src/SymAddr.h
+++ b/src/SymAddr.h
@@ -47,8 +47,8 @@ struct SymMBlock {
     return SymMBlock(pid, no);
   }
 
-  bool operator==(const SymMBlock &o) const { return pid == o.pid && alloc == o.alloc; };
-  bool operator!=(const SymMBlock &o) const { return !(*this == o); };
+  bool operator==(const SymMBlock &o) const { return pid == o.pid && alloc == o.alloc; }
+  bool operator!=(const SymMBlock &o) const { return !(*this == o); }
   bool operator<=(const SymMBlock &o) const {
     return pid < o.pid || (pid == o.pid && alloc <= o.alloc);
   }
@@ -92,8 +92,8 @@ public:
   SymMBlock block;
   uint32_t offset;
 
-  bool operator==(const SymAddr &o) const { return block == o.block && offset == o.offset; };
-  bool operator!=(const SymAddr &o) const { return !(*this == o); };
+  bool operator==(const SymAddr &o) const { return block == o.block && offset == o.offset; }
+  bool operator!=(const SymAddr &o) const { return !(*this == o); }
   bool operator<=(const SymAddr &o) const {
     return block < o.block || (block == o.block && offset <= o.offset);
   }
@@ -104,34 +104,34 @@ public:
     SymAddr copy = *this;
     ++offset;
     return copy;
-  };
+  }
   SymAddr &operator++() {
     ++offset;
     return *this;
-  };
+  }
   SymAddr operator--(int) {
     SymAddr copy = *this;
     --offset;
     return copy;
-  };
+  }
   SymAddr &operator--() {
     --offset;
     return *this;
-  };
+  }
   SymAddr operator+(intptr_t addend) const {
     SymAddr copy = *this;
     copy.offset += addend;
     return copy;
-  };
+  }
   SymAddr operator-(intptr_t addend) const {
     SymAddr copy = *this;
     copy.offset -= addend;
     return copy;
-  };
+  }
   intptr_t operator-(const SymAddr &other) const {
     assert(block == other.block);
     return offset - other.offset;
-  };
+  }
 
   std::string to_string(std::function<std::string(int)> pid_str
                         = (std::string(&)(int))std::to_string) const;
@@ -169,8 +169,8 @@ public:
       && (addr.offset + size) > sa.offset;
   }
 
-  bool operator==(const SymAddrSize &o) const { return addr == o.addr && size == o.size; };
-  bool operator!=(const SymAddrSize &o) const { return !(*this == o); };
+  bool operator==(const SymAddrSize &o) const { return addr == o.addr && size == o.size; }
+  bool operator!=(const SymAddrSize &o) const { return !(*this == o); }
   bool operator<(const SymAddrSize &o) const {
     return addr < o.addr || (addr == o.addr && size < o.size);
   }
@@ -185,31 +185,31 @@ public:
     typedef SymAddr& reference;
     typedef SymAddr* pointer;
     typedef unsigned difference_type;
-    bool operator<(const iterator &it) const { return addr < it.addr; };
-    bool operator>(const iterator &it) const { return addr > it.addr; };
-    bool operator==(const iterator &it) const { return addr == it.addr; };
-    bool operator!=(const iterator &it) const { return addr != it.addr; };
-    bool operator<=(const iterator &it) const { return addr <= it.addr; };
-    bool operator>=(const iterator &it) const { return addr >= it.addr; };
+    bool operator<(const iterator &it) const { return addr < it.addr; }
+    bool operator>(const iterator &it) const { return addr > it.addr; }
+    bool operator==(const iterator &it) const { return addr == it.addr; }
+    bool operator!=(const iterator &it) const { return addr != it.addr; }
+    bool operator<=(const iterator &it) const { return addr <= it.addr; }
+    bool operator>=(const iterator &it) const { return addr >= it.addr; }
     iterator operator++(int) {
       iterator it = *this;
       ++addr;
       return it;
-    };
+    }
     iterator &operator++() {
       ++addr;
       return *this;
-    };
+    }
     iterator operator--(int) {
       iterator it = *this;
       --addr;
       return it;
-    };
+    }
     iterator &operator--() {
       --addr;
       return *this;
-    };
-    SymAddr operator*() const { return addr; };
+    }
+    SymAddr operator*() const { return addr; }
 
   private:
     iterator(SymAddr addr) : addr(addr) {}
@@ -217,8 +217,8 @@ public:
     SymAddr addr;
   };
 
-  iterator begin() const { return iterator(addr); };
-  iterator end() const { return iterator(addr + size); };
+  iterator begin() const { return iterator(addr); }
+  iterator end() const { return iterator(addr + size); }
 };
 
 /* An SymData object is an SymAddrSize ref together with a chunk of memory,
@@ -250,9 +250,9 @@ public:
     assert(ref.includes(addr));
     return block.get()[addr-ref.addr];
   }
-  const SymAddrSize &get_ref() const { return ref; };
-  void *get_block() const { return block.get(); };
-  block_type &get_shared_block() { return block; };
+  const SymAddrSize &get_ref() const { return ref; }
+  void *get_block() const { return block.get(); }
+  block_type &get_shared_block() { return block; }
 };
 
 #endif

--- a/src/SymEv.h
+++ b/src/SymEv.h
@@ -90,7 +90,7 @@ struct SymEv {
   bool _rmw_result_used;
   SymData::block_type _expected, _written;
 
-  SymEv() : kind(NONE) {};
+  SymEv() : kind(NONE) {}
   static SymEv None() { return {NONE, {}}; }
   static SymEv Nondet(int count) { return {NONDET, count}; }
 
@@ -140,14 +140,14 @@ struct SymEv {
                         = (std::string(&)(int))std::to_string) const;
 
   bool operator==(const SymEv &s) const;
-  bool operator!=(const SymEv &s) const { return !(*this == s); };
+  bool operator!=(const SymEv &s) const { return !(*this == s); }
 
   bool has_addr() const;
   bool has_num() const;
   bool has_data() const;
   bool has_expected() const;
   bool has_rmwaction() const { return kind == RMW; }
-  bool has_cond() const { return kind == LOAD_AWAIT || kind == XCHG_AWAIT; };
+  bool has_cond() const { return kind == LOAD_AWAIT || kind == XCHG_AWAIT; }
   bool empty() const { return kind == NONE; }
   const SymAddrSize &addr()   const { assert(has_addr()); return arg.addr; }
         int          num()    const { assert(has_num()); return arg.num; }
@@ -179,30 +179,30 @@ struct SymEv {
   void set_observed(bool observed);
 
 private:
-  SymEv(enum kind kind, union arg arg) : kind(kind), arg(arg) {};
+  SymEv(enum kind kind, union arg arg) : kind(kind), arg(arg) {}
   SymEv(enum kind kind, union arg arg, AwaitCond cond)
     : kind(kind), arg(arg), arg2(cond.op),
-    _expected(std::move(cond.operand)) {};
+    _expected(std::move(cond.operand)) {}
   SymEv(enum kind kind, SymData addr_written)
     : kind(kind), arg(std::move(addr_written.get_ref())),
-      _written(std::move(addr_written.get_shared_block())) {};
+      _written(std::move(addr_written.get_shared_block())) {}
   SymEv(enum kind kind, SymData addr_written, SymData::block_type expected)
     : kind(kind), arg(std::move(addr_written.get_ref())),
       _expected(std::move(expected)),
-      _written(std::move(addr_written.get_shared_block())) {};
+      _written(std::move(addr_written.get_shared_block())) {}
   SymEv(enum kind kind, SymData addr_written, RmwAction action)
     : kind(kind), arg(addr_written.get_ref()), arg2(action.kind),
       _rmw_result_used(action.result_used),
       _expected(std::move(action.operand)),
       _written(std::move(addr_written.get_shared_block())) {
       assert(has_data());
-    };
+    }
   SymEv(enum kind kind, SymData addr_written, AwaitCond cond)
     : kind(kind), arg(addr_written.get_ref()), arg2(cond.op),
       _expected(std::move(cond.operand)),
       _written(std::move(addr_written.get_shared_block())) {
       assert(has_data());
-    };
+    }
 };
 
 inline std::ostream &operator<<(std::ostream &os, const SymEv &e){

--- a/src/TSOInterpreter.h
+++ b/src/TSOInterpreter.h
@@ -62,7 +62,7 @@ protected:
    */
   class TSOThread{
   public:
-    TSOThread() : partial_buffer_flush(-1) {};
+    TSOThread() : partial_buffer_flush(-1) {}
     /* The TSO store buffer of this thread. Newer entries are further
      * to the back.
      */

--- a/src/TSOPSOTraceBuilder.h
+++ b/src/TSOPSOTraceBuilder.h
@@ -56,8 +56,8 @@
 class TSOPSOTraceBuilder : public DetCheckTraceBuilder{
 public:
   TSOPSOTraceBuilder(const Configuration &conf = Configuration::default_conf)
-    : DetCheckTraceBuilder(conf) {};
-  virtual ~TSOPSOTraceBuilder() {};
+    : DetCheckTraceBuilder(conf) {}
+  virtual ~TSOPSOTraceBuilder() {}
   /* Schedules the next thread.
    *
    * Sets *proc and *aux, such that (*proc,*aux) should be the next

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -287,7 +287,7 @@ Trace *TSOTraceBuilder::get_trace() const{
   for(unsigned i = 0; i < prefix.len(); ++i){
     cmp.push_back(IID<CPid>(threads[prefix[i].iid.get_pid()].cpid,prefix[i].iid.get_index()));
     cmp_md.push_from(prefix[i].md);
-  };
+  }
   for(unsigned i = 0; i < errors.size(); ++i){
     errs.push_back(errors[i]->clone());
   }
@@ -3083,7 +3083,7 @@ bool TSOTraceBuilder::has_cycle(IID<IPid> *loc) const{
   /* Attempt to replay computation under SC */
   struct proc_t {
     proc_t()
-      : pc(0), pfx_index(0), store_index(0), blocked(false), block_clock() {};
+      : pc(0), pfx_index(0), store_index(0), blocked(false), block_clock() {}
     int pc; // Current program counter
     int pfx_index; // Index into prefix
     int store_index; // Index into stores

--- a/src/TSOTraceBuilder.h
+++ b/src/TSOTraceBuilder.h
@@ -113,12 +113,12 @@ protected:
     const void *ml;
     bool operator<(const Access &a) const{
       return type < a.type || (type == a.type && ml < a.ml);
-    };
+    }
     bool operator==(const Access &a) const{
       return type == a.type && (type == NA || ml == a.ml);
-    };
-    Access() : type(NA), ml(0) {};
-    Access(Type t, const void *m) : type(t), ml(m) {};
+    }
+    Access() : type(NA), ml(0) {}
+    Access(Type t, const void *m) : type(t), ml(m) {}
   };
 
   /* A store pending in a store buffer. */
@@ -126,7 +126,7 @@ protected:
   public:
     PendingStore(const SymAddrSize &ml, unsigned store_event,
                  const llvm::MDNode *md)
-      : ml(ml), store_event(store_event), last_rowe(-1), md(md) {};
+      : ml(ml), store_event(store_event), last_rowe(-1), md(md) {}
     /* The memory location that is being written to. */
     SymAddrSize ml;
     /* The index into prefix of the store event that produced this store
@@ -151,7 +151,7 @@ protected:
   public:
     Thread(const CPid &cpid, int spawn_event)
       : cpid(cpid), available(true), spawn_event(spawn_event), sleeping(false),
-        sleep_full_memory_conflict(false), sleep_sym(nullptr) {};
+        sleep_full_memory_conflict(false), sleep_sym(nullptr) {}
     CPid cpid;
     /* Is the thread available for scheduling? */
     bool available;
@@ -217,7 +217,7 @@ protected:
    */
   class ByteInfo{
   public:
-    ByteInfo() : last_update(-1), last_update_ml({SymMBlock::Global(0),0},1) {};
+    ByteInfo() : last_update(-1), last_update_ml({SymMBlock::Global(0),0},1) {}
     /* An index into prefix, to the latest update that accessed this
      * byte. last_update == -1 if there has been no update to this
      * byte.
@@ -251,17 +251,17 @@ protected:
      */
     struct last_read_t {
       std::vector<int> v;
-      int operator[](int i) const { return (i < int(v.size()) ? v[i] : -1); };
+      int operator[](int i) const { return (i < int(v.size()) ? v[i] : -1); }
       int &operator[](int i) {
         if(int(v.size()) <= i){
           v.resize(i+1,-1);
         }
         return v[i];
-      };
-      std::vector<int>::iterator begin() { return v.begin(); };
-      std::vector<int>::const_iterator begin() const { return v.begin(); };
-      std::vector<int>::iterator end() { return v.end(); };
-      std::vector<int>::const_iterator end() const { return v.end(); };
+      }
+      std::vector<int>::iterator begin() { return v.begin(); }
+      std::vector<int>::const_iterator begin() const { return v.begin(); }
+      std::vector<int>::iterator end() { return v.end(); }
+      std::vector<int>::const_iterator end() const { return v.end(); }
     } last_read;
   };
   std::map<SymAddr,ByteInfo> mem;
@@ -274,8 +274,8 @@ protected:
    */
   class Mutex{
   public:
-    Mutex() : last_access(-1), last_lock(-1), locked(false) {};
-    Mutex(int lacc) : last_access(lacc), last_lock(-1), locked(false) {};
+    Mutex() : last_access(-1), last_lock(-1), locked(false) {}
+    Mutex(int lacc) : last_access(lacc), last_lock(-1), locked(false) {}
     int last_access;
     int last_lock;
     bool locked;
@@ -289,8 +289,8 @@ protected:
   /* A CondVar represents a pthread_cond_t object. */
   class CondVar{
   public:
-    CondVar() : last_signal(-1) {};
-    CondVar(int init_idx) : last_signal(init_idx) {};
+    CondVar() : last_signal(-1) {}
+    CondVar(int init_idx) : last_signal(init_idx) {}
     /* Index in prefix of the latest call to either of
      * pthread_cond_init, pthread_cond_signal, or
      * pthread_cond_broadcast for this condition variable.
@@ -339,10 +339,10 @@ protected:
     int size;
     bool operator<(const Branch &b) const{
       return pid < b.pid || (pid == b.pid && alt < b.alt);
-    };
+    }
     bool operator==(const Branch &b) const{
       return pid == b.pid && alt == b.alt;
-    };
+    }
   };
 
   struct Race {
@@ -377,19 +377,19 @@ protected:
     };
     static Race Nonblock(int first, int second) {
       return Race(NONBLOCK, first, second, {-1,0}, -1);
-    };
+    }
     static Race Observed(int first, int second, int witness) {
       return Race(OBSERVED, first, second, {-1,0}, witness);
-    };
+    }
     static Race LockFail(int first, int second, IID<IPid> process) {
       return Race(LOCK_FAIL, first, second, process, -1);
-    };
+    }
     static Race LockSuc(int first, int second, int unlock) {
       return Race(LOCK_SUC, first, second, {-1,0}, unlock);
-    };
+    }
     static Race Nondet(int event, int alt) {
       return Race(NONDET, event, -1, {-1,0}, alt);
-    };
+    }
     static Race Sequence(int first, int second, IID<IPid> process, SymEv ev,
                          std::vector<unsigned> exclude) {
       return Race(SEQUENCE, first, second, process, std::move(ev),
@@ -432,7 +432,7 @@ protected:
   public:
     Event(const IID<IPid> &iid, sym_ty sym = {})
       : iid(iid), origin_iid(iid), md(0), clock(), may_conflict(false),
-        sym(std::move(sym)), sleep_branch_trace_count(0) {};
+        sym(std::move(sym)), sleep_branch_trace_count(0) {}
     /* The identifier for the first event in this event sequence. */
     IID<IPid> iid;
     /* The IID of the program instruction which is the origin of this
@@ -536,25 +536,25 @@ protected:
     assert(-1 <= aux && aux <= 0);
     assert(proc*2+1 < int(threads.size()));
     return aux ? proc*2 : proc*2+1;
-  };
+  }
 
   Event &curev() {
     assert(0 <= prefix_idx);
     assert(prefix_idx < int(prefix.len()));
     return prefix[prefix_idx];
-  };
+  }
 
   const Event &curev() const {
     assert(0 <= prefix_idx);
     assert(prefix_idx < int(prefix.len()));
     return prefix[prefix_idx];
-  };
+  }
 
   const Branch &curbranch() const {
     assert(0 <= prefix_idx);
     assert(prefix_idx < int(prefix.len()));
     return prefix.branch(prefix_idx);
-  };
+  }
 
   /* Symbolic events in Branches in the wakeup tree do not record the
    * data of memory accesses as these can change between executions.
@@ -563,7 +563,7 @@ protected:
    */
   Branch branch_with_symbolic_data(unsigned index) const {
     return Branch(prefix.branch(index), prefix[index].sym);
-  };
+  }
 
   IID<CPid> get_iid(unsigned i) const;
 

--- a/src/Trace.h
+++ b/src/Trace.h
@@ -40,14 +40,14 @@
 class Error{
 public:
   /* An error that was discovered in the event loc. */
-  Error(const IID<CPid> &loc) : loc(loc) {};
-  virtual ~Error() {};
+  Error(const IID<CPid> &loc) : loc(loc) {}
+  virtual ~Error() {}
   Error(const Error&) = delete;
   Error &operator=(const Error&) = delete;
   /* Create a deep copy of this error. */
   virtual Error *clone() const = 0;
   /* The location (event) where the error was discovered. */
-  virtual IID<CPid> get_location() const { return loc; };
+  virtual IID<CPid> get_location() const { return loc; }
   /* A human-readable representation of the error. */
   virtual std::string to_string() const = 0;
 protected:
@@ -62,7 +62,7 @@ public:
    * condition is described by assert_condition.
    */
   AssertionError(const IID<CPid> &loc, std::string assert_condition)
-    : Error(loc), condition(assert_condition) {};
+    : Error(loc), condition(assert_condition) {}
   virtual Error *clone() const;
   virtual std::string to_string() const;
 private:
@@ -74,7 +74,7 @@ private:
 class PthreadsError : public Error{
 public:
   PthreadsError(const IID<CPid> &loc, std::string msg)
-    : Error(loc), msg(msg) {};
+    : Error(loc), msg(msg) {}
   virtual Error *clone() const;
   virtual std::string to_string() const;
 private:
@@ -84,7 +84,7 @@ private:
 class SegmentationFaultError : public Error{
 public:
   SegmentationFaultError(const IID<CPid> &loc)
-    : Error(loc) {};
+    : Error(loc) {}
   virtual Error *clone() const;
   virtual std::string to_string() const;
 };
@@ -99,7 +99,7 @@ public:
 class RobustnessError : public Error{
 public:
   RobustnessError(const IID<CPid> &loc)
-    : Error(loc) {};
+    : Error(loc) {}
   virtual Error *clone() const;
   virtual std::string to_string() const;
 };
@@ -108,7 +108,7 @@ public:
 class MemoryError : public Error{
 public:
   MemoryError(const IID<CPid> &loc, std::string msg)
-    : Error(loc), msg(msg) {};
+    : Error(loc), msg(msg) {}
   virtual Error *clone() const;
   virtual std::string to_string() const;
 private:
@@ -121,7 +121,7 @@ private:
 class NondeterminismError : public Error{
 public:
   NondeterminismError(const IID<CPid> &loc, std::string msg)
-    : Error(loc), msg(msg) {};
+    : Error(loc), msg(msg) {}
   virtual Error *clone() const;
   virtual std::string to_string() const;
 private:
@@ -134,7 +134,7 @@ private:
 class InvalidInputError : public Error{
 public:
   InvalidInputError(const IID<CPid> &loc, std::string msg)
-    : Error(loc), msg(msg) {};
+    : Error(loc), msg(msg) {}
   virtual Error *clone() const;
   virtual std::string to_string() const;
 private:
@@ -180,15 +180,15 @@ public:
   Trace(const Trace&) = delete;
   Trace &operator=(const Trace&) = delete;
   /* The trace keeps ownership of the errors. */
-  const std::vector<Error*> &get_errors() const { return errors; };
-  bool has_errors() const { return errors.size(); };
+  const std::vector<Error*> &get_errors() const { return errors; }
+  bool has_errors() const { return errors.size(); }
   /* A multi-line, human-readable string representation of this
    * Trace. Indentation will be in multiples of ind spaces.
    */
   virtual std::string to_string(int ind = 0) const;
   /* Was the exploration of this execution (sleep set) blocked? */
-  virtual bool is_blocked() const { return blocked; };
-  virtual void set_blocked(bool b = true) { blocked = b; };
+  virtual bool is_blocked() const { return blocked; }
+  virtual void set_blocked(bool b = true) { blocked = b; }
 protected:
   std::vector<Error*> errors;
   bool blocked;
@@ -217,11 +217,11 @@ public:
   IIDSeqTrace(const IIDSeqTrace&) = delete;
   IIDSeqTrace &operator=(const IIDSeqTrace&) = delete;
   /* The sequence of events. */
-  virtual const std::vector<IID<CPid> > &get_computation() const { return computation; };
+  virtual const std::vector<IID<CPid> > &get_computation() const { return computation; }
   /* The sequence of metadata (see above). */
   virtual const SrcLocVector &get_computation_metadata() const{
     return computation_md;
-  };
+  }
   virtual std::string to_string(int ind = 0) const;
 protected:
   std::vector<IID<CPid> > computation;

--- a/src/TraceBuilder.h
+++ b/src/TraceBuilder.h
@@ -58,7 +58,7 @@ public:
    */
   virtual bool check_for_cycles() = 0;
   /* Have any errors been discovered in the current trace? */
-  virtual bool has_error() const { return errors.size(); };
+  virtual bool has_error() const { return errors.size(); }
   /* Compute the Trace of the current execution. */
   virtual Trace *get_trace() const = 0;
   /* Notify the TraceBuilder that the current execution has terminated.
@@ -74,7 +74,7 @@ public:
   /* Return the IID of the currently scheduled event. */
   virtual IID<CPid> get_iid() const = 0;
 
-  virtual void debug_print() const {};
+  virtual void debug_print() const {}
 
   /* Notify the TraceBuilder that an assertion has failed.
    *
@@ -118,7 +118,7 @@ public:
   /* Estimate the total number of traces for this program based on the
    * traces that have been seen.
    */
-  virtual long double estimate_trace_count() const { return 1; };
+  virtual long double estimate_trace_count() const { return 1; }
 protected:
   const Configuration &conf;
   std::vector<Error*> errors;

--- a/src/VClock.h
+++ b/src/VClock.h
@@ -72,7 +72,7 @@ public:
 
   bool includes(const IID<DOM> &iid) const {
     return iid.get_index() <= (*this)[iid.get_pid()];
-  };
+  }
 
   /* *** Partial order comparisons ***
    *
@@ -157,7 +157,7 @@ public:
 
   bool includes(const IID<int> &iid) const {
     return iid.get_index() <= (*this)[iid.get_pid()];
-  };
+  }
 
   /* *** Partial order comparisons ***
    *
@@ -202,8 +202,8 @@ public:
     /* Assign this vector clock to (*this - vc). */
     Ref &operator-=(const Ref vc);
     unsigned size() const { return _size; }
-    int operator[](int d) const { assert(d >= 0 && unsigned(d) < _size); return base[d]; };
-    int &operator[](int d) { assert(d >= 0 && unsigned(d) < _size); return base[d]; };
+    int operator[](int d) const { assert(d >= 0 && unsigned(d) < _size); return base[d]; }
+    int &operator[](int d) { assert(d >= 0 && unsigned(d) < _size); return base[d]; }
 
     /* *** Partial order comparisons ***
      *

--- a/src/WakeupTrees.h
+++ b/src/WakeupTrees.h
@@ -60,14 +60,14 @@ public:
   /* Does not implement the full iterator API, for now. */
   class iterator {
   public:
-    const Branch &branch() { return iter->first; };
-    WakeupTreeRef<Branch> node() { return {*iter->second}; };
-    bool operator<(const iterator &it) const { return iter < it.iter; };
-    bool operator==(const iterator &it) const { return iter == it.iter; };
-    bool operator>(const iterator &it) const { return iter > it.iter; };
-    bool operator<=(const iterator &it) const { return iter <= it.iter; };
-    bool operator!=(const iterator &it) const { return iter != it.iter; };
-    bool operator>=(const iterator &it) const { return iter >= it.iter; };
+    const Branch &branch() { return iter->first; }
+    WakeupTreeRef<Branch> node() { return {*iter->second}; }
+    bool operator<(const iterator &it) const { return iter < it.iter; }
+    bool operator==(const iterator &it) const { return iter == it.iter; }
+    bool operator>(const iterator &it) const { return iter > it.iter; }
+    bool operator<=(const iterator &it) const { return iter <= it.iter; }
+    bool operator!=(const iterator &it) const { return iter != it.iter; }
+    bool operator>=(const iterator &it) const { return iter >= it.iter; }
     iterator operator++(){ iter++; return *this; }
     iterator(typename WakeupTree<Branch>::children_type::iterator iter)
       : iter(iter) {}

--- a/src/unittest.cpp
+++ b/src/unittest.cpp
@@ -32,12 +32,12 @@
 struct Fixture{
   Fixture(){
     // Global initialization
-  };
+  }
   ~Fixture(){
     // Global destruction
     GlobalContext::destroy();
     llvm::llvm_shutdown();
-  };
+  }
 };
 
 BOOST_GLOBAL_FIXTURE(Fixture);

--- a/src/vecset.h
+++ b/src/vecset.h
@@ -33,7 +33,7 @@
 template<class T, class Compare = std::less<T>> class VecSet{
 public:
   /* An empty set */
-  VecSet() {};
+  VecSet() {}
   /* A set consisting of the values in v.
    *
    * Pre: v is sorted and distinct.
@@ -41,7 +41,7 @@ public:
   VecSet(const std::vector<T> &v)
     : vec(v) {
     assert(check_invariant());
-  };
+  }
   /* A set consisting of the values in v.
    *
    * Pre: v is sorted and distinct.
@@ -49,7 +49,7 @@ public:
   VecSet(std::vector<T> &&v)
     : vec(std::move(v)) {
     assert(check_invariant());
-  };
+  }
   /* A set consisting of the values of [begin,end). Each element is
    * inserted using a separate call to insert.
    */
@@ -60,15 +60,15 @@ public:
   VecSet(VecSet &&);
   VecSet &operator=(const VecSet&) = default;
   VecSet &operator=(VecSet&&);
-  virtual ~VecSet() {};
+  virtual ~VecSet() {}
   /* Returns a set which is the singleton {t}. */
   static VecSet singleton(const T &t){
     VecSet vs;
     vs.vec.push_back(t);
     return vs;
-  };
+  }
   /* Reserve space in the vector for at least n elements. */
-  void reserve(int n) { vec.reserve(n); };
+  void reserve(int n) { vec.reserve(n); }
   /* Insert t into this set.
    *
    * Return (i,b) where i is the index of t in the vector and b is
@@ -111,34 +111,34 @@ public:
    */
   int find(const T &t) const;
   /* Return the number of elements in this set. */
-  int size() const { return vec.size(); };
-  bool empty() const { return vec.empty();};
+  int size() const { return vec.size(); }
+  bool empty() const { return vec.empty();}
   /* Empties this set */
-  void clear() { vec.clear(); };
+  void clear() { vec.clear(); }
   /* Returns true iff all elements in this set are also members of s. */
   bool subset_of(const VecSet &s) const;
   /* Returns true iff there is some element that occurs both in this set and in s. */
   bool intersects(const VecSet &s) const;
   /* Returns the i:th smallest element in the set. */
-  const T &operator[](int i) const { return vec[i]; };
+  const T &operator[](int i) const { return vec[i]; }
   /* Returns the largest element in the set. */
-  const T &back() const { return vec.back(); };
+  const T &back() const { return vec.back(); }
   /* Removes the largest element from the set.
    *
    * Pre: the set is non-empty
    */
-  void pop_back() { vec.pop_back(); };
+  void pop_back() { vec.pop_back(); }
   typedef typename std::vector<T>::const_iterator const_iterator;
-  const_iterator begin() const { return vec.cbegin(); };
-  const_iterator end() const { return vec.cend(); };
-  const std::vector<T> &get_vector() const & { return vec; };
-  std::vector<T> &&get_vector() && { return std::move(vec); };
-  bool operator==(const VecSet &s) const { return vec == s.vec; };
-  bool operator<(const VecSet &s) const { return vec < s.vec; };
-  bool operator>(const VecSet &s) const { return vec > s.vec; };
-  bool operator<=(const VecSet &s) const { return vec <= s.vec; };
-  bool operator!=(const VecSet &s) const { return vec != s.vec; };
-  bool operator>=(const VecSet &s) const { return vec >= s.vec; };
+  const_iterator begin() const { return vec.cbegin(); }
+  const_iterator end() const { return vec.cend(); }
+  const std::vector<T> &get_vector() const & { return vec; }
+  std::vector<T> &&get_vector() && { return std::move(vec); }
+  bool operator==(const VecSet &s) const { return vec == s.vec; }
+  bool operator<(const VecSet &s) const { return vec < s.vec; }
+  bool operator>(const VecSet &s) const { return vec > s.vec; }
+  bool operator<=(const VecSet &s) const { return vec <= s.vec; }
+  bool operator!=(const VecSet &s) const { return vec != s.vec; }
+  bool operator>=(const VecSet &s) const { return vec >= s.vec; }
   /* Produces a string representation of the set with each element t
    * represented as f(t) without any new lines between the elements.
    */


### PR DESCRIPTION
Semicolons at the end of method definitions do not hurt, but they are really unnecessary in C++.