### PR TITLE
Consistently use braces around `else`

### DIFF
--- a/src/Execution.cpp
+++ b/src/Execution.cpp
@@ -615,13 +615,12 @@ static GenericValue executeFCMP_ORD(GenericValue Src1, GenericValue Src2,
         (Src2.AggregateVal[_i].DoubleVal ==
         Src2.AggregateVal[_i].DoubleVal)));
     }
+  } else if (Ty->isFloatTy()) {
+    Dest.IntVal = APInt(1,(Src1.FloatVal == Src1.FloatVal &&
+                           Src2.FloatVal == Src2.FloatVal));
   } else {
-    if (Ty->isFloatTy())
-      Dest.IntVal = APInt(1,(Src1.FloatVal == Src1.FloatVal &&
-                             Src2.FloatVal == Src2.FloatVal));
-    else
-      Dest.IntVal = APInt(1,(Src1.DoubleVal == Src1.DoubleVal &&
-                             Src2.DoubleVal == Src2.DoubleVal));
+    Dest.IntVal = APInt(1,(Src1.DoubleVal == Src1.DoubleVal &&
+                           Src2.DoubleVal == Src2.DoubleVal));
   }
   return Dest;
 }
@@ -647,13 +646,12 @@ static GenericValue executeFCMP_UNO(GenericValue Src1, GenericValue Src2,
             (Src2.AggregateVal[_i].DoubleVal !=
              Src2.AggregateVal[_i].DoubleVal)));
       }
+  } else if (Ty->isFloatTy()) {
+    Dest.IntVal = APInt(1,(Src1.FloatVal != Src1.FloatVal ||
+                           Src2.FloatVal != Src2.FloatVal));
   } else {
-    if (Ty->isFloatTy())
-      Dest.IntVal = APInt(1,(Src1.FloatVal != Src1.FloatVal ||
-                             Src2.FloatVal != Src2.FloatVal));
-    else
-      Dest.IntVal = APInt(1,(Src1.DoubleVal != Src1.DoubleVal ||
-                             Src2.DoubleVal != Src2.DoubleVal));
+    Dest.IntVal = APInt(1,(Src1.DoubleVal != Src1.DoubleVal ||
+                           Src2.DoubleVal != Src2.DoubleVal));
   }
   return Dest;
 }
@@ -3441,11 +3439,9 @@ bool Interpreter::checkRefuse(Instruction &I){
     int nargs = 0;
     if(isLoadAwait(I, &ptr, &cond)) {
       kind = LOAD;
-    } else {
-      if(isXchgAwait(I, &ptr, &cond)) {
-        kind = XCHG;
-        nargs = 1;
-      }
+    } else if(isXchgAwait(I, &ptr, &cond)) {
+      kind = XCHG;
+      nargs = 1;
     }
     if(kind != NONE) {
       Option<SymAddrSize> ptr_sas = TryGetSymAddrSize(ptr,I.getOperand(nargs+2)->getType());

--- a/src/Execution.cpp
+++ b/src/Execution.cpp
@@ -420,9 +420,9 @@ static GenericValue executeFCMP_OEQ(GenericValue Src1, GenericValue Src2,
   Dest.AggregateVal.resize( X.AggregateVal.size() );                        \
   for (uint32_t _i = 0; _i < X.AggregateVal.size(); _i++) {                 \
     if (X.AggregateVal[_i].TZ##Val != X.AggregateVal[_i].TZ##Val ||         \
-        Y.AggregateVal[_i].TZ##Val != Y.AggregateVal[_i].TZ##Val)           \
+        Y.AggregateVal[_i].TZ##Val != Y.AggregateVal[_i].TZ##Val) {         \
       Dest.AggregateVal[_i].IntVal = APInt(1,FLAG);                         \
-    else  {                                                                 \
+    } else {                                                                \
       Dest.AggregateVal[_i].IntVal = APInt(1,!FLAG);                        \
     }                                                                       \
   }
@@ -435,7 +435,6 @@ static GenericValue executeFCMP_OEQ(GenericValue Src1, GenericValue Src2,
       MASK_VECTOR_NANS_T(X, Y, Double, FLAG)                                \
     }                                                                       \
   }                                                                         \
-
 
 
 static GenericValue executeFCMP_ONE(GenericValue Src1, GenericValue Src2,
@@ -456,11 +455,11 @@ static GenericValue executeFCMP_ONE(GenericValue Src1, GenericValue Src2,
       llvm_unreachable(0);
   }
   // in vector case mask out NaN elements
-  if (Ty->isVectorTy())
+  if (Ty->isVectorTy()) {
     for (size_t _i = 0; _i < Src1.AggregateVal.size(); _i++)
       if (DestMask.AggregateVal[_i].IntVal == false)
         Dest.AggregateVal[_i].IntVal = APInt(1,false);
-
+  }
   return Dest;
 }
 
@@ -548,7 +547,6 @@ static GenericValue executeFCMP_UEQ(GenericValue Src1, GenericValue Src2,
   MASK_VECTOR_NANS(Ty, Src1, Src2, true)
   IMPLEMENT_VECTOR_UNORDERED(Ty, Src1, Src2, executeFCMP_OEQ)
   return executeFCMP_OEQ(Src1, Src2, Ty);
-
 }
 
 static GenericValue executeFCMP_UNE(GenericValue Src1, GenericValue Src2,
@@ -617,12 +615,13 @@ static GenericValue executeFCMP_ORD(GenericValue Src1, GenericValue Src2,
         (Src2.AggregateVal[_i].DoubleVal ==
         Src2.AggregateVal[_i].DoubleVal)));
     }
-  } else if (Ty->isFloatTy())
-    Dest.IntVal = APInt(1,(Src1.FloatVal == Src1.FloatVal &&
-                           Src2.FloatVal == Src2.FloatVal));
-  else {
-    Dest.IntVal = APInt(1,(Src1.DoubleVal == Src1.DoubleVal &&
-                           Src2.DoubleVal == Src2.DoubleVal));
+  } else {
+    if (Ty->isFloatTy())
+      Dest.IntVal = APInt(1,(Src1.FloatVal == Src1.FloatVal &&
+                             Src2.FloatVal == Src2.FloatVal));
+    else
+      Dest.IntVal = APInt(1,(Src1.DoubleVal == Src1.DoubleVal &&
+                             Src2.DoubleVal == Src2.DoubleVal));
   }
   return Dest;
 }
