### PR TITLE
TSOTraceBuilder: Use CPids in wakeup sequences 

### DIFF
--- a/src/CPid.cpp
+++ b/src/CPid.cpp
@@ -129,6 +129,11 @@ CPidSystem::CPidSystem(){
   identifiers[CPid()] = 0;
 }
 
+CPid CPidSystem::spawn_peek(const CPid &c) const {
+  int c_id = identifiers.at(c);
+  return c.spawn(real_children[c_id].size());
+}
+
 CPid CPidSystem::spawn(const CPid &c){
   int c_id = identifiers[c];
   CPid c2 = c.spawn(real_children[c_id].size());

--- a/src/CPid.cpp
+++ b/src/CPid.cpp
@@ -154,3 +154,9 @@ CPid CPidSystem::new_aux(const CPid &c){
   identifiers[c2] = c2_id;
   return c2;
 }
+
+int CPidSystem::get_index(const CPid &c) const{
+  return identifiers.at(c);
+}
+
+const CPid CPid::canary = CPid({0,-1});

--- a/src/CPid.h
+++ b/src/CPid.h
@@ -121,6 +121,9 @@ public:
   CPidSystem(const CPidSystem&) = default;
   CPidSystem &operator=(const CPidSystem&) = default;
 
+  /* Return the child id that would be created, if c spawned a new child
+   * now */
+  CPid spawn_peek(const CPid &c) const;
   /* Spawn a new (meaning not in this set) real process child for c,
    * add it to this set and return it.
    *

--- a/src/CPid.h
+++ b/src/CPid.h
@@ -82,6 +82,9 @@ public:
   bool operator>(const CPid &c) const { return compare(c) > 0; }
   bool operator>=(const CPid &c) const { return compare(c) >= 0; }
 
+  /* A guard value that will never appear as a valid CPid */
+  static const CPid canary;
+
 private:
   /* For a CPid <p0.p1.....pn> or <p0.p1.....pn/i>, the vector
    * proc_seq is [p1,...,pn]. */
@@ -130,6 +133,9 @@ public:
    * Pre: c is in this set.
    */
   CPid new_aux(const CPid &c);
+
+  /* Get the index in creation order */
+  int get_index(const CPid &c) const;
 
 private:
   /* Each CPid in the set is identified by a natural number: its index

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -377,9 +377,10 @@ void RFSCTraceBuilder::debug_print() const {
 
 bool RFSCTraceBuilder::spawn(){
   curev().may_conflict = true;
-  if (!record_symbolic(SymEv::Spawn(threads.size() - 1))) return false;
   IPid parent_ipid = curev().iid.get_pid();
-  CPid child_cpid = CPS.spawn(threads[parent_ipid].cpid);
+  const CPid &parent_cpid = threads[parent_ipid].cpid;
+  if (!record_symbolic(SymEv::Spawn(CPS.spawn_peek(parent_cpid)))) return false;
+  CPid child_cpid = CPS.spawn(parent_cpid);
   threads.push_back(Thread(child_cpid,prefix_idx));
   return true;
 }
@@ -468,7 +469,7 @@ bool RFSCTraceBuilder::fence(){
 }
 
 bool RFSCTraceBuilder::join(int tgt_proc){
-  if (!record_symbolic(SymEv::Join(tgt_proc))) return false;
+  if (!record_symbolic(SymEv::Join(threads[tgt_proc].cpid))) return false;
   curev().may_conflict = true;
   add_happens_after_thread(prefix_idx, tgt_proc);
   return true;

--- a/src/SymEv.cpp
+++ b/src/SymEv.cpp
@@ -56,10 +56,11 @@ bool SymEv::is_compatible_with(SymEv other) const {
   case STORE: case UNOBS_STORE:
     if (arg.addr != other.arg.addr) return false;
     break;
-  case SPAWN: case JOIN:
   case NONDET:
     if (arg.num != other.arg.num) return false;
     break;
+  case SPAWN: case JOIN:
+      /* XXX: We ignore mismatches here */
   case FULLMEM:
   case NONE:
     break;

--- a/src/SymEv.h
+++ b/src/SymEv.h
@@ -21,6 +21,7 @@
 #define __SYM_EV_H__
 
 #include "MRef.h"
+#include "CPid.h"
 #include "SymAddr.h"
 #include "RMWAction.h"
 #include "AwaitCond.h"
@@ -86,10 +87,34 @@ struct SymEv {
     arg2(AwaitCond::Op await_op) : await_op(await_op) {}
   } arg2;
   bool _rmw_result_used;
-  SymData::block_type _expected, _written;
+  /* This is a dangerous thing. The enclosing SymEv is responsible for
+   * destruction */
+  union arg3 {
+    struct data {SymData::block_type _expected, _written; } d;
+    CPid cpid;
+    arg3() {}
+    arg3(struct data &&d) : d(std::move(d)) {}
+    arg3(CPid cpid) : cpid(std::move(cpid)) {}
+    ~arg3() {}
+  } arg3;
+
+  /* We're paying the price for having an union arg3 */
+  ~SymEv();
+  SymEv(const SymEv &o)
+    : kind(o.kind), arg(o.arg), arg2(o.arg2), _rmw_result_used(o._rmw_result_used) {
+    if (arg3_is_data())  new (&arg3) union arg3(arg3::data(o.arg3.d));
+    else if (has_cpid()) new (&arg3) union arg3(o.arg3.cpid);
+  }
+  SymEv(SymEv && o)
+    : kind(o.kind), arg(o.arg), arg2(o.arg2), _rmw_result_used(o._rmw_result_used) {
+    if (arg3_is_data())  new (&arg3) union arg3(std::move(o.arg3.d));
+    else if (has_cpid()) new (&arg3) union arg3(std::move(o.arg3.cpid));
+  }
+  SymEv &operator=(const SymEv &o)  { this->~SymEv(); return *new(this) SymEv(o); }
+  SymEv &operator=(const SymEv &&o) { this->~SymEv(); return *new(this) SymEv(std::move(o)); }
 
   SymEv() : kind(NONE) {}
-  static SymEv None() { return {NONE, {}}; }
+  static SymEv None() { return {NONE}; }
   static SymEv Nondet(int count) { return {NONDET, count}; }
 
   static SymEv Load(SymAddrSize addr) { return {LOAD, addr}; }
@@ -110,7 +135,7 @@ struct SymEv {
   static SymEv CmpXhgFail(SymData addr, SymData::block_type expected) {
     return {CMPXHGFAIL, addr, expected};
   }
-  static SymEv Fullmem() { return {FULLMEM, {}}; }
+  static SymEv Fullmem() { return {FULLMEM}; }
 
   static SymEv MInit(SymAddrSize addr) { return {M_INIT, addr}; }
   static SymEv MLock(SymAddrSize addr) { return {M_LOCK, addr}; }
@@ -126,8 +151,8 @@ struct SymEv {
   static SymEv CAwake(SymAddrSize cond) { return {C_AWAKE, cond}; }
   static SymEv CDelete(SymAddrSize addr) { return {C_DELETE, addr}; }
 
-  static SymEv Spawn(int proc) { return {SPAWN, proc}; }
-  static SymEv Join(int proc) { return {JOIN, proc}; }
+  static SymEv Spawn(CPid proc) { return {SPAWN, std::move(proc)}; }
+  static SymEv Join(CPid proc) { return {JOIN, std::move(proc)}; }
 
   static SymEv UnobsStore(SymData addr) {
     return {UNOBS_STORE, std::move(addr)};
@@ -142,6 +167,7 @@ struct SymEv {
 
   bool has_addr() const;
   bool has_num() const;
+  bool has_cpid() const { return kind == SPAWN || kind == JOIN; }
   bool has_data() const;
   bool has_expected() const;
   bool has_rmwaction() const { return kind == RMW; }
@@ -149,15 +175,16 @@ struct SymEv {
   bool empty() const { return kind == NONE; }
   const SymAddrSize &addr()   const { assert(has_addr()); return arg.addr; }
         int          num()    const { assert(has_num()); return arg.num; }
-  SymData data() const { assert(has_data()); return {arg.addr, _written}; }
+  const CPid        &cpid()   const { assert(has_cpid()); return arg3.cpid; }
+  SymData data() const { assert(has_data()); return {arg.addr, arg3.d._written}; }
   SymData expected() const {
     assert(has_expected());
-    return {arg.addr, _expected};
+    return {arg.addr, arg3.d._expected};
   }
   RmwAction rmwaction() const {
     assert(has_rmwaction());
-    assert(_expected);
-    return {arg2.rmw_kind, _expected, _rmw_result_used};
+    assert(arg3.d._expected);
+    return {arg2.rmw_kind, arg3.d._expected, _rmw_result_used};
   }
   RmwAction::Kind rmw_kind() const {
     assert(has_rmwaction());
@@ -169,38 +196,41 @@ struct SymEv {
   }
   AwaitCond cond() const {
     assert(has_cond());
-    assert(_expected);
-    return {arg2.await_op, _expected};
+    assert(arg3.d._expected);
+    return {arg2.await_op, arg3.d._expected};
   }
 
   void purge_data();
   void set_observed(bool observed);
 
 private:
-  SymEv(enum kind kind, union arg arg) : kind(kind), arg(arg) {}
+  SymEv(enum kind kind, union arg arg = {}) : kind(kind), arg(arg) {}
+  SymEv(enum kind kind, CPid &&cpid) : kind(kind), arg3(std::move(cpid)) {}
   SymEv(enum kind kind, union arg arg, AwaitCond cond)
     : kind(kind), arg(arg), arg2(cond.op),
-    _expected(std::move(cond.operand)) {}
+      arg3(arg3::data{std::move(cond.operand), {}}) {}
   SymEv(enum kind kind, SymData addr_written)
     : kind(kind), arg(std::move(addr_written.get_ref())),
-      _written(std::move(addr_written.get_shared_block())) {}
+      arg3(arg3::data{{}, std::move(addr_written.get_shared_block())}) {}
   SymEv(enum kind kind, SymData addr_written, SymData::block_type expected)
     : kind(kind), arg(std::move(addr_written.get_ref())),
-      _expected(std::move(expected)),
-      _written(std::move(addr_written.get_shared_block())) {}
+      arg3(arg3::data{std::move(expected),
+                      std::move(addr_written.get_shared_block())}) {}
   SymEv(enum kind kind, SymData addr_written, RmwAction action)
     : kind(kind), arg(addr_written.get_ref()), arg2(action.kind),
       _rmw_result_used(action.result_used),
-      _expected(std::move(action.operand)),
-      _written(std::move(addr_written.get_shared_block())) {
+      arg3(arg3::data{std::move(action.operand),
+                      std::move(addr_written.get_shared_block())}) {
       assert(has_data());
     }
   SymEv(enum kind kind, SymData addr_written, AwaitCond cond)
     : kind(kind), arg(addr_written.get_ref()), arg2(cond.op),
-      _expected(std::move(cond.operand)),
-      _written(std::move(addr_written.get_shared_block())) {
+      arg3(arg3::data{std::move(cond.operand),
+                      std::move(addr_written.get_shared_block())}) {
       assert(has_data());
     }
+
+  bool arg3_is_data() const;
 };
 
 inline std::ostream &operator<<(std::ostream &os, const SymEv &e){

--- a/src/TSOTraceBuilder.h
+++ b/src/TSOTraceBuilder.h
@@ -646,10 +646,10 @@ protected:
   bool do_events_conflict(int i, int j) const;
   bool do_events_conflict(const Event &fst, const Event &snd) const;
   /* Check if two symbolic events conflict. */
-  bool do_events_conflict(IPid fst_pid, const sym_ty &fst,
-                          IPid snd_pid, const sym_ty &snd) const;
-  bool do_symevs_conflict(IPid fst_pid, const SymEv &fst,
-                          IPid snd_pid, const SymEv &snd) const;
+  bool do_events_conflict(const CPid &fst_pid, const sym_ty &fst,
+                          const CPid &snd_pid, const sym_ty &snd) const;
+  bool do_symevs_conflict(const CPid &fst_pid, const SymEv &fst,
+                          const CPid &snd_pid, const SymEv &snd) const;
   /* Check if events fst and snd are in an observed race with thd as an
    * observer.
    */
@@ -658,12 +658,12 @@ protected:
   /* Check if two symbolic events are in an observed race with a third
    * as an observer.
    */
-  bool is_observed_conflict(IPid fst_pid, const sym_ty &fst,
-                            IPid snd_pid, const sym_ty &snd,
-                            IPid thd_pid, const sym_ty &thd) const;
-  bool is_observed_conflict(IPid fst_pid, const SymEv &fst,
-                            IPid snd_pid, const SymEv &snd,
-                            IPid thd_pid, const SymEv &thd) const;
+  bool is_observed_conflict(const CPid &fst_pid, const sym_ty &fst,
+                            const CPid &snd_pid, const sym_ty &snd,
+                            const CPid &thd_pid, const sym_ty &thd) const;
+  bool is_observed_conflict(const CPid &fst_pid, const SymEv &fst,
+                            const CPid &snd_pid, const SymEv &snd,
+                            const CPid &thd_pid, const SymEv &thd) const;
   /* Reconstruct the above-vector clock of a blocked event with IID
    * iid. */
   VClock<IPid> reconstruct_blocked_clock(IID<IPid> iid) const;

--- a/tests/smoke/reference.results.txt
+++ b/tests/smoke/reference.results.txt
@@ -56,7 +56,7 @@ rmw_test2 Forbid : 300
 fib_bench_true_2 Forbid : 140
 safestack_c21_21 Forbid : 36
 safestack_c21_21_opt Forbid : 36
-opt_ipid_regr Allow : 2
+opt_ipid_regr Forbid : 2
 
 # Unroller
 unroll_double_loop Forbid : 1


### PR DESCRIPTION
This is another way than stable IPids to solve the issue of reordering spawn events in Optimal. There might be a performance impact; we'll have to measure to know if this is sane, or if finishing stable IPids is better.

This is not the complete change required to make stable IPids obsolete. We also use IPids in SymAddrs, and the work required and performance penalty is probably larger than this part.

This PR builds on #186, so cannot be merged before that