### PR TITLE
Properly set CXXFLAGS in the presence of multiple C++ libraries

### DIFF
--- a/m4/ax_llvm.m4
+++ b/m4/ax_llvm.m4
@@ -62,9 +62,18 @@ AC_DEFUN([AX_LLVM],
       fi
     fi
 
-    CPPFLAGS="$CPPFLAGS `$LLVMCONFIG --cppflags`"
-    CFLAGS="$CFLAGS `$LLVMCONFIG --cflags`"
-    CXXFLAGS="$CXXFLAGS `$LLVMCONFIG --cxxflags`"
+    LLVM_CPPFLAGS=`$LLVMCONFIG --cppflags | sed 's/-I\//-isystem \//g'`
+    LLVM_CFLAGS=`$LLVMCONFIG --cflags | sed 's/-I\//-isystem \//g'`
+    LLVM_CXXFLAGS=`$LLVMCONFIG --cxxflags | sed 's/-I\//-isystem \//g'`
+    GCC_MAJOR=`$CXX -dumpversion 2>/dev/null | cut -d. -f1`
+    if test -n "$GCC_MAJOR" && test -d "/usr/include/c++/$GCC_MAJOR"; then
+      STDCXX_ISYSTEM="-isystem /usr/include/c++/$GCC_MAJOR -isystem /usr/include/x86_64-linux-gnu/c++/$GCC_MAJOR"
+    else
+      STDCXX_ISYSTEM=""
+    fi
+    CPPFLAGS="$CPPFLAGS $STDCXX_ISYSTEM $LLVM_CPPFLAGS"
+    CFLAGS="$CFLAGS $STDCXX_ISYSTEM $LLVM_CFLAGS"
+    CXXFLAGS="$CXXFLAGS $STDCXX_ISYSTEM $LLVM_CXXFLAGS"
     LLVMLDFLAGS=`$LLVMCONFIG --ldflags`
     LLVMLIBS=`$LLVMCONFIG --libs`
     SYSLIBS=`$LLVMCONFIG --system-libs 2>/dev/null`


### PR DESCRIPTION
In systems that have C++ libraries both from `libstd++` and from `libc++abi-19-dev` compiling the tests of Nidhugg fails with:
```sh
$ make test
Making test in src
make[1]: Entering directory '/home/kostis/nidhugg/src'
  CXX      ARM_test.o
In file included from /usr/include/boost/core/demangle.hpp:32,
                 from /usr/include/boost/core/typeinfo.hpp:135,
                 from /usr/include/boost/function/function_base.hpp:16,
                 from /usr/include/boost/function/detail/prologue.hpp:18,
                 from /usr/include/boost/function/function_template.hpp:13,
                 from /usr/include/boost/function/detail/maybe_include.hpp:15,
                 from /usr/include/boost/function/function0.hpp:11,
                 from /usr/include/boost/test/tree/fixture.hpp:21,
                 from /usr/include/boost/test/tree/decorator.hpp:22,
                 from /usr/include/boost/test/tools/fpc_tolerance.hpp:19,
                 from /usr/include/boost/test/tools/fpc_op.hpp:19,
                 from /usr/include/boost/test/test_tools.hpp:54,
                 from /usr/include/boost/test/unit_test.hpp:18,
                 from ARM_test.cpp:27:
/usr/lib/llvm-19/include/cxxabi.h:55:1: error: conflicting declaration of C function ‘__cxxabiv1::__cxa_exception* __cxxabiv1::__cxa_init_primary_exception(void*, std::type_info*, void (*)(void*))’
   55 | __cxa_init_primary_exception(void* object, std::type_info* tinfo, void(_LIBCXXABI_DTOR_FUNC* dest)(void*)) throw();
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14/bits/exception_ptr.h:36,
                 from /usr/include/c++/14/exception:166,
                 from /usr/include/c++/14/ext/concurrence.h:34,
                 from /usr/include/c++/14/bits/shared_ptr_base.h:62,
                 from /usr/include/c++/14/bits/shared_ptr.h:53,
                 from /usr/include/c++/14/memory:80,
                 from Configuration.h:25,
                 from DPORDriver.h:25,
                 from ARM_test.cpp:23:
/usr/include/c++/14/bits/cxxabi_init_exception.h:70:7: note: previous declaration ‘__cxxabiv1::__cxa_refcounted_exception* __cxxabiv1::__cxa_init_primary_exception(void*, std::type_info*, void (*)(void*))’
   70 |       __cxa_init_primary_exception(void *__object, std::type_info *__tinfo,
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[1]: *** [Makefile:951: ARM_test.o] Error 1
make[1]: Leaving directory '/home/kostis/nidhugg/src'
make: *** [Makefile:461: test-recursive] Error 1
```

The problem is caused because `lvm-config-19 --cppflags` adds `-I/usr/lib/llvm-19/include` to the compile flags (via `m4/ax_llvm.m4`). This directory contains a `cxxabi.h` from `libc++abi-19-dev` that conflicts with the corresponding header of `libstdc++`.

The Boost.Test headers (e.g. `boost/core/demangle.hpp`) contain an `#include <cxxabi.h>`. The compiler finds first  the header file from LLVM instead of that of libstdc++, which causes the `make test` failure shown above. (In contrast, vanilla `make` works OK.)

This pull request fixes the problem by using a combination of `-isystem` and `-I` flags and being careful about their order.

Thanks to @orestis42 for the investigation of the issue and for proposing this fix.