### PR TITLE
PartialLoopPurity: Fix the "defined nowhere" issue

### DIFF
--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -15,11 +15,14 @@ import collections
 NIDHUGG=os.path.join(sys.path[0], 'nidhugg')
 CLANG='%%CLANG%%'
 CLANGXX='%%CLANGXX%%'
+GDB='gdb'
 
 Param = collections.namedtuple("Param",["name","help","param","transform"])
 
 nidhuggcparamslist = [
     Param("--help",'Prints this text.',False,False),
+    Param("--gdb",'Run nidhugg under GDB.',False,False),
+    Param("--transform-gdb",'Run nidhugg under GDB while doing module transformation.',False,False),
     Param('--verbose','Show commands being run.',False,False),
     Param('--version','Prints the nidhugg version.',False,False),
     Param('--c','Interpret input FILE as C code. (Compile with clang.)',False,False),
@@ -54,6 +57,10 @@ tmpdir=None
 # If we should print verbosely
 verbose=False
 
+# Whether we should run nidhugg under gdb
+gdb=False
+transform_gdb=False
+
 def init_tmpdir():
     global tmpdir
     if tmpdir == None:
@@ -68,7 +75,7 @@ def destroy_tmpdir():
 
 atexit.register(destroy_tmpdir)
 
-def run(cmd,ignoreret=False):
+def run(cmd, *, ignoreret=False):
     return_codes = [0, 42]
     cmdstr=''
     for s in cmd:
@@ -237,17 +244,19 @@ def transform(nidhuggcargs,transformargs,irfname):
     (fd,outputfname) = tempfile.mkstemp(suffix='.ll',dir=tmpdir)
     os.close(fd)
     cmd = [NIDHUGG]+transformargs+['-transform',outputfname,irfname]
+    if transform_gdb: cmd = [GDB,'--args'] + cmd
     run(cmd)
     return outputfname
 
 def run_nidhugg(nidhuggcargs,nidhuggargs,irfname):
     cmd = [NIDHUGG,irfname]+nidhuggargs
+    if gdb: cmd = [GDB,'--args'] + cmd
     return run(cmd)
 
 def main():
     try:
         global CLANG, CLANGXX, NIDHUGG
-        global verbose
+        global verbose, gdb, transform_gdb
         t0 = time.time()
         (nidhuggcargs,compilerargs,nidhuggargs) = get_args()
         transformargs=[]
@@ -258,6 +267,10 @@ def main():
                 exit(0)
             elif argname == '--verbose':
                 verbose = True
+            elif argname == '--gdb':
+                gdb = True
+            elif argname == '--transform-gdb':
+                transform_gdb = True
             elif argname == '--clang':
                 CLANG=argarg
             elif argname == '--clangxx':

--- a/src/vecset.h
+++ b/src/vecset.h
@@ -132,7 +132,7 @@ public:
   const_iterator begin() const { return vec.cbegin(); }
   const_iterator end() const { return vec.cend(); }
   const std::vector<T> &get_vector() const & { return vec; }
-  std::vector<T> &&get_vector() && { return std::move(vec); }
+  std::vector<T> get_vector() && { return std::exchange(vec, {}); }
   bool operator==(const VecSet &s) const { return seq_eq(vec, s.vec); }
   bool operator<(const VecSet &s) const { return seq_lt(vec, s.vec); }
   bool operator>(const VecSet &s) const { return seq_lt(s.vec, vec); }

--- a/tests/smoke/C-tests/plptest_defined_nowhere.c
+++ b/tests/smoke/C-tests/plptest_defined_nowhere.c
@@ -1,0 +1,30 @@
+// nidhuggc: -sc -optimal --unroll=3
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <assert.h>
+
+atomic_int x, y, z;
+
+static void *p(void *arg) {
+  while(true) {
+    if (x) {
+      if (y) {
+	x = 2;
+      }
+    } else {
+      x = 3;
+    }
+    if (z) break;
+  }
+  return arg;
+}
+
+int main() {
+  pthread_t pt;
+  pthread_create(&pt, NULL, p, NULL);
+  z = 1;
+  x = 1;
+  y = 1;
+  (void)x;
+}

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -115,6 +115,7 @@ plptest_cmpxchg_reuse Forbid : 12
 plptest_cmpxchg_member_reuse Forbid : 12
 plptest_cmpxchg_weak_reuse Forbid : 12
 plptest_futex_mutex Forbid : 10
+plptest_defined_nowhere Forbid : 13
 # These should not be transformed
 plptest_cmpxchg_reuse_reorder Forbid : 14
 plptest_leaky_counter Forbid : 4


### PR DESCRIPTION
PLP could generate purity conditions with conjunctions such that at no point in the loop are all the terms of the conjunction defined. This can occur when multiple path conditions get merged into a single conjunction. However, if we are not "before" the definition of any of the terms (according to our reverse postorder), then it is safe to take any arbitrary value of the terms whose definitions were not executed. Thus, we insert phi nodes to bring values down to the point of the assume, even when they do not strictly dominate that point, picking an arbitrary value (here zero, note that LLVM `undefined` might not be safe, as it can change between evaluations of it).

A test case demonstrates a loop that can be bounded if this relaxation is performed.