### PR TITLE
Fix codespell nondeterministically breaking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "monthly"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: codespell-project/actions-codespell@master
+    - uses: codespell-project/actions-codespell@v2
       with:
         path: src
         ignore_words_list: aci,curev,datas,olt,ot,pevent,te

--- a/src/POWERARMTraceBuilder.tcc
+++ b/src/POWERARMTraceBuilder.tcc
@@ -1000,7 +1000,7 @@ namespace PATB_impl{
       }
     }
 
-    /* Add brances, update relations */
+    /* Add branches, update relations */
     parameters.reserve(parameters.size() + last - first + 1);
     for(int i = first; i <= last; ++i){
       parameters.push_back(B);
@@ -1094,7 +1094,7 @@ namespace PATB_impl{
       }
     }
 
-    /* Add brances, update relations */
+    /* Add branches, update relations */
     parameters.reserve(parameters.size() + last - first + 1);
     for(int i = last; first <= i; --i){
       parameters.push_back(B);
@@ -2289,7 +2289,7 @@ namespace PATB_impl{
       default:
         throw std::logic_error("POWERARMTraceBuilder: Unknown type of parameter choice in locked branch.");
       }
-      // Add brances to get_evt(prefix[i]).new_branches except for branches[0]
+      // Add branches to get_evt(prefix[i]).new_branches except for branches[0]
       union_except_one(get_evt(prefix[i]).new_branches,branches);
       get_evt(prefix[i]).cur_branch = B;
     }

--- a/src/PartialLoopPurityPass.cpp
+++ b/src/PartialLoopPurityPass.cpp
@@ -1540,7 +1540,7 @@ namespace {
       llvm::Instruction *I = findInsertionPoint(L, conj);
       if (!I) {
         if (cl_plp_dbgp >= 1)
-          llvm::dbgs() << "Not elimiating loop purity: No valid insertion location found\n";
+          llvm::dbgs() << "Not eliminating loop purity: No valid insertion location found\n";
         continue;
       }
       if (cl_plp_dbgp >= 1) llvm::dbgs() << " Insertion point: " << *I << "\n";

--- a/src/RFSCDecisionTree.h
+++ b/src/RFSCDecisionTree.h
@@ -224,7 +224,7 @@ class RFSCDecisionTree final {
 public:
   RFSCDecisionTree(std::unique_ptr<RFSCScheduler> scheduler)
     : scheduler(std::move(scheduler)) {
-    // Initiallize the work_queue with a "root"-node
+    // Initialize the work_queue with a "root"-node
     this->scheduler->enqueue(std::make_shared<DecisionNode>());
   }
 


### PR DESCRIPTION
We had configured the codespell github CI action to follow the latest version of codespell. Unfortunately, this created the posibility for codespell to break nondeterministically. Instead, I fix the version, and configure dependabot to propose updates.