### PR TITLE
Namespace cleanups

### DIFF
--- a/src/CastElimPass.cpp
+++ b/src/CastElimPass.cpp
@@ -33,9 +33,9 @@ void CastElimPass::getAnalysisUsage(llvm::AnalysisUsage &AU) const{
 
 namespace {
   llvm::Value *findSubstitute(llvm::CastInst &CI) {
-    using namespace llvm;
-    Value *src = CI.getOperand(0);
-    if (auto *csrc = dyn_cast<CastInst>(src)) { /* A->B->C cast */
+    using llvm::CastInst;
+    llvm::Value *src = CI.getOperand(0);
+    if (auto *csrc = llvm::dyn_cast<CastInst>(src)) { /* A->B->C cast */
       if (csrc->getSrcTy() == CI.getDestTy() /* A->B->A cast */
           && CI.getOpcode() == CastInst::Trunc
           && (csrc->getOpcode() == CastInst::SExt

--- a/src/Execution.cpp
+++ b/src/Execution.cpp
@@ -77,7 +77,7 @@
 #include <llvm/Support/MathExtras.h>
 #include <algorithm>
 #include <cmath>
-using namespace llvm;
+using namespace llvm;  // NOLINT(build/namespaces)
 
 //===----------------------------------------------------------------------===//
 //                     Various Helper Functions

--- a/src/ExternalFunctions.cpp
+++ b/src/ExternalFunctions.cpp
@@ -76,7 +76,7 @@
 #endif
 #endif
 
-using namespace llvm;
+using namespace llvm;  // NOLINT(build/namespaces)
 
 static ManagedStatic<sys::Mutex> FunctionsLock;
 

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -58,12 +58,13 @@
 #include <llvm/Module.h>
 #endif
 #include <cstring>
-using namespace llvm;
+using llvm::Interpreter;
+using llvm::GenericValue;
 
 /// create - Create a new interpreter object.  This can never fail.
 ///
 std::unique_ptr<Interpreter> Interpreter::
-create(Module *M, TSOPSOTraceBuilder &TB, const Configuration &C,
+create(llvm::Module *M, TSOPSOTraceBuilder &TB, const Configuration &C,
        std::string* ErrStr) {
   // Tell this Module to materialize everything and release the GVMaterializer.
 #ifdef LLVM_MODULE_MATERIALIZE_ALL_PERMANENTLY_ERRORCODE_BOOL

--- a/src/Timing.cpp
+++ b/src/Timing.cpp
@@ -119,7 +119,8 @@ namespace Timing {
               << std::setw(12) << (E) << "\n"
     OUT("Name", "Count", "Inclusive", "Exclusive");
     for (result &r : vec) {
-      using namespace std::chrono;
+      using std::chrono::duration_cast;
+      using std::chrono::microseconds;
       OUT(r.c->name, r.count,
           duration_cast<microseconds>(r.inclusive).count(),
           duration_cast<microseconds>(r.exclusive).count());

--- a/src/TraceUtil.cpp
+++ b/src/TraceUtil.cpp
@@ -186,10 +186,9 @@ SrcLocVector SrcLocVectorBuilder::build() {
 }
 
 void SrcLocVectorBuilder::push_from(const llvm::MDNode *md) {
-  using namespace TraceUtil;
   int lineno;
   std::string file_name, dir_name;
-  if (!get_location(md, &lineno, &file_name, &dir_name)) {
+  if (!TraceUtil::get_location(md, &lineno, &file_name, &dir_name)) {
     vector.locations.emplace_back();
   } else {
     vector.locations.emplace_back(lineno, intern_string(std::move(file_name)),


### PR DESCRIPTION
Eliminate some `using namespace` directives when these are for only a few items of the namespace.
Add two `NOLINT(build/namespace)` comments to suppress `using namespace` `cpplint` warnings.