@@ -648,12 +647,13 @@ static GenericValue executeFCMP_UNO(GenericValue Src1, GenericValue Src2,
             (Src2.AggregateVal[_i].DoubleVal !=
              Src2.AggregateVal[_i].DoubleVal)));
       }
-  } else if (Ty->isFloatTy())
-    Dest.IntVal = APInt(1,(Src1.FloatVal != Src1.FloatVal ||
-                           Src2.FloatVal != Src2.FloatVal));
-  else {
-    Dest.IntVal = APInt(1,(Src1.DoubleVal != Src1.DoubleVal ||
-                           Src2.DoubleVal != Src2.DoubleVal));
+  } else {
+    if (Ty->isFloatTy())
+      Dest.IntVal = APInt(1,(Src1.FloatVal != Src1.FloatVal ||
+                             Src2.FloatVal != Src2.FloatVal));
+    else
+      Dest.IntVal = APInt(1,(Src1.DoubleVal != Src1.DoubleVal ||
+                             Src2.DoubleVal != Src2.DoubleVal));
   }
   return Dest;
 }
@@ -767,24 +767,24 @@ void Interpreter::visitBinaryOperator(BinaryOperator &I) {
 #define INTEGER_VECTOR_FUNCTION(OP)                                \
     for (unsigned i = 0; i < R.AggregateVal.size(); ++i)           \
       R.AggregateVal[i].IntVal =                                   \
-      Src1.AggregateVal[i].IntVal.OP(Src2.AggregateVal[i].IntVal);
+        Src1.AggregateVal[i].IntVal.OP(Src2.AggregateVal[i].IntVal);
 
     // Macros to execute binary operation 'OP' over floating point type TY
     // (float or double) vectors
 #define FLOAT_VECTOR_FUNCTION(OP, TY)                               \
       for (unsigned i = 0; i < R.AggregateVal.size(); ++i)          \
         R.AggregateVal[i].TY =                                      \
-        Src1.AggregateVal[i].TY OP Src2.AggregateVal[i].TY;
+          Src1.AggregateVal[i].TY OP Src2.AggregateVal[i].TY;
 
     // Macros to choose appropriate TY: float or double and run operation
     // execution
 #define FLOAT_VECTOR_OP(OP) {                                         \
-  if (dyn_cast<VectorType>(Ty)->getElementType()->isFloatTy())        \
+  if (dyn_cast<VectorType>(Ty)->getElementType()->isFloatTy()) {      \
     FLOAT_VECTOR_FUNCTION(OP, FloatVal)                               \
-  else {                                                              \
-    if (dyn_cast<VectorType>(Ty)->getElementType()->isDoubleTy())     \
+  } else {                                                            \
+    if (dyn_cast<VectorType>(Ty)->getElementType()->isDoubleTy()) {   \
       FLOAT_VECTOR_FUNCTION(OP, DoubleVal)                            \
-    else {                                                            \
+    } else {                                                            \
       dbgs() << "Unhandled type for OP instruction: " << *Ty << "\n"; \
       llvm_unreachable(0);                                            \
     }                                                                 \
@@ -811,16 +811,16 @@ void Interpreter::visitBinaryOperator(BinaryOperator &I) {
     case Instruction::FMul:  FLOAT_VECTOR_OP(*) break;
     case Instruction::FDiv:  FLOAT_VECTOR_OP(/) break;
     case Instruction::FRem:
-      if (dyn_cast<VectorType>(Ty)->getElementType()->isFloatTy())
+      if (dyn_cast<VectorType>(Ty)->getElementType()->isFloatTy()) {
         for (unsigned i = 0; i < R.AggregateVal.size(); ++i)
           R.AggregateVal[i].FloatVal =
           fmod(Src1.AggregateVal[i].FloatVal, Src2.AggregateVal[i].FloatVal);
-      else {
-        if (dyn_cast<VectorType>(Ty)->getElementType()->isDoubleTy())
+      } else {
+        if (dyn_cast<VectorType>(Ty)->getElementType()->isDoubleTy()) {
           for (unsigned i = 0; i < R.AggregateVal.size(); ++i)
             R.AggregateVal[i].DoubleVal =
             fmod(Src1.AggregateVal[i].DoubleVal, Src2.AggregateVal[i].DoubleVal);
-        else {
+        } else {
           dbgs() << "Unhandled type for Rem instruction: " << *Ty << "\n";
           llvm_unreachable(0);
         }
@@ -1108,9 +1108,9 @@ GenericValue Interpreter::executeGEPOperation(Value *Ptr, gep_type_iterator I,
       int64_t Idx;
       unsigned BitWidth =
         cast<IntegerType>(I.getOperand()->getType())->getBitWidth();
-      if (BitWidth == 32)
+      if (BitWidth == 32) {
         Idx = (int64_t)(int32_t)IdxGV.IntVal.getZExtValue();
-      else {
+      } else {
         assert(BitWidth == 64 && "Invalid index type for getelementptr");
         Idx = (int64_t)IdxGV.IntVal.getZExtValue();
       }
@@ -1700,9 +1700,8 @@ GenericValue Interpreter::executeFPToUIInst(Value *SrcVal, Type *DstTy,
 
     if (SrcTy->getTypeID() == Type::FloatTyID)
       Dest.IntVal = APIntOps::RoundFloatToAPInt(Src.FloatVal, DBitWidth);
-    else {
+    else
       Dest.IntVal = APIntOps::RoundDoubleToAPInt(Src.DoubleVal, DBitWidth);
-    }
   }
 
   return Dest;
@@ -1738,9 +1737,8 @@ GenericValue Interpreter::executeFPToSIInst(Value *SrcVal, Type *DstTy,
 
     if (SrcTy->getTypeID() == Type::FloatTyID)
       Dest.IntVal = APIntOps::RoundFloatToAPInt(Src.FloatVal, DBitWidth);
-    else {
+    else
       Dest.IntVal = APIntOps::RoundDoubleToAPInt(Src.DoubleVal, DBitWidth);
-    }
   }
   return Dest;
 }
@@ -1770,9 +1768,8 @@ GenericValue Interpreter::executeUIToFPInst(Value *SrcVal, Type *DstTy,
     assert(DstTy->isFloatingPointTy() && "Invalid UIToFP instruction");
     if (DstTy->getTypeID() == Type::FloatTyID)
       Dest.FloatVal = APIntOps::RoundAPIntToFloat(Src.IntVal);
-    else {
+    else
       Dest.DoubleVal = APIntOps::RoundAPIntToDouble(Src.IntVal);
-    }
   }
   return Dest;
 }
@@ -1803,9 +1800,8 @@ GenericValue Interpreter::executeSIToFPInst(Value *SrcVal, Type *DstTy,
 
     if (DstTy->getTypeID() == Type::FloatTyID)
       Dest.FloatVal = APIntOps::RoundSignedAPIntToFloat(Src.IntVal);
-    else {
+    else
       Dest.DoubleVal = APIntOps::RoundSignedAPIntToDouble(Src.IntVal);
-    }
   }
 
   return Dest;
@@ -1836,7 +1832,6 @@ GenericValue Interpreter::executeIntToPtrInst(Value *SrcVal, Type *DstTy,
 
 GenericValue Interpreter::executeBitCastInst(Value *SrcVal, Type *DstTy,
                                              ExecutionContext &SF) {
-
   // This instruction supports bitwise conversion of vectors to integers and
   // to vectors of other types (as long as they have the same size)
   Type *SrcTy = SrcVal->getType();
@@ -1957,14 +1952,12 @@ GenericValue Interpreter::executeBitCastInst(Value *SrcVal, Type *DstTy,
     } else {
       if (DstElemTy->isDoubleTy())
         Dest.DoubleVal = TempDst.AggregateVal[0].IntVal.bitsToDouble();
-      else if (DstElemTy->isFloatTy()) {
+      else if (DstElemTy->isFloatTy())
         Dest.FloatVal = TempDst.AggregateVal[0].IntVal.bitsToFloat();
-      } else {
+      else
         Dest.IntVal = TempDst.AggregateVal[0].IntVal;
-      }
     }
   } else { //  if (isa<VectorType>(SrcTy)) || isa<VectorType>(DstTy))
-
     // scalar src bitcast to scalar dst
     if (DstTy->isPointerTy()) {
       assert(SrcTy->isPointerTy() && "Invalid BitCast");
@@ -1972,25 +1965,22 @@ GenericValue Interpreter::executeBitCastInst(Value *SrcVal, Type *DstTy,
     } else if (DstTy->isIntegerTy()) {
       if (SrcTy->isFloatTy())
         Dest.IntVal = APInt::floatToBits(Src.FloatVal);
-      else if (SrcTy->isDoubleTy()) {
+      else if (SrcTy->isDoubleTy())
         Dest.IntVal = APInt::doubleToBits(Src.DoubleVal);
-      } else if (SrcTy->isIntegerTy()) {
+      else if (SrcTy->isIntegerTy())
         Dest.IntVal = Src.IntVal;
-      } else {
+      else
         llvm_unreachable("Invalid BitCast");
-      }
     } else if (DstTy->isFloatTy()) {
       if (SrcTy->isIntegerTy())
         Dest.FloatVal = Src.IntVal.bitsToFloat();
-      else {
+      else
         Dest.FloatVal = Src.FloatVal;
-      }
     } else if (DstTy->isDoubleTy()) {
       if (SrcTy->isIntegerTy())
         Dest.DoubleVal = Src.IntVal.bitsToDouble();
-      else {
+      else
         Dest.DoubleVal = Src.DoubleVal;
-      }
     } else {
       llvm_unreachable("Invalid Bitcast");
     }
@@ -2277,7 +2267,6 @@ void Interpreter::visitExtractValueInst(ExtractValueInst &I) {
 }
 
 void Interpreter::visitInsertValueInst(InsertValueInst &I) {
-
   ExecutionContext &SF = ECStack()->back();
   Value *Agg = I.getAggregateOperand();
 
@@ -3450,10 +3439,13 @@ bool Interpreter::checkRefuse(Instruction &I){
     AwaitCond cond;
     enum kind { NONE = 0, LOAD = 1, XCHG = 2, } kind = NONE;
     int nargs = 0;
-    if(isLoadAwait(I, &ptr, &cond)) kind = LOAD;
-    else if(isXchgAwait(I, &ptr, &cond)) {
+    if(isLoadAwait(I, &ptr, &cond)) {
+      kind = LOAD;
+    } else {
+      if(isXchgAwait(I, &ptr, &cond)) {
         kind = XCHG;
         nargs = 1;
+      }
     }
     if(kind != NONE) {
       Option<SymAddrSize> ptr_sas = TryGetSymAddrSize(ptr,I.getOperand(nargs+2)->getType());
@@ -3464,8 +3456,9 @@ bool Interpreter::checkRefuse(Instruction &I){
         if (!cond.satisfied_by((const void*)ptr, ptr_sas->size)) {
           assert(!cond.satisfied_by(actual.get(), ptr_sas->size));
           bool callback_ret;
-          if (kind == LOAD) callback_ret = TB.load_await_fail(*ptr_sas, cond);
-          else {
+          if (kind == LOAD) {
+            callback_ret = TB.load_await_fail(*ptr_sas, cond);
+          } else {
             assert(kind == XCHG);
             ExecutionContext &SF = ECStack()->back();
             GenericValue Val = getOperandValue(I.getOperand(1), SF);

--- a/src/POWERExecution.cpp
+++ b/src/POWERExecution.cpp
@@ -366,10 +366,10 @@ void POWERInterpreter::visitICmpInst(llvm::ICmpInst &I) {
   setCurInstrValue(R);
 }
 
-#define IMPLEMENT_FCMP(OP, TY)                                \
-  case llvm::Type::TY##TyID:                                  \
-  Dest.IntVal = llvm::APInt(1,Src1.TY##Val OP Src2.TY##Val);  \
-  break
+#define IMPLEMENT_FCMP(OP, TY)                                  \
+  case llvm::Type::TY##TyID:                                    \
+    Dest.IntVal = llvm::APInt(1,Src1.TY##Val OP Src2.TY##Val);  \
+    break
 
 #define IMPLEMENT_VECTOR_FCMP_T(OP, TY)                                 \
   assert(Src1.AggregateVal.size() == Src2.AggregateVal.size());         \
@@ -401,7 +401,7 @@ static llvm::GenericValue executeFCMP_OEQ(llvm::GenericValue Src1, llvm::Generic
   return Dest;
 }
 
-#define IMPLEMENT_SCALAR_NANS(TY, X,Y)                              \
+#define IMPLEMENT_SCALAR_NANS(TY, X, Y)                             \
   if (TY->isFloatTy()) {                                            \
     if (X.FloatVal != X.FloatVal || Y.FloatVal != Y.FloatVal) {     \
       Dest.IntVal = llvm::APInt(1,false);                           \
@@ -414,30 +414,30 @@ static llvm::GenericValue executeFCMP_OEQ(llvm::GenericValue Src1, llvm::Generic
     }                                                               \
   }
 
-#define MASK_VECTOR_NANS_T(X,Y, TZ, FLAG)                           \
+#define MASK_VECTOR_NANS_T(X, Y, TZ, FLAG)                          \
   assert(X.AggregateVal.size() == Y.AggregateVal.size());           \
   Dest.AggregateVal.resize( X.AggregateVal.size() );                \
   for (uint32_t _i = 0; _i < X.AggregateVal.size(); _i++) {         \
     if (X.AggregateVal[_i].TZ##Val != X.AggregateVal[_i].TZ##Val || \
-        Y.AggregateVal[_i].TZ##Val != Y.AggregateVal[_i].TZ##Val)   \
+        Y.AggregateVal[_i].TZ##Val != Y.AggregateVal[_i].TZ##Val) { \
       Dest.AggregateVal[_i].IntVal = llvm::APInt(1,FLAG);           \
-    else  {                                                         \
+    } else {                                                        \
       Dest.AggregateVal[_i].IntVal = llvm::APInt(1,!FLAG);          \
     }                                                               \
   }
 
-#define MASK_VECTOR_NANS(TY, X,Y, FLAG)                                 \
-  if (TY->isVectorTy()) {                                               \
-                         if (llvm::dyn_cast<llvm::VectorType>(TY)->getElementType()->isFloatTy()) { \
-                                                                                                   MASK_VECTOR_NANS_T(X, Y, Float, FLAG) \
-                                                                                                   } else { \
-                                                                                                           MASK_VECTOR_NANS_T(X, Y, Double, FLAG) \
-                                                                                                           } \
-                         }                                              \
+#define MASK_VECTOR_NANS(TY, X, Y, FLAG)                            \
+  if (TY->isVectorTy()) {                                           \
+    if (llvm::dyn_cast<llvm::VectorType>(TY)->getElementType()->isFloatTy()) { \
+      MASK_VECTOR_NANS_T(X, Y, Float, FLAG)                         \
+    } else {                                                        \
+      MASK_VECTOR_NANS_T(X, Y, Double, FLAG)                        \
+    }                                                               \
+  }                                              \
 
 
-
-static llvm::GenericValue executeFCMP_ONE(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_ONE(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty)
 {
   llvm::GenericValue Dest;
@@ -455,15 +455,16 @@ static llvm::GenericValue executeFCMP_ONE(llvm::GenericValue Src1, llvm::Generic
     llvm_unreachable(nullptr);
   }
   // in vector case mask out NaN elements
-  if (Ty->isVectorTy())
+  if (Ty->isVectorTy()) {
     for (size_t _i = 0; _i < Src1.AggregateVal.size(); _i++)
       if (DestMask.AggregateVal[_i].IntVal == false)
         Dest.AggregateVal[_i].IntVal = llvm::APInt(1,false);
-
+  }
   return Dest;
 }
 
-static llvm::GenericValue executeFCMP_OLE(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_OLE(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   switch (Ty->getTypeID()) {
@@ -477,7 +478,8 @@ static llvm::GenericValue executeFCMP_OLE(llvm::GenericValue Src1, llvm::Generic
   return Dest;
 }
 
-static llvm::GenericValue executeFCMP_OGE(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_OGE(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   switch (Ty->getTypeID()) {
@@ -491,7 +493,8 @@ static llvm::GenericValue executeFCMP_OGE(llvm::GenericValue Src1, llvm::Generic
   return Dest;
 }
 
-static llvm::GenericValue executeFCMP_OLT(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_OLT(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   switch (Ty->getTypeID()) {
@@ -505,7 +508,8 @@ static llvm::GenericValue executeFCMP_OLT(llvm::GenericValue Src1, llvm::Generic
   return Dest;
 }
 
-static llvm::GenericValue executeFCMP_OGT(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_OGT(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   switch (Ty->getTypeID()) {
@@ -519,18 +523,20 @@ static llvm::GenericValue executeFCMP_OGT(llvm::GenericValue Src1, llvm::Generic
   return Dest;
 }
 
-#define IMPLEMENT_UNORDERED(TY, X,Y)                                    \
+#define IMPLEMENT_UNORDERED(TY, X, Y)                                   \
   if (TY->isFloatTy()) {                                                \
     if (X.FloatVal != X.FloatVal || Y.FloatVal != Y.FloatVal) {         \
       Dest.IntVal = llvm::APInt(1,true);                                \
       return Dest;                                                      \
     }                                                                   \
-  } else if (X.DoubleVal != X.DoubleVal || Y.DoubleVal != Y.DoubleVal) { \
-    Dest.IntVal = llvm::APInt(1,true);                                  \
-    return Dest;                                                        \
+  } else {                                                              \
+    if (X.DoubleVal != X.DoubleVal || Y.DoubleVal != Y.DoubleVal) {     \
+      Dest.IntVal = llvm::APInt(1,true);                                \
+      return Dest;                                                      \
+    }                                                                   \
   }
 
-#define IMPLEMENT_VECTOR_UNORDERED(TY, X,Y, _FUNC)          \
+#define IMPLEMENT_VECTOR_UNORDERED(TY, X, Y, _FUNC)         \
   if (TY->isVectorTy()) {                                   \
     llvm::GenericValue DestMask = Dest;                     \
     Dest = _FUNC(Src1, Src2, Ty);                           \
@@ -540,17 +546,18 @@ static llvm::GenericValue executeFCMP_OGT(llvm::GenericValue Src1, llvm::Generic
     return Dest;                                            \
   }
 
-static llvm::GenericValue executeFCMP_UEQ(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_UEQ(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
     MASK_VECTOR_NANS(Ty, Src1, Src2, true)
     IMPLEMENT_VECTOR_UNORDERED(Ty, Src1, Src2, executeFCMP_OEQ)
     return executeFCMP_OEQ(Src1, Src2, Ty);
-
 }
 
-static llvm::GenericValue executeFCMP_UNE(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_UNE(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -559,7 +566,8 @@ static llvm::GenericValue executeFCMP_UNE(llvm::GenericValue Src1, llvm::Generic
     return executeFCMP_ONE(Src1, Src2, Ty);
 }
 
-static llvm::GenericValue executeFCMP_ULE(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_ULE(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -568,7 +576,8 @@ static llvm::GenericValue executeFCMP_ULE(llvm::GenericValue Src1, llvm::Generic
     return executeFCMP_OLE(Src1, Src2, Ty);
 }
 
-static llvm::GenericValue executeFCMP_UGE(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_UGE(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -577,7 +586,8 @@ static llvm::GenericValue executeFCMP_UGE(llvm::GenericValue Src1, llvm::Generic
     return executeFCMP_OGE(Src1, Src2, Ty);
 }
 
-static llvm::GenericValue executeFCMP_ULT(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_ULT(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -586,7 +596,8 @@ static llvm::GenericValue executeFCMP_ULT(llvm::GenericValue Src1, llvm::Generic
     return executeFCMP_OLT(Src1, Src2, Ty);
 }
 
-static llvm::GenericValue executeFCMP_UGT(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_UGT(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -595,7 +606,8 @@ static llvm::GenericValue executeFCMP_UGT(llvm::GenericValue Src1, llvm::Generic
     return executeFCMP_OGT(Src1, Src2, Ty);
 }
 
-static llvm::GenericValue executeFCMP_ORD(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_ORD(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   if(Ty->isVectorTy()) {
@@ -616,17 +628,20 @@ static llvm::GenericValue executeFCMP_ORD(llvm::GenericValue Src1, llvm::Generic
                                                      (Src2.AggregateVal[_i].DoubleVal ==
                                                       Src2.AggregateVal[_i].DoubleVal)));
     }
-  } else if (Ty->isFloatTy())
-    Dest.IntVal = llvm::APInt(1,(Src1.FloatVal == Src1.FloatVal &&
-                                 Src2.FloatVal == Src2.FloatVal));
-  else {
-    Dest.IntVal = llvm::APInt(1,(Src1.DoubleVal == Src1.DoubleVal &&
-                                 Src2.DoubleVal == Src2.DoubleVal));
+  } else {
+    if (Ty->isFloatTy()) {
+      Dest.IntVal = llvm::APInt(1,(Src1.FloatVal == Src1.FloatVal &&
+                                   Src2.FloatVal == Src2.FloatVal));
+    } else {
+      Dest.IntVal = llvm::APInt(1,(Src1.DoubleVal == Src1.DoubleVal &&
+                                   Src2.DoubleVal == Src2.DoubleVal));
+    }
   }
   return Dest;
 }
 
-static llvm::GenericValue executeFCMP_UNO(llvm::GenericValue Src1, llvm::GenericValue Src2,
+static llvm::GenericValue executeFCMP_UNO(llvm::GenericValue Src1,
+                                          llvm::GenericValue Src2,
                                           llvm::Type *Ty) {
   llvm::GenericValue Dest;
   if(Ty->isVectorTy()) {
@@ -647,18 +662,22 @@ static llvm::GenericValue executeFCMP_UNO(llvm::GenericValue Src1, llvm::Generic
                                                      (Src2.AggregateVal[_i].DoubleVal !=
                                                       Src2.AggregateVal[_i].DoubleVal)));
     }
-  } else if (Ty->isFloatTy())
-    Dest.IntVal = llvm::APInt(1,(Src1.FloatVal != Src1.FloatVal ||
-                                 Src2.FloatVal != Src2.FloatVal));
-  else {
-    Dest.IntVal = llvm::APInt(1,(Src1.DoubleVal != Src1.DoubleVal ||
-                                 Src2.DoubleVal != Src2.DoubleVal));
+  } else {
+    if (Ty->isFloatTy()) {
+      Dest.IntVal = llvm::APInt(1,(Src1.FloatVal != Src1.FloatVal ||
+                                   Src2.FloatVal != Src2.FloatVal));
+    } else {
+      Dest.IntVal = llvm::APInt(1,(Src1.DoubleVal != Src1.DoubleVal ||
+                                   Src2.DoubleVal != Src2.DoubleVal));
+    }
   }
   return Dest;
 }
 
-static llvm::GenericValue executeFCMP_BOOL(llvm::GenericValue Src1, llvm::GenericValue Src2,
-                                           const llvm::Type *Ty, const bool val) {
+static llvm::GenericValue executeFCMP_BOOL(llvm::GenericValue Src1,
+                                           llvm::GenericValue Src2,
+                                           const llvm::Type *Ty,
+                                           const bool val) {
   llvm::GenericValue Dest;
   if(Ty->isVectorTy()) {
     assert(Src1.AggregateVal.size() == Src2.AggregateVal.size());
@@ -668,7 +687,6 @@ static llvm::GenericValue executeFCMP_BOOL(llvm::GenericValue Src1, llvm::Generi
   } else {
     Dest.IntVal = llvm::APInt(1, val);
   }
-
   return Dest;
 }
 
@@ -706,8 +724,10 @@ void POWERInterpreter::visitFCmpInst(llvm::FCmpInst &I) {
   setCurInstrValue(R);
 }
 
-static llvm::GenericValue executeCmpInst(unsigned predicate, llvm::GenericValue Src1,
-                                         llvm::GenericValue Src2, llvm::Type *Ty) {
+static llvm::GenericValue executeCmpInst(unsigned predicate,
+                                         llvm::GenericValue Src1,
+                                         llvm::GenericValue Src2,
+                                         llvm::Type *Ty) {
   llvm::GenericValue Result;
   switch (predicate) {
   case llvm::ICmpInst::ICMP_EQ:    return executeICMP_EQ(Src1, Src2, Ty);
@@ -775,18 +795,17 @@ void POWERInterpreter::visitBinaryOperator(llvm::BinaryOperator &I) {
 
     // Macros to choose appropriate TY: float or double and run operation
     // execution
-#define FLOAT_VECTOR_OP(OP) {                                           \
-      if (llvm::dyn_cast<llvm::VectorType>(Ty)->getElementType()->isFloatTy()) \
-        FLOAT_VECTOR_FUNCTION(OP, FloatVal)                             \
-        else {                                                          \
-          if (llvm::dyn_cast<llvm::VectorType>(Ty)->getElementType()->isDoubleTy()) \
-            FLOAT_VECTOR_FUNCTION(OP, DoubleVal)                        \
-            else {                                                      \
-              llvm::dbgs() << "Unhandled type for OP instruction: " << *Ty << "\n"; \
-              llvm_unreachable(0);                                      \
-            }                                                           \
-        }                                                               \
-    }
+#define FLOAT_VECTOR_OP(OP)                                           \
+      if (llvm::dyn_cast<llvm::VectorType>(Ty)->getElementType()->isFloatTy()) { \
+        FLOAT_VECTOR_FUNCTION(OP, FloatVal)                           \
+      } else {                                                        \
+        if (llvm::dyn_cast<llvm::VectorType>(Ty)->getElementType()->isDoubleTy()) { \
+          FLOAT_VECTOR_FUNCTION(OP, DoubleVal)                        \
+        } else {                                                      \
+          llvm::dbgs() << "Unhandled type for OP instruction: " << *Ty << "\n"; \
+          llvm_unreachable(0);                                        \
+        }                                                             \
+      }                                                               \
 
     switch(I.getOpcode()){
     default:
@@ -808,16 +827,16 @@ void POWERInterpreter::visitBinaryOperator(llvm::BinaryOperator &I) {
     case llvm::Instruction::FMul:  FLOAT_VECTOR_OP(*) break;
     case llvm::Instruction::FDiv:  FLOAT_VECTOR_OP(/) break;
     case llvm::Instruction::FRem:
-      if (llvm::dyn_cast<llvm::VectorType>(Ty)->getElementType()->isFloatTy())
+      if (llvm::dyn_cast<llvm::VectorType>(Ty)->getElementType()->isFloatTy()) {
         for (unsigned i = 0; i < R.AggregateVal.size(); ++i)
           R.AggregateVal[i].FloatVal =
             fmod(Src1.AggregateVal[i].FloatVal, Src2.AggregateVal[i].FloatVal);
-      else {
-        if (llvm::dyn_cast<llvm::VectorType>(Ty)->getElementType()->isDoubleTy())
+      } else {
+        if (llvm::dyn_cast<llvm::VectorType>(Ty)->getElementType()->isDoubleTy()) {
           for (unsigned i = 0; i < R.AggregateVal.size(); ++i)
             R.AggregateVal[i].DoubleVal =
               fmod(Src1.AggregateVal[i].DoubleVal, Src2.AggregateVal[i].DoubleVal);
-        else {
+        } else {
           llvm::dbgs() << "Unhandled type for Rem instruction: " << *Ty << "\n";
           llvm_unreachable(nullptr);
         }
@@ -1096,9 +1115,9 @@ llvm::GenericValue POWERInterpreter::executeGEPOperation(llvm::Value *PtrVal,
       int64_t Idx;
       unsigned BitWidth =
         llvm::cast<llvm::IntegerType>(I.getOperand()->getType())->getBitWidth();
-      if (BitWidth == 32)
+      if (BitWidth == 32) {
         Idx = (int64_t)(int32_t)IdxGV.IntVal.getZExtValue();
-      else {
+      } else {
         assert(BitWidth == 64 && "Invalid index type for getelementptr");
         Idx = (int64_t)IdxGV.IntVal.getZExtValue();
       }
@@ -1559,13 +1578,12 @@ llvm::GenericValue POWERInterpreter::executeFPToUIInst(llvm::Value *SrcVal,
     uint32_t DBitWidth = llvm::cast<llvm::IntegerType>(DstTy)->getBitWidth();
     assert(SrcTy->isFloatingPointTy() && "Invalid FPToUI instruction");
 
-    if (SrcTy->getTypeID() == llvm::Type::FloatTyID)
+    if (SrcTy->getTypeID() == llvm::Type::FloatTyID) {
       Dest.IntVal = llvm::APIntOps::RoundFloatToAPInt(Src.FloatVal, DBitWidth);
-    else {
+    } else {
       Dest.IntVal = llvm::APIntOps::RoundDoubleToAPInt(Src.DoubleVal, DBitWidth);
     }
   }
-
   return Dest;
 }
 
@@ -1600,9 +1618,8 @@ llvm::GenericValue POWERInterpreter::executeFPToSIInst(llvm::Value *SrcVal,
 
     if (SrcTy->getTypeID() == llvm::Type::FloatTyID)
       Dest.IntVal = llvm::APIntOps::RoundFloatToAPInt(Src.FloatVal, DBitWidth);
-    else {
+    else
       Dest.IntVal = llvm::APIntOps::RoundDoubleToAPInt(Src.DoubleVal, DBitWidth);
-    }
   }
   return Dest;
 }
@@ -1633,9 +1650,8 @@ llvm::GenericValue POWERInterpreter::executeUIToFPInst(llvm::Value *SrcVal,
     assert(DstTy->isFloatingPointTy() && "Invalid UIToFP instruction");
     if (DstTy->getTypeID() == llvm::Type::FloatTyID)
       Dest.FloatVal = llvm::APIntOps::RoundAPIntToFloat(Src.IntVal);
-    else {
+    else
       Dest.DoubleVal = llvm::APIntOps::RoundAPIntToDouble(Src.IntVal);
-    }
   }
   return Dest;
 }
@@ -1667,9 +1683,8 @@ llvm::GenericValue POWERInterpreter::executeSIToFPInst(llvm::Value *SrcVal,
 
     if (DstTy->getTypeID() == llvm::Type::FloatTyID)
       Dest.FloatVal = llvm::APIntOps::RoundSignedAPIntToFloat(Src.IntVal);
-    else {
+    else
       Dest.DoubleVal = llvm::APIntOps::RoundSignedAPIntToDouble(Src.IntVal);
-    }
   }
 
   return Dest;
@@ -1703,7 +1718,6 @@ llvm::GenericValue POWERInterpreter::executeIntToPtrInst(llvm::Value *SrcVal,
 llvm::GenericValue POWERInterpreter::executeBitCastInst(llvm::Value *SrcVal,
                                                         const llvm::GenericValue &Src,
                                                         llvm::Type *DstTy) {
-
   // This instruction supports bitwise conversion of vectors to integers and
   // to vectors of other types (as long as they have the same size)
   llvm::Type *SrcTy = SrcVal->getType();
@@ -1831,20 +1845,21 @@ llvm::GenericValue POWERInterpreter::executeBitCastInst(llvm::Value *SrcVal,
       }
     }
   } else { //   if (isa<VectorType>(SrcTy) || isa<VectorType>(DstTy))
-
     // scalar src bitcast to scalar dst
     if (DstTy->isPointerTy()) {
       assert(SrcTy->isPointerTy() && "Invalid BitCast");
       Dest.PointerVal = Src.PointerVal;
     } else if (DstTy->isIntegerTy()) {
-      if (SrcTy->isFloatTy())
+      if (SrcTy->isFloatTy()) {
         Dest.IntVal = llvm::APInt::floatToBits(Src.FloatVal);
-      else if (SrcTy->isDoubleTy()) {
-        Dest.IntVal = llvm::APInt::doubleToBits(Src.DoubleVal);
-      } else if (SrcTy->isIntegerTy()) {
-        Dest.IntVal = Src.IntVal;
       } else {
-        llvm_unreachable("Invalid BitCast");
+        if (SrcTy->isDoubleTy()) {
+          Dest.IntVal = llvm::APInt::doubleToBits(Src.DoubleVal);
+        } else if (SrcTy->isIntegerTy()) {
+          Dest.IntVal = Src.IntVal;
+        } else {
+          llvm_unreachable("Invalid BitCast");
+        }
       }
     } else if (DstTy->isFloatTy()) {
       if (SrcTy->isIntegerTy()) {

--- a/src/PartialLoopPurityPass.cpp
+++ b/src/PartialLoopPurityPass.cpp
@@ -718,14 +718,12 @@ namespace {
   llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const BinaryPredicate &pred) {
     if (pred.is_true()) {
       os << "true";
+    } else if (pred.is_false()) {
+      os << "false";
     } else {
-      if (pred.is_false()) {
-        os << "false";
-      } else {
-        pred.lhs->printAsOperand(os);
-        os << " " << getPredicateName(pred.op) << " ";
-        pred.rhs->printAsOperand(os);
-      }
+      pred.lhs->printAsOperand(os);
+      os << " " << getPredicateName(pred.op) << " ";
+      pred.rhs->printAsOperand(os);
     }
     return os;
   }


### PR DESCRIPTION
Enforce the rule that an `else` should either have braces on both its
sides or none of them.

While at it, fix some whitespace issues and add a missing include.

There is one more place in the code that the above rule is violated
(src/PartialLoopPurityPass.cpp:325), which is left for @margnus1 to fix.