### PR TITLE
configure.ac: fix finding dlopen() on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ AX_LLVM(,[AC_MSG_FAILURE(LLVM is required.)])
 AC_SUBST(LLVMVERSION)
 CXXFLAGS="`echo " $CXXFLAGS " | sed 's/ -fno-rtti / /' | sed 's/ -fno-exceptions / /'` --std=c++14 $BOOST_CPPFLAGS"
 LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
-AC_CHECK_LIB([dl], [dlopen],[],[AC_MSG_FAILURE([Could not find library libdl.])])
+AC_SEARCH_LIBS([dlopen], [dl],[],[AC_MSG_FAILURE([Could not find library libdl.])])
 ifdef([PKG_CHECK_MODULES],[
   PKG_CHECK_MODULES([FFI], [libffi], [
     AC_DEFINE([HAVE_LIBFFI], [1], [Define to 1 if we have libffi])


### PR DESCRIPTION
AC_CHECK_LIB checks for the presence of a given function in a library, and fails if the library can't be found or doesn't contain the function..

AC_SEARCH_LIBS checks if a function is present, and if it isn't, tries again with each specified library in sequence, stopping and linking in the first library to contain the function, and failing if the function isn't found anywhere.

Linux systems have dlopen inside a libdl library. OpenBSD has dlopen inside libc, this change fixes compilation on OpenBSD and probably the other BSDs.

Ref: https://www.gnu.org/software/autoconf/manual/autoconf-2.71/html_node/Libraries.html