### PR TITLE
Add support for LLVM 15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,28 @@ jobs:
           build-args: LLVM_VERSION=${{ matrix.llvm }}
       - name: Run tests
         run: docker run --rm -t ${{ steps.build.outputs.digest }}
+  debug_llvms:
+    name: Test with custom-built LLVM ${{ matrix.llvm }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - llvm: "15.0.3"
+            ubuntu: 22
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build Nidhugg
+        id: build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          file: ci/Dockerfile.debug_test${{ matrix.ubuntu }}
+          build-args: LLVM_VERSION=${{ matrix.llvm }}
+      - name: Run tests
+        run: docker run --rm -t ${{ steps.build.outputs.digest }}
   docker_image:
     name: Test the standard docker file
     runs-on: ubuntu-latest

--- a/README
+++ b/README
@@ -36,9 +36,10 @@ Requirements
 
    5. Python version 3.0 or higher.
 
-   6. The LLVM library and headers, version 3.8 or higher. If you are
-      compiling the LLVM library from sources, see Compiling LLVM
-      below.
+   6. The LLVM library and headers, version 3.8 or higher. The ARM and
+      POWER memory models are not supported when using LLVM version 15
+      and higher. If you are compiling the LLVM library from sources,
+      see Compiling LLVM below.
 
    7. Foreign Function Interface (libffi) library and headers.
 

--- a/ci/Dockerfile.debug_test22
+++ b/ci/Dockerfile.debug_test22
@@ -1,0 +1,60 @@
+FROM ubuntu:22.04 as build
+ARG LLVM_VERSION=15.0.3
+
+# COPY ci/install_deps.sh /ci/
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC \
+      apt-get --no-install-recommends -y install \
+      libboost-dev \
+      libboost-test-dev \
+      libboost-system-dev \
+      libc6 \
+      libc6-dev \
+      libstdc++6 \
+      g++ \
+      autoconf \
+      automake \
+      python3 \
+      libffi-dev \
+      libz-dev \
+      libtinfo-dev \
+      libxml2-dev \
+      wget ca-certificates \
+      xz-utils \
+      cmake \
+      make
+
+ADD https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VERSION/llvm-project-$LLVM_VERSION.src.tar.xz /
+
+RUN \
+    /bin/bash -c \
+    "cd / && \
+     tar xf llvm-project-$LLVM_VERSION.src.tar.xz && \
+     mkdir /build && \
+     cd /build && \
+     cmake -DCMAKE_INSTALL_PREFIX=/usr/local/       \
+           -DCMAKE_BUILD_TYPE=MinSizeRel            \
+           -DLLVM_TARGETS_TO_BUILD=""               \
+           -DLLVM_LINK_LLVM_DYLIB=ON                \
+           -DLLVM_OPTIMIZED_TABLEGEN=ON             \
+           -DLLVM_ENABLE_ASSERTIONS=ON              \
+           -DLLVM_ENABLE_PROJECTS="clang"           \
+           /llvm-project-$LLVM_VERSION.src/llvm/ && \
+     make -j`nproc` &&                              \
+     cmake -DCMAKE_INSTALL_PREFIX=/usr/local -P cmake_install.cmake && \
+     cd / && rm -r /build/ /llvm-project-$LLVM_VERSION.src/ && \
+     (strip /usr/local/lib/*.so /usr/local/bin/* || true)"
+
+COPY . /nidhugg
+
+RUN \
+    /bin/bash -c \
+    "cd /nidhugg && \
+     autoreconf --install && \
+     (./configure --prefix=/usr/local/ --enable-asserts CXXFLAGS='-Og -g' \
+                  LDFLAGS='-g -Wl,-rpath=/usr/local/lib/' \
+      || (cat config.log; false)) && \
+     make -Csrc -j`nproc` all unittest"
+
+CMD make -C /nidhugg -j3 test

--- a/configure.ac
+++ b/configure.ac
@@ -785,6 +785,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 ## Check how to call getAnalysis to get LoopInfo
 AC_MSG_CHECKING([how to get LoopInfo analysis])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Analysis/LoopPass.h>
 ]],[[
   llvm::LPPassManager *LPM = 0;
@@ -1017,6 +1018,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 ## Check if llvm::LoopInfo::erase exists
 AC_MSG_CHECKING([for llvm::LoopInfo::erase])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Analysis/LoopPass.h>
 ]],[[
   llvm::Loop * L = 0;
@@ -1031,6 +1033,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 ## Check if llvm::LoopInfo::markAsRemoved exists
 AC_MSG_CHECKING([for llvm::LoopInfo::markAsRemoved])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Analysis/LoopPass.h>
 ]],[[
   llvm::Loop * L = 0;

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,7 @@ AX_BOOST_BASE([1.65], [], [AC_MSG_FAILURE([Boost Required!])])
 AX_BOOST_UNIT_TEST_FRAMEWORK
 AX_BOOST_SYSTEM
 AX_LLVM(,[AC_MSG_FAILURE(LLVM is required.)])
+AC_SUBST(LLVMVERSION)
 CXXFLAGS="`echo " $CXXFLAGS " | sed 's/ -fno-rtti / /' | sed 's/ -fno-exceptions / /'` --std=c++14 $BOOST_CPPFLAGS"
 LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
 AC_CHECK_LIB([dl], [dlopen],[],[AC_MSG_FAILURE([Could not find library libdl.])])

--- a/src/AssumeAwaitPass.h
+++ b/src/AssumeAwaitPass.h
@@ -22,8 +22,15 @@
 #ifndef __ASSUME_AWAIT_PASS_H__
 #define __ASSUME_AWAIT_PASS_H__
 
-#include <llvm/Analysis/LoopPass.h>
 #include <llvm/Pass.h>
+
+/* Avoid including huge header files, we just need a forward
+ * declarations
+ */
+namespace llvm {
+  class CallInst;
+  class BasicBlock;
+}
 
 /* The AssumeAwaitPass identifies calls to __VERIFIER_assume with simple
  * conditions and replaces them with

--- a/src/AssumeAwaitPass.h
+++ b/src/AssumeAwaitPass.h
@@ -30,6 +30,7 @@
 namespace llvm {
   class CallInst;
   class BasicBlock;
+  class FunctionType;
 }
 
 /* The AssumeAwaitPass identifies calls to __VERIFIER_assume with simple
@@ -50,11 +51,11 @@ public:
 private:
   static const unsigned no_sizes = 4;
   static unsigned sizes[no_sizes];
-  llvm::Value *F_load_await[no_sizes];
-  llvm::Value *F_xchg_await[no_sizes];
+  std::pair<llvm::Value*,llvm::FunctionType*> F_load_await[no_sizes];
+  std::pair<llvm::Value*,llvm::FunctionType*> F_xchg_await[no_sizes];
   bool tryRewriteAssume(llvm::Function *F, llvm::BasicBlock *BB, llvm::Instruction *I) const;
   bool tryRewriteAssumeCmpXchg(llvm::Function *F, llvm::BasicBlock *BB, llvm::CallInst *I) const;
-  llvm::Value *getAwaitFunction(llvm::Instruction *Load) const;
+  std::pair<llvm::Value*,llvm::FunctionType*> getAwaitFunction(llvm::Instruction *Load) const;
 };
 
 #endif

--- a/src/CheckModule.h
+++ b/src/CheckModule.h
@@ -59,9 +59,9 @@ namespace CheckModule {
 
   /* Same check as check_functions, but only for individual functions.
    */
-  void check_pthread_create(const llvm::Module *M);
-  void check_pthread_join(const llvm::Module *M);
-  void check_pthread_self(const llvm::Module *M);
+  llvm::Type *check_pthread_create(const llvm::Module *M);
+  void check_pthread_join(const llvm::Module *M, llvm::Type *PthreadTTy);
+  void check_pthread_self(const llvm::Module *M, llvm::Type *PthreadTTy);
   void check_pthread_exit(const llvm::Module *M);
   void check_pthread_mutex_init(const llvm::Module *M);
   void check_pthread_mutex_lock(const llvm::Module *M);

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -310,6 +310,11 @@ void Configuration::check_commandline(){
     if(cl_memory_model == Configuration::POWER) mm = "POWER";
     if(cl_memory_model == Configuration::ARM) mm = "ARM";
     if(cl_memory_model == Configuration::ARM || cl_memory_model == Configuration::POWER){
+      if (LLVM_VERSION_MAJOR > 14 && !cl_transform.getNumOccurrences()) {
+        Debug::warn("Configuration::check_commandline:mm:power-arm-no-opaque-ptrs")
+          << "WARNING: Memory model " << mm << " does not support \"Opaque Pointers\","
+          " which are enabled by default in Clang 15. Nidhugg might crash.\n";
+      }
       if(cl_extfun_no_race.getNumOccurrences()){
         Debug::warn("Configuration::check_commandline:mm:extfun-no-race")
           << "WARNING: --extfun-no-race ignored under memory model " << mm << ".\n";

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -128,8 +128,7 @@ Interpreter::Interpreter(Module *M, TSOPSOTraceBuilder &TB,
 #else
       const DataLayout &DL = getDataLayout();
 #endif
-      size_t GVSize = (size_t)(DL.getTypeAllocSize
-                               (gv->getType()->getPointerElementType()));
+      size_t GVSize = (size_t)(DL.getTypeAllocSize(gv->getValueType()));
       void *GVPtr = getPointerToGlobal(gv);
       SymMBlock mb = SymMBlock::Global(++glbl_ctr);
       AllocatedMem.emplace(GVPtr, SymMBlockSize(std::move(mb), GVSize));

--- a/src/LLVMUtils.cpp
+++ b/src/LLVMUtils.cpp
@@ -1,0 +1,47 @@
+
+#include "LLVMUtils.h"
+
+#if defined(HAVE_LLVM_IR_DERIVEDTYPES_H)
+#include <llvm/IR/DerivedTypes.h>
+#elif defined(HAVE_LLVM_DERIVEDTYPES_H)
+#include <llvm/DerivedTypes.h>
+#endif
+
+namespace {
+#if LLVM_VERSION_MAJOR > 14
+  template <typename pthread_t_type = pthread_t>
+  struct getLLVMType {};
+
+  template<typename T>
+  struct getLLVMType<T*> {
+    llvm::Type* operator()(llvm::LLVMContext &C) {
+      return llvm::PointerType::get(C, 0);
+    };
+  };
+
+  template<>
+  struct getLLVMType<std::uint32_t> {
+    llvm::Type *operator()(llvm::LLVMContext &C) {
+      return llvm::IntegerType::get(C, 32);
+    };
+  };
+
+  template<>
+  struct getLLVMType<std::uint64_t> {
+    llvm::Type *operator()(llvm::LLVMContext &C) {
+      return llvm::IntegerType::get(C, 64);
+    };
+  };
+#endif
+}
+
+namespace LLVMUtils {
+  llvm::Type* getPthreadTType(llvm::PointerType *PthreadTPtr) {
+#if LLVM_VERSION_MAJOR > 14
+    if (PthreadTPtr->isOpaque())
+      return getLLVMType<pthread_t>()(PthreadTPtr->getContext());
+    else
+#endif
+      return PthreadTPtr->getPointerElementType();
+  }
+}

--- a/src/LLVMUtils.h
+++ b/src/LLVMUtils.h
@@ -1,0 +1,32 @@
+/* Copyright (C) 2022 Magnus Lång
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#ifndef __LLVM_UTILS_H__
+#define __LLVM_UTILS_H__
+
+#include <llvm/IR/Type.h>
+
+namespace LLVMUtils {
+  llvm::Type* getPthreadTType(llvm::PointerType *PthreadTPtr);
+};
+
+
+#endif /* !defined(__LLVM_UTILS_H__) */

--- a/src/LoopBoundPass.cpp
+++ b/src/LoopBoundPass.cpp
@@ -33,6 +33,7 @@
 #elif defined(HAVE_LLVM_INSTRUCTIONS_H)
 #include <llvm/Instructions.h>
 #endif
+#include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 
 namespace {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -127,5 +127,6 @@ nidhuggc$(EXEEXT): $(srcdir)/nidhuggc.py
 	| sed 's|%%PYTHON%%|@PYTHON@|g' \
 	| sed 's|%%CLANG%%|@CLANG@|g' \
 	| sed 's|%%CLANGXX%%|@CLANGXX@|g' \
+	| sed 's|%%LLVMVERSION%%|@LLVMVERSION@|g' \
 	> nidhuggc
 	$(AM_V_at)chmod a+x nidhuggc

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ libnidhugg_a_SOURCES = \
   FBVClock.cpp FBVClock.h \
   IID.h IID.tcc \
   Interpreter.cpp Interpreter.h \
+  LLVMUtils.cpp LLVMUtils.h \
   LoopBoundPass.cpp LoopBoundPass.h \
   MRef.cpp MRef.h \
   nregex.cpp nregex.h \

--- a/src/POWERExecution.cpp
+++ b/src/POWERExecution.cpp
@@ -33,6 +33,7 @@
  */
 
 #include "Debug.h"
+#include "LLVMUtils.h"
 #include "POWERInterpreter.h"
 
 #include <llvm/ADT/APInt.h>
@@ -1051,7 +1052,7 @@ void POWERInterpreter::SwitchToNewBasicBlock(llvm::BasicBlock *Dest, ExecutionCo
 //===----------------------------------------------------------------------===//
 
 void POWERInterpreter::visitAllocaInst(llvm::AllocaInst &I) {
-  llvm::Type *Ty = I.getType()->getPointerElementType();  // Type to be allocated
+  llvm::Type *Ty = I.getAllocatedType();  // Type to be allocated
 
   // Get the number of elements being allocated by the array...
   unsigned NumElements =
@@ -2758,9 +2759,8 @@ std::shared_ptr<POWERInterpreter::FetchedInstruction> POWERInterpreter::fetch(ll
             store_count = 2;
             FI->Operands[0].IsAddrOf = 0;
             assert(I.getOperand(0)->getType()->isPointerTy());
-            llvm::Type *ty =
-              llvm::cast<llvm::PointerType>(I.getOperand(0)->getType())
-              ->getPointerElementType();
+            llvm::Type *ty = LLVMUtils::getPthreadTType
+              (llvm::cast<llvm::PointerType>(I.getOperand(0)->getType()));
 #ifdef LLVM_EXECUTIONENGINE_DATALAYOUT_PTR
             int pthread_t_sz = int(getDataLayout()->getTypeStoreSize(ty));
 #else

--- a/src/PartialLoopPurityPass.cpp
+++ b/src/PartialLoopPurityPass.cpp
@@ -30,6 +30,7 @@
 #include <boost/container/flat_map.hpp>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Analysis/CallGraph.h>
+#include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Analysis/LoopPass.h>
 #include <llvm/Analysis/ValueTracking.h>
 #if defined(HAVE_LLVM_IR_DOMINATORS_H)

--- a/src/SpinAssumePass.cpp
+++ b/src/SpinAssumePass.cpp
@@ -25,6 +25,7 @@
 #include "vecset.h"
 
 #include <llvm/Pass.h>
+#include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Analysis/LoopPass.h>
 #if defined(HAVE_LLVM_IR_DOMINATORS_H)
 #include <llvm/IR/Dominators.h>

--- a/src/SpinAssumePass.h
+++ b/src/SpinAssumePass.h
@@ -25,6 +25,13 @@
 #include <llvm/Analysis/LoopPass.h>
 #include <llvm/Pass.h>
 
+/* Avoid including huge header files, we just need a forward
+ * declarations
+ */
+namespace llvm {
+  class Instruction;
+}
+
 /* The DeclareAssumePass checks that __VERIFIER_assume is correctly
  * declared in the module. If they are incorrectly declared, an
  * error is raised. If they are not declared, then their (correct)

--- a/src/nidhuggc.py
+++ b/src/nidhuggc.py
@@ -15,6 +15,7 @@ import collections
 NIDHUGG=os.path.join(sys.path[0], 'nidhugg')
 CLANG='%%CLANG%%'
 CLANGXX='%%CLANGXX%%'
+LLVMVERSION='%%LLVMVERSION%%'
 GDB='gdb'
 
 Param = collections.namedtuple("Param",["name","help","param","transform"])
@@ -229,15 +230,15 @@ def get_IR(nidhuggcargs,compilerargs):
     os.close(fd)
     if lang == 'C':
         cmd = [CLANG,'-o',outputfname,'-S','-emit-llvm','-g']
-        cmd.extend(compilerargs)
-        cmd.append(inputfname)
-        run(cmd)
     else:
         assert(lang == 'C++')
         cmd = [CLANGXX,'-o',outputfname,'-S','-emit-llvm','-g']
-        cmd.extend(compilerargs)
-        cmd.append(inputfname)
-        run(cmd)
+    if (int(LLVMVERSION.split(".")[0]) > 14):
+        # POWER and ARM backends can't handle opaque pointers
+        cmd.extend(['-Xclang','-no-opaque-pointers'])
+    cmd.extend(compilerargs)
+    cmd.append(inputfname)
+    run(cmd)
     return outputfname
 
 def transform(nidhuggcargs,transformargs,irfname):


### PR DESCRIPTION
LLVM 15 enabled "Opaque Pointers" by default, which needed some fixing. This PR leaves the backends for the POWER and ARM memory models unfixed; instead, we issue a warning and have `nidhuggc` tell clang to not generate those pointers, but that will likely not be supported in LLVM 16.

Since the LLVM project do not distribute binaries for LLVM 15, a new Dockerfile is introduced for CI which builds LLVM and Clang from source (luckily, this also means we are finally running the whole test suite in a debug build). Thanks to @kostis for his work on this part.
Closes #181 