### PR TITLE
Add runtime inner loop monitor to the Partial Loop Purity analysis

### DIFF
--- a/src/PartialLoopPurityPass.cpp
+++ b/src/PartialLoopPurityPass.cpp
@@ -810,13 +810,6 @@ namespace {
     return llvm::dyn_cast<llvm::Instruction>(V);
   }
 
-  void maybeResolvePhi(llvm::Value *&V, const llvm::BasicBlock *From,
-                       const llvm::BasicBlock *To) {
-    llvm::PHINode *N = llvm::dyn_cast_or_null<llvm::PHINode>(V);
-    if (!N || N->getParent() != To) return;
-    V = N->getIncomingValueForBlock(From);
-  }
-
   BinaryPredicate collapseTautologies(const BinaryPredicate &cond) {
     if (cond.is_true() || cond.is_false()) return cond;
     if (cond.rhs == cond.lhs) {
@@ -975,9 +968,7 @@ namespace {
     }
     if (!L->contains(To)) return false;
     if (rpo.is_backedge(From, To)) return false;
-    PurityCondition in = conds[To].map([From, To](BinaryPredicate term) {
-      maybeResolvePhi(term.rhs, From, To);
-      maybeResolvePhi(term.lhs, From, To);
+    PurityCondition in = conds[To].map([](BinaryPredicate term) {
       term.normalise();
       return collapseTautologies(term);
     });

--- a/tests/smoke/C-tests/plptest_inner_impure.c
+++ b/tests/smoke/C-tests/plptest_inner_impure.c
@@ -1,0 +1,47 @@
+// nidhuggc: -unroll=2 -sc -optimal
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <assert.h>
+
+void __VERIFIER_assume(bool b);
+
+atomic_int x;
+atomic_int y;
+atomic_int z;
+atomic_int w = 0;
+atomic_int *p;
+
+static void *test(void *arg) {
+  while(true) {
+    int a = x;
+    bool did_z = false;
+    int b;
+    /* Can only incement z once per iteration of the outer loop, and
+     * only exit once b != 0
+     */
+    while(!(b = y)) {
+      if (!did_z) { z++; did_z = true; }
+    }
+    if (a) break;
+    (void)*p;
+    /* PLP would insert __VERIFIER_assume(!b) here, trying to say that
+     * the outer loop is pure if the inner loop is not taken.
+     * However, this actually filters out executions where the inner
+     * loop is taken; thus making the assertion in main unsatisfiable.
+     */
+  }
+
+  return arg;
+}
+
+int main() {
+  pthread_t t;
+  p = &w;
+  pthread_create(&t, NULL, test, NULL);
+  y = 1;
+  y = 0;
+  y = 1;
+  x = 1;
+  assert(z < 2);
+}

--- a/tests/smoke/C-tests/plptest_safestack_21_easier.c
+++ b/tests/smoke/C-tests/plptest_safestack_21_easier.c
@@ -1,0 +1,108 @@
+// nidhuggc: -sc -optimal -no-assume-await -unroll=4
+/* Test based on the SafeStack benchmark from SCTBench. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+#ifndef N
+#  define N 2,1
+#endif
+
+const unsigned iters[] = {N};
+
+#define NUM_THREADS (sizeof(iters)/sizeof(*iters))
+
+#ifndef STACK_SIZE
+#  define STACK_SIZE 2 // NUM_THREADS
+#endif
+
+void __VERIFIER_assume(int truth);
+
+typedef struct SafeStackItem {
+    atomic_int Value;
+    atomic_int Next;
+} SafeStackItem;
+
+typedef struct SafeStack {
+    SafeStackItem array[STACK_SIZE];
+    atomic_int head;
+    atomic_int count;
+} SafeStack;
+
+pthread_t threads[NUM_THREADS];
+SafeStack stack;
+
+void Init(int pushCount) {
+    int i;
+    atomic_init(&stack.count, pushCount);
+    atomic_init(&stack.head, 0);
+    for (i = 0; i < pushCount - 1; i++) {
+	atomic_init(&stack.array[i].Next, i + 1);
+    }
+    atomic_init(&stack.array[pushCount - 1].Next, -1);
+}
+
+int Pop(void) {
+    while(true) {
+	if (atomic_load(&stack.count) <= 1) continue;
+	int head1 = atomic_load(&stack.head);
+	int next1 = atomic_exchange(&stack.array[head1].Next, -1);
+
+	__VERIFIER_assume(next1 != -1);
+	if (next1 >= 0) {
+	    int head2 = head1;
+	    if (atomic_compare_exchange_strong(&stack.head, &head2, next1)) {
+		atomic_fetch_sub(&stack.count, 1);
+		return head1;
+	    } else {
+		atomic_exchange(&stack.array[head1].Next, next1);
+	    }
+	}
+    }
+}
+
+void Push(int index) {
+    int head1 = atomic_load(&stack.head);
+    do {
+	atomic_store(&stack.array[index].Next, head1);
+    } while (!(atomic_compare_exchange_strong(&stack.head, &head1, index)));
+    atomic_fetch_add(&stack.count, 1);
+}
+
+
+void* thread(void* arg) {
+    int idx = (int)(uintptr_t)arg;
+    uintptr_t i = iters[idx];
+    for (;;) {
+	if (i-- == 0) return NULL;
+	int elem = Pop();
+
+	// Check for double-pop. Requires N=3,3,1 (or greater) to
+	// reproduce original bug
+	stack.array[elem].Value = idx;
+	assert(stack.array[elem].Value == idx);
+
+	if (i-- == 0) return NULL;
+	Push(elem);
+    }
+    return NULL;
+}
+
+int main(void) {
+    uintptr_t i;
+    Init(STACK_SIZE);
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_create(&threads[i], NULL, thread, (void*) i);
+    }
+
+    for (i = 0; i < NUM_THREADS; ++i) {
+        pthread_join(threads[i], NULL);
+    }
+
+    return 0;
+}

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -101,10 +101,11 @@ plptest_fully_pure Forbid : 2
 plptest_risk_of_segfault Forbid : 2
 plptest_spinloop Forbid : 2
 plptest_br_cond_not Forbid : 1
-plptest_safestack_21_easy Forbid : 11
-plptest_safestack_21_inlined Forbid : 11
-plptest_safestack_21_inlined_xchg Forbid : 11
-plptest_safestack_21 Forbid : 11
+plptest_safestack_21_easier Forbid : 11
+plptest_safestack_21_easy Forbid : 12
+plptest_safestack_21_inlined Forbid : 12
+plptest_safestack_21_inlined_xchg Forbid : 12
+plptest_safestack_21 Forbid : 12
 plptest_burns_nobound Forbid : 9
 plptest_seqlock Forbid : 7
 plptest_seqlock_harder Forbid : 5

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -121,6 +121,7 @@ plptest_cmpxchg_reuse_reorder Forbid : 14
 plptest_leaky_counter Forbid : 4
 plptest_nested Forbid : 2
 plptest_impure_phi Allow : 2
+plptest_inner_impure Allow : 15
 
 # TSO test with inline assembly
 inlineasm Forbid : 12


### PR DESCRIPTION
When a loop contains an inner loop, PLP would deduce a purity condition that implies that loop exiting, but would insert an assume outside that inner loop, only enforcing that the final iteration would terminate. Thus, an execution where the inner loop performed arbitrary impure actions would be considered "pure". This is fixed by inserting a runtime monitor in such inner loops that keeps track if they have looped, thus avoiding bounding such executions.

With a small extension to assume-await, we almost keep our prior performance, with a minor regression on safestack.